### PR TITLE
tentative port to WIN32

### DIFF
--- a/WIN32-NOTES
+++ b/WIN32-NOTES
@@ -1,0 +1,83 @@
+# WIN32 specific notes
+
+Works and checked on Visual Studio 2010 C++ Express, should work
+with any Visual Studio 2010 or 2012 Desktop.
+
+OpenSSL in ssl directory at the same level, Botan in btn,
+if you want Debug versions you need ssl+dbg and botand.{lib,dll}.
+Note openssl.exe should be in the PATH for cryptotest.exe
+
+win32+openssl and win32+botan, flags in config.h, solution file
+in softhsm2.
+
+## project list
+
+convarch: internal static library
+
+softhsm2 (main project): softhsm2.dll
+
+keyconv, util: keyconv.exe and util.exe tools
+
+p11test, cryptotest, datamgrtest, handlemgrtest, objstoretest,
+sessionmgrtest, slotmgrtest: checking tools
+
+## C4996 "unsafe" functions
+
+fopen
+getenv
+gmtime
+_snprint
+sprintf
+sscanf
+strncpy
+strtok
+_vsnprintf
+vsnprintf
+vsprintf
+
+## port summary (_WIN32 stuff)
+
+windows.h included from config.h with some tuning
+(so config.h should be included first)
+
+softhsm2.conf.win32
+(installed by VS p11test project including in the topdir)
+
+No unistd.h, sys/mman.h, sys/socket.h, etc
+
+sys/time.h -> time.h
+
+/ in file path -> \ (\\ in chars/strings)
+
+__func__ -> __FUNCTION__
+(should be _MSC_VER in place of _WIN32?)
+
+wb/rb in fopen for binary files
+
+dlopen & co -> LoadLibrary & co
+
+valloc, mlock, etc -> VirtualAlloc, VirtualLock, etc
+
+threadID -> GetCurrentThreadId
+
+pthread_mutex -> Mutex
+(note CreateMutex is now defined by config.h)
+
+sem_* -> Semaphore
+(note getvalue doesn't exist with good reasons on WIN32, simulated
+inside a critical section)
+
+dirent & co -> _findfirst & co
+
+remove -> _rmdir or _unlink
+(WIN32 remove() doesn't handle directories)
+
+fcntl F_SETL & co* -> LockFileEx & co
+
+shell "rm -rf foo" -> cmd.exe "rmdir /s /q foo 2> nul"
+
+syslog -> provided using Event
+
+getopt, getpassphrase -> provided
+
+setenv -> provided using _putenv

--- a/src/bin/common/getpw.cpp
+++ b/src/bin/common/getpw.cpp
@@ -36,7 +36,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 // Get a password from the user
 void getPW(char* pin, char* newPIN, CK_ULONG userType)

--- a/src/bin/common/library.cpp
+++ b/src/bin/common/library.cpp
@@ -50,11 +50,11 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle)
 	// Load PKCS #11 library
 	if (module)
 	{
-		HINSTANCE hDLL = LoadLibrary(_T(module));
+		hDLL = LoadLibraryA(module);
 	}
 	else
 	{
-		HINSTANCE hDLL = LoadLibrary(_T(DEFAULT_PKCS11_LIB));
+		hDLL = LoadLibraryA(DEFAULT_PKCS11_LIB);
 	}
 
 	if (hDLL == NULL)
@@ -64,8 +64,11 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle)
 	}
 
 	// Retrieve the entry point for C_GetFunctionList
-	pGetFunctionList = (CK_C_GetFunctionList) GetProcAddress(hDLL, _T("C_GetFunctionList"));
+	pGetFunctionList = (CK_C_GetFunctionList) GetProcAddress(hDLL, "C_GetFunctionList");
             
+	// Store the handle so we can FreeLibrary it later
+	*moduleHandle = hDLL;
+
 #elif defined(HAVE_DLOPEN)
 	void* pDynLib = NULL;
 
@@ -105,7 +108,7 @@ void unloadLibrary(void* moduleHandle)
 	if (moduleHandle)
 	{
 #if defined(HAVE_LOADLIBRARY)
-		// no idea
+		FreeLibrary((HMODULE) moduleHandle);
 #elif defined(HAVE_DLOPEN)
 		dlclose(moduleHandle);
 #endif

--- a/src/bin/keyconv/base64.c
+++ b/src/bin/keyconv/base64.c
@@ -47,8 +47,10 @@ static const char rcsid[] = "$ISC: base64.c,v 8.6 1999/01/08 19:25:18 vixie Exp 
 #endif /* not lint */
 
 #include <sys/types.h>
+#ifndef _WIN32
 #include <sys/param.h>
 #include <sys/socket.h>
+#endif
 
 #include <ctype.h>
 #include <stdio.h>

--- a/src/bin/keyconv/softhsm-keyconv.cpp
+++ b/src/bin/keyconv/softhsm-keyconv.cpp
@@ -44,7 +44,9 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <iostream>
 #include <fstream>
 #include <stdint.h>

--- a/src/bin/migrate/softhsm-migrate.cpp
+++ b/src/bin/migrate/softhsm-migrate.cpp
@@ -40,10 +40,16 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <iostream>
 #include <fstream>
 #include <sched.h>
+
+#ifdef _WIN32
+#define sched_yield() SleepEx(0, 0)
+#endif
 
 // Display the usage
 void usage()

--- a/src/bin/util/softhsm-util.cpp
+++ b/src/bin/util/softhsm-util.cpp
@@ -40,7 +40,9 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <iostream>
 #include <fstream>
 

--- a/src/bin/win32/getopt.cpp
+++ b/src/bin/win32/getopt.cpp
@@ -1,0 +1,520 @@
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *        This product includes software developed by the NetBSD
+ *        Foundation, Inc. and its contributors.
+ * 4. Neither the name of The NetBSD Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <config.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+
+/* Windows needs warnx().  We change the definition though:
+ *  1. (another) global is defined, opterrmsg, which holds the error message
+ *  2. errors are always printed out on stderr w/o the program name
+ * Note that opterrmsg always gets set no matter what opterr is set to.  The
+ * error message will not be printed if opterr is 0 as usual.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+extern char opterrmsg[128];
+char opterrmsg[128]; /* last error message is stored here */
+
+static void warnx(int print_error, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	if (fmt != NULL)
+		_vsnprintf(opterrmsg, 128, fmt, ap);
+	else
+		opterrmsg[0]='\0';
+	va_end(ap);
+	if (print_error) {
+		fprintf(stderr, opterrmsg);
+		fprintf(stderr, "\n");
+	}
+}
+
+#endif /*_WIN32*/
+
+/* not part of the original file */
+#ifndef _DIAGASSERT
+#define _DIAGASSERT(X)
+#endif
+
+#if HAVE_CONFIG_H && !HAVE_GETOPT_LONG && !HAVE_DECL_OPTIND
+#define REPLACE_GETOPT
+#endif
+
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+
+#if !HAVE_GETOPT_LONG
+#define IGNORE_FIRST	(*options == '-' || *options == '+')
+#define PRINT_ERROR	((opterr) && ((*options != ':') \
+				      || (IGNORE_FIRST && options[1] != ':')))
+#define IS_POSIXLY_CORRECT (getenv("POSIXLY_CORRECT") != NULL)
+#define PERMUTE         (!IS_POSIXLY_CORRECT && !IGNORE_FIRST)
+/* XXX: GNU ignores PC if *options == '-' */
+#define IN_ORDER        (!IS_POSIXLY_CORRECT && *options == '-')
+
+/* return values */
+#define	BADCH	(int)'?'
+#define	BADARG		((IGNORE_FIRST && options[1] == ':') \
+			 || (*options == ':') ? (int)':' : (int)'?')
+#define INORDER (int)1
+
+#define	EMSG	""
+
+static int getopt_internal(int, char * const *, const char *);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+	   
+	return b;
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end,
+	     int opt_end, char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	_DIAGASSERT(nargv != NULL);
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ *  Returns -2 if -- is found (can be long option or end of options marker).
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options)
+{
+	char *oli;				/* option letter list index */
+	int optchar;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	optarg = NULL;
+
+	/*
+	 * XXX Some programs (like rsyncd) expect to be able to
+	 * XXX re-initialize optind to 0 and have getopt_long(3)
+	 * XXX properly function again.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = 1;
+
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((*(place = nargv[optind]) != '-')
+		    || (place[1] == '\0')) {    /* found non-option */
+			place = EMSG;
+			if (IN_ORDER) {
+				/*
+				 * GNU extension: 
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return INORDER;
+			}
+			if (!PERMUTE) {
+				/*
+				 * if no permutation wanted, stop parsing
+				 * at first non-option
+				 */
+				return -1;
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+		if (place[1] && *++place == '-') {	/* found "--" */
+			place++;
+			return -2;
+		}
+	}
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (oli = (char *) strchr(options + (IGNORE_FIRST ? 1 : 0),
+				   optchar)) == NULL) {
+		/* option letter unknown or ':' */
+		if (!*place)
+			++optind;
+#ifndef _WIN32
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+#else
+			warnx(PRINT_ERROR, illoptchar, optchar);
+#endif
+		optopt = optchar;
+		return BADCH;
+	}
+	if (optchar == 'W' && oli[1] == ';') {		/* -W long-option */
+		/* XXX: what if no long options provided (called by getopt)? */
+		if (*place) 
+			return -2;
+
+		if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+#ifndef _WIN32
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+#else
+				warnx(PRINT_ERROR, recargchar, optchar);
+#endif
+			optopt = optchar;
+			return BADARG;
+		} else				/* white space */
+			place = nargv[optind];
+		/*
+		 * Handle -W arg the same as --arg (which causes getopt to
+		 * stop parsing).
+		 */
+		return -2;
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		/* XXX: disable test for :: if PC? (GNU doesn't) */
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+#else
+					warnx(PRINT_ERROR, recargchar, optchar);
+#endif
+				optopt = optchar;
+				return BADARG;
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return optchar;
+}
+
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the real getopt]
+ */
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
+		++optind;
+		/*
+		 * We found an option (--), so if we skipped non-options,
+		 * we have to permute.
+		 */
+		if (nonopt_end != -1) {
+			permute_args(nonopt_start, nonopt_end, optind,
+				       nargv);
+			optind -= nonopt_end - nonopt_start;
+		}
+		nonopt_start = nonopt_end = -1;
+		retval = -1;
+	}
+	return retval;
+}
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc,
+	    char * const *nargv,
+	    const char *options,
+	    const struct option *long_options,
+	    int *idx)
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+	_DIAGASSERT(long_options != NULL);
+	/* idx may be NULL */
+
+	if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
+		char *current_argv, *has_equal;
+		size_t current_argv_len;
+		int i, match;
+
+		current_argv = place;
+		match = -1;
+
+		optind++;
+		place = EMSG;
+
+		if (*current_argv == '\0') {		/* found "--" */
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((has_equal = strchr(current_argv, '=')) != NULL) {
+			/* argument found (--option=arg) */
+			current_argv_len = has_equal - current_argv;
+			has_equal++;
+		} else
+			current_argv_len = strlen(current_argv);
+	    
+		for (i = 0; long_options[i].name; i++) {
+			/* find matching long option */
+			if (strncmp(current_argv, long_options[i].name,
+			    current_argv_len))
+				continue;
+
+			if (strlen(long_options[i].name) ==
+			    (unsigned)current_argv_len) {
+				/* exact match */
+				match = i;
+				break;
+			}
+			if (match == -1)		/* partial match */
+				match = i;
+			else {
+				/* ambiguous abbreviation */
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(ambig, (int)current_argv_len,
+					     current_argv);
+#else
+					warnx(PRINT_ERROR, ambig, (int)current_argv_len,
+					     current_argv);
+#endif
+				optopt = 0;
+				return BADCH;
+			}
+		}
+		if (match != -1) {			/* option found */
+		        if (long_options[match].has_arg == no_argument
+			    && has_equal) {
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(noarg, (int)current_argv_len,
+					     current_argv);
+#else
+					warnx(PRINT_ERROR, noarg, (int)current_argv_len,
+					     current_argv);
+#endif
+				/*
+				 * XXX: GNU sets optopt to val regardless of
+				 * flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				return BADARG;
+			}
+			if (long_options[match].has_arg == required_argument ||
+			    long_options[match].has_arg == optional_argument) {
+				if (has_equal)
+					optarg = has_equal;
+				else if (long_options[match].has_arg ==
+				    required_argument) {
+					/*
+					 * optional argument doesn't use
+					 * next nargv
+					 */
+					optarg = nargv[optind++];
+				}
+			}
+			if ((long_options[match].has_arg == required_argument)
+			    && (optarg == NULL)) {
+				/*
+				 * Missing argument; leading ':'
+				 * indicates no error should be generated
+				 */
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(recargstring, current_argv);
+#else
+					warnx(PRINT_ERROR, recargstring, current_argv);
+#endif
+				/*
+				 * XXX: GNU sets optopt to val regardless
+				 * of flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				--optind;
+				return BADARG;
+			}
+		} else {			/* unknown option */
+#ifndef _WIN32
+			if (PRINT_ERROR)
+				warnx(illoptstring, current_argv);
+#else
+				warnx(PRINT_ERROR, illoptstring, current_argv);
+#endif
+			optopt = 0;
+			return BADCH;
+		}
+		if (long_options[match].flag) {
+			*long_options[match].flag = long_options[match].val;
+			retval = 0;
+		} else 
+			retval = long_options[match].val;
+		if (idx)
+			*idx = match;
+	}
+	return retval;
+}
+#endif /* !GETOPT_LONG */

--- a/src/bin/win32/getopt.h
+++ b/src/bin/win32/getopt.h
@@ -1,0 +1,101 @@
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *        This product includes software developed by the NetBSD
+ *        Foundation, Inc. and its contributors.
+ * 4. Neither the name of The NetBSD Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+#ifdef _WIN32
+/* from <sys/cdefs.h> */
+# ifdef  __cplusplus
+#  define __BEGIN_DECLS  extern "C" {
+#  define __END_DECLS    }
+# else
+#  define __BEGIN_DECLS
+#  define __END_DECLS
+# endif
+# define __P(args)      args
+#endif
+
+/*#ifndef _WIN32
+#include <sys/cdefs.h>
+#include <unistd.h>
+#endif*/
+
+/*
+ * Gnu like getopt_long() and BSD4.4 getsubopt()/optreset extensions
+ */
+#if !defined(_POSIX_SOURCE) && !defined(_XOPEN_SOURCE)
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+struct option {
+        /* name of long option */
+        const char *name;
+        /*
+         * one of no_argument, required_argument, and optional_argument:
+         * whether option takes an argument
+         */
+        int has_arg;
+        /* if not NULL, set *flag to val when option found */
+        int *flag;
+        /* if flag not NULL, value to set *flag to; else return value */
+        int val;
+};
+
+__BEGIN_DECLS
+int getopt_long __P((int, char * const *, const char *,
+    const struct option *, int *));
+__END_DECLS
+#endif
+
+#ifdef _WIN32
+/* These are global getopt variables */
+__BEGIN_DECLS
+
+extern int   opterr,   /* if error message should be printed */
+             optind,   /* index into parent argv vector */
+             optopt,   /* character checked for validity */
+             optreset; /* reset getopt */
+extern char* optarg;   /* argument associated with option */
+
+/* Original getopt */
+int getopt __P((int, char * const *, const char *));
+
+__END_DECLS
+#endif
+ 
+#endif /* !_GETOPT_H_ */

--- a/src/bin/win32/getpassphase.cpp
+++ b/src/bin/win32/getpassphase.cpp
@@ -1,0 +1,35 @@
+/* WIN32 getpassphrase */
+
+#include <config.h>
+#include <stdio.h>
+
+char *
+getpassphrase(const char *prompt) {
+	static char buf[128];
+	HANDLE h;
+	DWORD cc, mode;
+	int cnt;
+
+	h = GetStdHandle(STD_INPUT_HANDLE);
+	fputs(prompt, stderr);
+	fflush(stderr);
+	fflush(stdout);
+	FlushConsoleInputBuffer(h);
+	GetConsoleMode(h, &mode);
+	SetConsoleMode(h, ENABLE_PROCESSED_INPUT);
+
+	for (cnt = 0; cnt < sizeof(buf) - 1; cnt++)
+	{
+		ReadFile(h, buf + cnt, 1, &cc, NULL);
+		if (buf[cnt] == '\r')
+			break;
+		fputc('*', stdout);
+		fflush(stderr);
+		fflush(stdout);
+	}
+
+	SetConsoleMode(h, mode);
+	buf[cnt] = '\0';
+	fputs("\n", stderr);
+	return (buf);
+}

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1265,7 +1265,7 @@ CK_RV SoftHSM::C_SetAttributeValue(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE 
 		return rv;
 
 	// Ask the P11Object to save the template with attribute values.
-	return p11object->saveTemplate(token, isPrivate, pTemplate,ulCount,OBJECT_OP_SET);
+	return p11object->saveTemplate(token, isPrivate != CK_FALSE, pTemplate,ulCount,OBJECT_OP_SET);
 }
 
 // Initialise object search in the specified session using the specified attribute template as search parameters
@@ -1390,8 +1390,8 @@ CK_RV SoftHSM::C_FindObjectsInit(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pT
 		if (bAttrMatch)
 		{
 			CK_SLOT_ID slotID = slot->getSlotID();
-			CK_BBOOL isToken = (*it)->getAttribute(CKA_TOKEN)->getBooleanValue();
-			CK_BBOOL isPrivate = (*it)->getAttribute(CKA_PRIVATE)->getBooleanValue();
+			bool isToken = (*it)->getAttribute(CKA_TOKEN)->getBooleanValue();
+			bool isPrivate = (*it)->getAttribute(CKA_PRIVATE)->getBooleanValue();
 			// Create an object handle for every returned object.
 			CK_OBJECT_HANDLE hObject;
 			if (isToken)
@@ -5963,20 +5963,20 @@ CK_RV SoftHSM::CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTempla
 	}
 	else
 	{
-		object = sessionObjectStore->createObject(slot->getSlotID(), hSession, isPrivate);
+		object = sessionObjectStore->createObject(slot->getSlotID(), hSession, isPrivate != CK_FALSE);
 	}
 	if (object == NULL) return CKR_GENERAL_ERROR;
 
 	p11object->init(object);
 
-	rv = p11object->saveTemplate(token, isPrivate, pTemplate,ulCount,op);
+	rv = p11object->saveTemplate(token, isPrivate != CK_FALSE, pTemplate,ulCount,op);
 	if (rv != CKR_OK)
 		return rv;
 
 	if (isToken) {
-		*phObject = handleManager->addTokenObject(slot->getSlotID(), isPrivate, object);
+		*phObject = handleManager->addTokenObject(slot->getSlotID(), isPrivate != CK_FALSE, object);
 	} else {
-		*phObject = handleManager->addSessionObject(slot->getSlotID(), hSession, isPrivate, object);
+		*phObject = handleManager->addSessionObject(slot->getSlotID(), hSession, isPrivate != CK_FALSE, object);
 	}
 
 	return CKR_OK;

--- a/src/lib/common/Semaphore.h
+++ b/src/lib/common/Semaphore.h
@@ -34,7 +34,9 @@
 #define _SOFTHSM_V2_SEMAPHORE_H
 
 #include "config.h"
+#ifndef _WIN32
 #include <semaphore.h>
+#endif
 #include <string>
 
 class Semaphore
@@ -57,10 +59,19 @@ public:
 
 private:
 	// Constructor
+#ifndef _WIN32
 	Semaphore(sem_t* semaphore, std::string name);
+#else
+	Semaphore(HANDLE semaphore, std::string name);
+#endif
 
 	// The actual POSIX semaphore
+#ifndef _WIN32
 	sem_t* semaphore;
+#else
+	HANDLE semaphore;
+	CRITICAL_SECTION cs;
+#endif
 
 	// The name of the semaphore (needed to destroy it)
 	std::string name;

--- a/src/lib/common/log.cpp
+++ b/src/lib/common/log.cpp
@@ -32,12 +32,12 @@
  argument list as defined in stdarg (3).
  *****************************************************************************/
 
+#include "config.h"
 #include <stdarg.h>
 #include <syslog.h>
 #include <stdio.h>
 #include <sstream>
 #include <vector>
-#include "config.h"
 #include "log.h"
 
 void softHSMLog(const int loglevel, const char* functionName, const char* fileName, const int lineNo, const char* format, ...)

--- a/src/lib/common/log.h
+++ b/src/lib/common/log.h
@@ -60,28 +60,44 @@
 
 /* Logging errors */
 #if SOFTLOGLEVEL >= SOFTERROR
+#ifndef _WIN32
 #define ERROR_MSG(...) softHSMLog(LOG_ERR, __func__, __FILE__, __LINE__, __VA_ARGS__);
+#else
+#define ERROR_MSG(...) softHSMLog(LOG_ERR, __FUNCTION__, __FILE__, __LINE__, __VA_ARGS__);
+#endif
 #else
 #define ERROR_MSG(...)
 #endif
 
 /* Logging warnings */
 #if SOFTLOGLEVEL >= SOFTWARNING
+#ifndef _WIN32
 #define WARNING_MSG(...) softHSMLog(LOG_WARNING, __func__, __FILE__, __LINE__, __VA_ARGS__);
+#else
+#define WARNING_MSG(...) softHSMLog(LOG_WARNING, __FUNCTION__, __FILE__, __LINE__, __VA_ARGS__);
+#endif
 #else
 #define WARNING_MSG(...)
 #endif
 
 /* Logging information */
 #if SOFTLOGLEVEL >= SOFTINFO
+#ifndef _WIN32
 #define INFO_MSG(...) softHSMLog(LOG_INFO, __func__, __FILE__, __LINE__, __VA_ARGS__);
+#else
+#define INFO_MSG(...) softHSMLog(LOG_INFO, __FUNCTION__, __FILE__, __LINE__, __VA_ARGS__);
+#endif
 #else
 #define INFO_MSG(...)
 #endif
 
 /* Logging debug information */
 #if SOFTLOGLEVEL >= SOFTDEBUG
+#ifndef _WIN32
 #define DEBUG_MSG(...) softHSMLog(LOG_DEBUG, __func__, __FILE__, __LINE__, __VA_ARGS__);
+#else
+#define DEBUG_MSG(...) softHSMLog(LOG_DEBUG, __FUNCTION__, __FILE__, __LINE__, __VA_ARGS__);
+#endif
 #else
 #define DEBUG_MSG(...)
 #endif

--- a/src/lib/crypto/BotanCryptoFactory.cpp
+++ b/src/lib/crypto/BotanCryptoFactory.cpp
@@ -80,6 +80,12 @@ BotanCryptoFactory::~BotanCryptoFactory()
 	{
 		delete (BotanRNG*)it->second;
 	}
+#elif _WIN32
+	std::map<DWORD,RNG*>::iterator it;
+	for (it=rngs.begin(); it != rngs.end(); it++)
+	{
+		delete (BotanRNG*)it->second;
+	}
 #endif
 
 	// TODO: We cannot do this because the MutexFactory is destroyed before the CryptoFactory
@@ -292,6 +298,20 @@ RNG* BotanCryptoFactory::getRNG(std::string name /* = "default" */)
 
 		// Find the RNG
 		std::map<pthread_t,RNG*>::iterator findIt;
+		findIt=rngs.find(threadID);
+		if (findIt != rngs.end())
+		{
+			return findIt->second;
+		}
+
+		threadRNG = new BotanRNG();
+		rngs[threadID] = threadRNG;
+#elif _WIN32
+		// Get thread ID
+		DWORD threadID = GetCurrentThreadId();
+
+		// Find the RNG
+		std::map<DWORD,RNG*>::iterator findIt;
 		findIt=rngs.find(threadID);
 		if (findIt != rngs.end())
 		{

--- a/src/lib/crypto/BotanCryptoFactory.h
+++ b/src/lib/crypto/BotanCryptoFactory.h
@@ -83,6 +83,8 @@ private:
 	// Thread specific RNG
 #ifdef HAVE_PTHREAD_H
 	std::map<pthread_t, RNG*> rngs;
+#elif _WIN32
+	std::map<DWORD, RNG*> rngs;
 #endif
         Mutex* rngsMutex;
 };

--- a/src/lib/crypto/BotanRNG.cpp
+++ b/src/lib/crypto/BotanRNG.cpp
@@ -51,7 +51,8 @@ bool BotanRNG::generateRandom(ByteString& data, const size_t len)
 {
 	data.wipe(len);
 
-	rng->randomize(&data[0], len);
+	if (len > 0)
+		rng->randomize(&data[0], len);
 
 	return true;
 }

--- a/src/lib/crypto/BotanSymmetricAlgorithm.cpp
+++ b/src/lib/crypto/BotanSymmetricAlgorithm.cpp
@@ -141,7 +141,8 @@ bool BotanSymmetricAlgorithm::encryptUpdate(const ByteString& data, ByteString& 
 	// Write data
 	try
 	{
-		cryption->write(data.const_byte_str(), data.size());
+		if (data.size() > 0)
+			cryption->write(data.const_byte_str(), data.size());
 	}
 	catch (...)
 	{
@@ -160,9 +161,10 @@ bool BotanSymmetricAlgorithm::encryptUpdate(const ByteString& data, ByteString& 
 	int bytesRead = 0;
 	try
 	{
-		int outLen = cryption->remaining();
+		size_t outLen = cryption->remaining();
 		encryptedData.resize(outLen);
-		bytesRead = cryption->read(&encryptedData[0], outLen);
+		if (outLen > 0)
+			bytesRead = cryption->read(&encryptedData[0], outLen);
 	}
 	catch (...)
 	{
@@ -198,9 +200,10 @@ bool BotanSymmetricAlgorithm::encryptFinal(ByteString& encryptedData)
 	try
 	{
 		cryption->end_msg();
-		int outLen = cryption->remaining();
+		size_t outLen = cryption->remaining();
 		encryptedData.resize(outLen);
-		bytesRead = cryption->read(&encryptedData[0], outLen);
+		if (outLen > 0)
+			bytesRead = cryption->read(&encryptedData[0], outLen);
 	}
 	catch (...)
 	{
@@ -310,7 +313,8 @@ bool BotanSymmetricAlgorithm::decryptUpdate(const ByteString& encryptedData, Byt
 	// Write data
 	try
 	{
-		cryption->write(encryptedData.const_byte_str(), encryptedData.size());
+		if (encryptedData.size() > 0)
+			cryption->write(encryptedData.const_byte_str(), encryptedData.size());
 	}
 	catch (...)
 	{
@@ -329,9 +333,10 @@ bool BotanSymmetricAlgorithm::decryptUpdate(const ByteString& encryptedData, Byt
 	int bytesRead = 0;
 	try
 	{
-		int outLen = cryption->remaining();
+		size_t outLen = cryption->remaining();
 		data.resize(outLen);
-		bytesRead = cryption->read(&data[0], outLen);
+		if (outLen > 0)
+			bytesRead = cryption->read(&data[0], outLen);
 	}
 	catch (...)
 	{
@@ -367,9 +372,10 @@ bool BotanSymmetricAlgorithm::decryptFinal(ByteString& data)
 	try
 	{
 		cryption->end_msg();
-		int outLen = cryption->remaining();
+		size_t outLen = cryption->remaining();
 		data.resize(outLen);
-		bytesRead = cryption->read(&data[0], outLen);
+		if (outLen > 0)
+			bytesRead = cryption->read(&data[0], outLen);
 	}
 	catch (...)
 	{

--- a/src/lib/crypto/OSSLEVPHashAlgorithm.h
+++ b/src/lib/crypto/OSSLEVPHashAlgorithm.h
@@ -41,7 +41,9 @@ class OSSLEVPHashAlgorithm : public HashAlgorithm
 {
 public:
 	// Base constructors
-	OSSLEVPHashAlgorithm() : HashAlgorithm() { }
+	OSSLEVPHashAlgorithm() : HashAlgorithm() {
+		EVP_MD_CTX_init(&curCTX);
+	}
 
 	// Destructor
 	~OSSLEVPHashAlgorithm();

--- a/src/lib/crypto/OSSLEVPMacAlgorithm.h
+++ b/src/lib/crypto/OSSLEVPMacAlgorithm.h
@@ -44,7 +44,9 @@ class OSSLEVPMacAlgorithm : public MacAlgorithm
 {
 public:
 	// Constructor
-	OSSLEVPMacAlgorithm() { };
+	OSSLEVPMacAlgorithm() {
+		HMAC_CTX_init(&curCTX);
+	};
 
 	// Destructor
 	~OSSLEVPMacAlgorithm();

--- a/src/lib/crypto/OSSLEVPSymmetricAlgorithm.cpp
+++ b/src/lib/crypto/OSSLEVPSymmetricAlgorithm.cpp
@@ -141,6 +141,13 @@ bool OSSLEVPSymmetricAlgorithm::encryptUpdate(const ByteString& data, ByteString
 		return false;
 	}
 
+	if (data.size() == 0)
+	{
+		encryptedData.resize(0);
+
+		return true;
+	}
+
 	// Prepare the output block
 	encryptedData.resize(data.size() + getBlockSize() - 1);
 

--- a/src/lib/crypto/OSSLGOST.h
+++ b/src/lib/crypto/OSSLGOST.h
@@ -40,6 +40,11 @@
 class OSSLGOST : public AsymmetricAlgorithm
 {
 public:
+	// Constructor
+	OSSLGOST() : AsymmetricAlgorithm() {
+		EVP_MD_CTX_init(&curCTX);
+	}
+
 	// Destructor
 	~OSSLGOST();
 

--- a/src/lib/crypto/OSSLRNG.cpp
+++ b/src/lib/crypto/OSSLRNG.cpp
@@ -39,7 +39,9 @@ bool OSSLRNG::generateRandom(ByteString& data, const size_t len)
 {
 	data.wipe(len);
 
-	return RAND_bytes(&data[0], len);
+	if (len == 0)
+		return true;
+	return RAND_bytes(&data[0], len) == 1;
 }
 
 // Seed the random pool

--- a/src/lib/crypto/test/AESTests.cpp
+++ b/src/lib/crypto/test/AESTests.cpp
@@ -426,7 +426,11 @@ void AESTests::testECB()
 
 void AESTests::writeTmpFile(ByteString& data)
 {
+#ifndef _WIN32
 	FILE* out = fopen("shsmv2-aestest.tmp", "w");
+#else
+	FILE* out = fopen("shsmv2-aestest.tmp", "wb");
+#endif
 	CPPUNIT_ASSERT(out != NULL);
 
 	CPPUNIT_ASSERT(fwrite(&data[0], 1, data.size(), out) == data.size());
@@ -439,7 +443,11 @@ void AESTests::readTmpFile(ByteString& data)
 
 	data.wipe();
 
+#ifndef _WIN32
 	FILE* in = fopen("shsmv2-aestest-out.tmp", "r");
+#else
+	FILE* in = fopen("shsmv2-aestest-out.tmp", "rb");
+#endif
 	CPPUNIT_ASSERT(in != NULL);
 
 	int read = 0;

--- a/src/lib/crypto/test/DESTests.cpp
+++ b/src/lib/crypto/test/DESTests.cpp
@@ -798,7 +798,11 @@ void DESTests::testCFB()
 
 void DESTests::writeTmpFile(ByteString& data)
 {
+#ifndef _WIN32
 	FILE* out = fopen("shsmv2-destest.tmp", "w");
+#else
+	FILE* out = fopen("shsmv2-destest.tmp", "wb");
+#endif
 	CPPUNIT_ASSERT(out != NULL);
 
 	CPPUNIT_ASSERT(fwrite(&data[0], 1, data.size(), out) == data.size());
@@ -811,7 +815,11 @@ void DESTests::readTmpFile(ByteString& data)
 
 	data.wipe();
 
+#ifndef _WIN32
 	FILE* in = fopen("shsmv2-destest-out.tmp", "r");
+#else
+	FILE* in = fopen("shsmv2-destest-out.tmp", "rb");
+#endif
 	CPPUNIT_ASSERT(in != NULL);
 
 	int read = 0;

--- a/src/lib/crypto/test/GOSTTests.cpp
+++ b/src/lib/crypto/test/GOSTTests.cpp
@@ -91,7 +91,11 @@ void GOSTTests::testHash()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat gost-hashtest.tmp | openssl dgst -engine gost -md_gost94 -binary > gost-hashtest-out.tmp 2> /dev/null") == 0);
+#ifndef _WIN32
+	CPPUNIT_ASSERT(system("openssl dgst -engine gost -md_gost94 -binary < gost-hashtest.tmp > gost-hashtest-out.tmp 2> /dev/null") == 0);
+#else
+	CPPUNIT_ASSERT(system("openssl dgst -engine gost -md_gost94 -binary < gost-hashtest.tmp > gost-hashtest-out.tmp 2> nul") == 0);
+#endif
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -122,7 +126,11 @@ void GOSTTests::testHash()
 
 void GOSTTests::writeTmpFile(ByteString& data)
 {
+#ifndef _WIN32
 	FILE* out = fopen("gost-hashtest.tmp", "w");
+#else
+	FILE* out = fopen("gost-hashtest.tmp", "wb");
+#endif
 	CPPUNIT_ASSERT(out != NULL);
 
 	CPPUNIT_ASSERT(fwrite(&data[0], 1, data.size(), out) == data.size());
@@ -135,7 +143,11 @@ void GOSTTests::readTmpFile(ByteString& data)
 
 	data.wipe();
 
+#ifdef _WIN32
 	FILE* in = fopen("gost-hashtest-out.tmp", "r");
+#else
+	FILE* in = fopen("gost-hashtest-out.tmp", "rb");
+#endif
 	CPPUNIT_ASSERT(in != NULL);
 
 	int read = 0;

--- a/src/lib/crypto/test/HashTests.cpp
+++ b/src/lib/crypto/test/HashTests.cpp
@@ -72,7 +72,7 @@ void HashTests::testMD5()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat shsmv2-hashtest.tmp | openssl md5 -binary > shsmv2-hashtest-out.tmp") == 0);
+	CPPUNIT_ASSERT(system("openssl md5 -binary < shsmv2-hashtest.tmp > shsmv2-hashtest-out.tmp") == 0);
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -117,7 +117,7 @@ void HashTests::testSHA1()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat shsmv2-hashtest.tmp | openssl sha1 -binary > shsmv2-hashtest-out.tmp") == 0);
+	CPPUNIT_ASSERT(system("openssl sha1 -binary < shsmv2-hashtest.tmp > shsmv2-hashtest-out.tmp") == 0);
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -162,7 +162,7 @@ void HashTests::testSHA224()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat shsmv2-hashtest.tmp | openssl sha -sha224 -binary > shsmv2-hashtest-out.tmp") == 0);
+	CPPUNIT_ASSERT(system("openssl sha -sha224 -binary < shsmv2-hashtest.tmp > shsmv2-hashtest-out.tmp") == 0);
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -207,7 +207,7 @@ void HashTests::testSHA256()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat shsmv2-hashtest.tmp | openssl sha -sha256 -binary > shsmv2-hashtest-out.tmp") == 0);
+	CPPUNIT_ASSERT(system("openssl sha -sha256 -binary < shsmv2-hashtest.tmp > shsmv2-hashtest-out.tmp") == 0);
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -252,7 +252,7 @@ void HashTests::testSHA384()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat shsmv2-hashtest.tmp | openssl sha -sha384 -binary > shsmv2-hashtest-out.tmp") == 0);
+	CPPUNIT_ASSERT(system("openssl sha -sha384 -binary < shsmv2-hashtest.tmp > shsmv2-hashtest-out.tmp") == 0);
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -297,7 +297,7 @@ void HashTests::testSHA512()
 	writeTmpFile(b);
 
 	// Use OpenSSL externally to hash it
-	CPPUNIT_ASSERT(system("cat shsmv2-hashtest.tmp | openssl sha -sha512 -binary > shsmv2-hashtest-out.tmp") == 0);
+	CPPUNIT_ASSERT(system("openssl sha -sha512 -binary < shsmv2-hashtest.tmp > shsmv2-hashtest-out.tmp") == 0);
 
 	// Read the hash from file
 	readTmpFile(osslHash);
@@ -328,7 +328,11 @@ void HashTests::testSHA512()
 
 void HashTests::writeTmpFile(ByteString& data)
 {
+#ifndef _WIN32
 	FILE* out = fopen("shsmv2-hashtest.tmp", "w");
+#else
+	FILE* out = fopen("shsmv2-hashtest.tmp", "wb");
+#endif
 	CPPUNIT_ASSERT(out != NULL);
 
 	CPPUNIT_ASSERT(fwrite(&data[0], 1, data.size(), out) == data.size());
@@ -341,7 +345,11 @@ void HashTests::readTmpFile(ByteString& data)
 
 	data.wipe();
 
+#ifndef _WIN32
 	FILE* in = fopen("shsmv2-hashtest-out.tmp", "r");
+#else
+	FILE* in = fopen("shsmv2-hashtest-out.tmp", "rb");
+#endif
 	CPPUNIT_ASSERT(in != NULL);
 
 	int read = 0;

--- a/src/lib/crypto/test/MacTests.cpp
+++ b/src/lib/crypto/test/MacTests.cpp
@@ -79,7 +79,7 @@ void MacTests::testHMACMD5()
 
 	// Use OpenSSL externally to mac it
 	char commandLine[2048];
-	sprintf(commandLine, "cat shsmv2-mactest.tmp | openssl dgst -hmac %s -md5 -binary > shsmv2-mactest-out.tmp", pk);
+	sprintf(commandLine, "openssl dgst -hmac %s -md5 -binary < shsmv2-mactest.tmp > shsmv2-mactest-out.tmp", pk);
 	CPPUNIT_ASSERT(system(commandLine) == 0);
 
 	// Read the MAC from file
@@ -132,7 +132,7 @@ void MacTests::testHMACSHA1()
 
 	// Use OpenSSL externally mac hash it
 	char commandLine[2048];
-	sprintf(commandLine, "cat shsmv2-mactest.tmp | openssl dgst -hmac %s -sha1 -binary > shsmv2-mactest-out.tmp", pk);
+	sprintf(commandLine, "openssl dgst -hmac %s -sha1 -binary < shsmv2-mactest.tmp > shsmv2-mactest-out.tmp", pk);
 	CPPUNIT_ASSERT(system(commandLine) == 0);
 
 	// Read the MAC from file
@@ -191,7 +191,7 @@ void MacTests::testHMACSHA224()
 
 	// Use OpenSSL externally to mac it
 	char commandLine[2048];
-	sprintf(commandLine, "cat shsmv2-mactest.tmp | openssl dgst -hmac %s -sha224 -binary > shsmv2-mactest-out.tmp", pk);
+	sprintf(commandLine, "openssl dgst -hmac %s -sha224 -binary < shsmv2-mactest.tmp > shsmv2-mactest-out.tmp", pk);
 	CPPUNIT_ASSERT(system(commandLine) == 0);
 
 	// Read the MAC from file
@@ -248,7 +248,7 @@ void MacTests::testHMACSHA256()
 
 	// Use OpenSSL externally to mac it
 	char commandLine[2048];
-	sprintf(commandLine, "cat shsmv2-mactest.tmp | openssl dgst -hmac %s -sha256 -binary > shsmv2-mactest-out.tmp", pk);
+	sprintf(commandLine, "openssl dgst -hmac %s -sha256 -binary < shsmv2-mactest.tmp > shsmv2-mactest-out.tmp", pk);
 	CPPUNIT_ASSERT(system(commandLine) == 0);
 
 	// Read the MAC from file
@@ -301,7 +301,7 @@ void MacTests::testHMACSHA384()
 
 	// Use OpenSSL externally to mac it
 	char commandLine[2048];
-	sprintf(commandLine, "cat shsmv2-mactest.tmp | openssl dgst -hmac %s -sha384 -binary > shsmv2-mactest-out.tmp", pk);
+	sprintf(commandLine, "openssl dgst -hmac %s -sha384 -binary < shsmv2-mactest.tmp > shsmv2-mactest-out.tmp", pk);
 	CPPUNIT_ASSERT(system(commandLine) == 0);
 
 	// Read the MAC from file
@@ -362,7 +362,7 @@ void MacTests::testHMACSHA512()
 
 	// Use OpenSSL externally to mac it
 	char commandLine[2048];
-	sprintf(commandLine, "cat shsmv2-mactest.tmp | openssl dgst -hmac %s -sha512 -binary > shsmv2-mactest-out.tmp", pk);
+	sprintf(commandLine, "openssl dgst -hmac %s -sha512 -binary < shsmv2-mactest.tmp > shsmv2-mactest-out.tmp", pk);
 	CPPUNIT_ASSERT(system(commandLine) == 0);
 
 	// Read the MAC from file
@@ -388,7 +388,11 @@ void MacTests::testHMACSHA512()
 
 void MacTests::writeTmpFile(ByteString& data)
 {
+#ifndef _WIN32
 	FILE* out = fopen("shsmv2-mactest.tmp", "w");
+#else
+	FILE* out = fopen("shsmv2-mactest.tmp", "wb");
+#endif
 	CPPUNIT_ASSERT(out != NULL);
 
 	CPPUNIT_ASSERT(fwrite(&data[0], 1, data.size(), out) == data.size());
@@ -401,7 +405,11 @@ void MacTests::readTmpFile(ByteString& data)
 
 	data.wipe();
 
+#ifndef _WIN32
 	FILE* in = fopen("shsmv2-mactest-out.tmp", "r");
+#else
+	FILE* in = fopen("shsmv2-mactest-out.tmp", "rb");
+#endif
 	CPPUNIT_ASSERT(in != NULL);
 
 	int read = 0;

--- a/src/lib/data_mgr/ByteString.cpp
+++ b/src/lib/data_mgr/ByteString.cpp
@@ -46,7 +46,8 @@ ByteString::ByteString(const unsigned char* bytes, const size_t bytesLen)
 {
 	byteString.resize(bytesLen);
 
-	memcpy(&byteString[0], bytes, bytesLen);
+	if (bytesLen > 0)
+		memcpy(&byteString[0], bytes, bytesLen);
 }
 
 ByteString::ByteString(const char* hexString)
@@ -111,7 +112,8 @@ ByteString& ByteString::operator+=(const ByteString& append)
 
 	byteString.resize(newLen);
 
-	memcpy(&byteString[curLen], &append.byteString[0], toAdd);
+	if (toAdd > 0)
+		memcpy(&byteString[curLen], &append.byteString[0], toAdd);
 
 	return *this;
 }
@@ -297,7 +299,8 @@ void ByteString::wipe(const size_t newSize /* = 0 */)
 {
 	this->resize(newSize);
 
-	memset(&byteString[0], 0x00, byteString.size());
+	if (!byteString.empty())
+		memset(&byteString[0], 0x00, byteString.size());
 }
 
 // Comparison
@@ -306,6 +309,10 @@ bool ByteString::operator==(const ByteString& compareTo) const
 	if (compareTo.size() != this->size())
 	{
 		return false;
+	}
+	else if (this->size() == 0)
+	{
+		return true;
 	}
 
 	return (memcmp(&byteString[0], &compareTo.byteString[0], this->size()) == 0);
@@ -316,6 +323,10 @@ bool ByteString::operator!=(const ByteString& compareTo) const
 	if (compareTo.size() != this->size())
 	{
 		return true;
+	}
+	else if (this->size() == 0)
+	{
+		return false;
 	}
 
 	return (memcmp(&byteString[0], &compareTo.byteString[0], this->size()) != 0);

--- a/src/lib/object_store/OSToken.cpp
+++ b/src/lib/object_store/OSToken.cpp
@@ -49,6 +49,12 @@
 #include <map>
 #include <list>
 #include <stdio.h>
+#ifndef _WIN32
+#include <unistd.h>
+#else
+#include <direct.h>
+#define rmdir _rmdir
+#endif
 
 // Constructor
 OSToken::OSToken(const std::string tokenPath)
@@ -446,7 +452,7 @@ bool OSToken::clearToken()
 	}
 
 	// Now remove the token directory
-	if (remove(tokenPath.c_str()))
+	if (rmdir(tokenPath.c_str()))
 	{
 		ERROR_MSG("Failed to remove the token directory %s", tokenPath.c_str());
 

--- a/src/lib/object_store/ObjectFile.cpp
+++ b/src/lib/object_store/ObjectFile.cpp
@@ -34,7 +34,9 @@
 #include "ObjectFile.h"
 #include "OSToken.h"
 #include "OSPathSep.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/src/lib/object_store/ObjectStore.cpp
+++ b/src/lib/object_store/ObjectStore.cpp
@@ -38,6 +38,7 @@
 #include "ObjectStore.h"
 #include "Directory.h"
 #include "OSToken.h"
+#include "OSPathSep.h"
 #include "UUID.h"
 #include <stdio.h>
 
@@ -66,7 +67,7 @@ ObjectStore::ObjectStore(std::string storePath)
 	for (std::vector<std::string>::iterator i = dirs.begin(); i != dirs.end(); i++)
 	{
 		// Create a token instance
-		OSToken* token = new OSToken(storePath + "/" + *i);
+		OSToken* token = new OSToken(storePath + OS_PATHSEP + *i);
 
 		if (!token->isValid())
 		{

--- a/src/lib/object_store/test/DirectoryTests.cpp
+++ b/src/lib/object_store/test/DirectoryTests.cpp
@@ -40,7 +40,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(DirectoryTests);
 
 void DirectoryTests::setUp()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("mkdir testdir"));
 	CPPUNIT_ASSERT(!system("mkdir testdir/anotherdir"));
 	CPPUNIT_ASSERT(!system("mkdir testdir/anotherdir2"));
@@ -48,18 +48,33 @@ void DirectoryTests::setUp()
 	CPPUNIT_ASSERT(!system("echo someStuff > testdir/afile"));
 	CPPUNIT_ASSERT(!system("echo someOtherStuff > testdir/anotherFile"));
 	CPPUNIT_ASSERT(!system("echo justStuff > testdir/justaFile"));
+#else
+	CPPUNIT_ASSERT(!system("mkdir testdir"));
+	CPPUNIT_ASSERT(!system("mkdir testdir\\anotherdir"));
+	CPPUNIT_ASSERT(!system("mkdir testdir\\anotherdir2"));
+	CPPUNIT_ASSERT(!system("mkdir testdir\\anotherdir3"));
+	CPPUNIT_ASSERT(!system("echo someStuff > testdir\\afile"));
+	CPPUNIT_ASSERT(!system("echo someOtherStuff > testdir\\anotherFile"));
+	CPPUNIT_ASSERT(!system("echo justStuff > testdir\\justaFile"));
+#endif
 }
 
 void DirectoryTests::tearDown()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("rm -rf testdir"));
+#else
+	CPPUNIT_ASSERT(!system("rmdir /s /q testdir 2> nul"));
+#endif
 }
 
 void DirectoryTests::testDirectory()
 {
-	// FIXME: Path separator is not platform independent
+#ifndef _WIN32
 	Directory testdir("./testdir");
+#else
+	Directory testdir(".\\testdir");
+#endif
 
 	CPPUNIT_ASSERT(testdir.isValid());
 

--- a/src/lib/object_store/test/FileTests.cpp
+++ b/src/lib/object_store/test/FileTests.cpp
@@ -45,15 +45,21 @@ CPPUNIT_TEST_SUITE_REGISTRATION(FileTests);
 
 void FileTests::setUp()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	int rv = system("rm -rf testdir");
+#else
+	int rv = system("rmdir /s /q testdir 2> nul");
+#endif
 	CPPUNIT_ASSERT(!system("mkdir testdir"));
 }
 
 void FileTests::tearDown()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("rm -rf testdir"));
+#else
+	CPPUNIT_ASSERT(!system("rmdir /s /q testdir 2> nul"));
+#endif
 }
 
 void FileTests::testExistNotExist()
@@ -62,15 +68,27 @@ void FileTests::testExistNotExist()
 	CPPUNIT_ASSERT(!exists("nonExistentFile"));
 
 	// Attempt to open a file known not to exist
+#ifndef _WIN32
 	File doesntExist("testdir/nonExistentFile");
+#else
+	File doesntExist("testdir\\nonExistentFile");
+#endif
 
 	CPPUNIT_ASSERT(!doesntExist.isValid());
 
 	// Attempt to open a file known to exist
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("echo someStuff > testdir/existingFile"));
+#else
+	CPPUNIT_ASSERT(!system("echo someStuff > testdir\\existingFile"));
+#endif
 	CPPUNIT_ASSERT(exists("existingFile"));
 
+#ifndef _WIN32
 	File exists("testdir/existingFile");
+#else
+	File exists("testdir\\existingFile");
+#endif
 
 	CPPUNIT_ASSERT(exists.isValid());
 }
@@ -82,13 +100,21 @@ void FileTests::testCreateNotCreate()
 	CPPUNIT_ASSERT(!exists("nonExistentFile2"));
 	
 	// Attempt to open a file known not to exist
+#ifndef _WIN32
 	File doesntExist("testdir/nonExistentFile", true, true, false);
+#else
+	File doesntExist("testdir\\nonExistentFile", true, true, false);
+#endif
 
 	CPPUNIT_ASSERT(!doesntExist.isValid());
 	CPPUNIT_ASSERT(!exists("nonExistentFile"));
 
 	// Attempt to open a file known not to exist in create mode
+#ifndef _WIN32
 	File willBeCreated("testdir/nonExistentFile2", true, true, true);
+#else
+	File willBeCreated("testdir\\nonExistentFile2", true, true, true);
+#endif
 
 	CPPUNIT_ASSERT(willBeCreated.isValid());
 	CPPUNIT_ASSERT(exists("nonExistentFile2"));
@@ -97,11 +123,20 @@ void FileTests::testCreateNotCreate()
 void FileTests::testLockUnlock()
 {
 	// Create pre-condition
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("echo someStuff > testdir/existingFile"));
+#else
+	CPPUNIT_ASSERT(!system("echo someStuff > testdir\\existingFile"));
+#endif
 	CPPUNIT_ASSERT(exists("existingFile"));
 
+#ifndef _WIN32
 	File file1("testdir/existingFile");
 	File file2("testdir/existingFile");
+#else
+	File file1("testdir\\existingFile");
+	File file2("testdir\\existingFile");
+#endif
 
 	CPPUNIT_ASSERT(file1.lock(false));
 	CPPUNIT_ASSERT(!file1.lock(false));
@@ -128,7 +163,11 @@ void FileTests::testWriteRead()
 
 	// Create a file for writing
 	{
+#ifndef _WIN32
 		File newFile("testdir/newFile", false, true);
+#else
+		File newFile("testdir\\newFile", false, true);
+#endif
 
 		CPPUNIT_ASSERT(newFile.isValid());
 
@@ -150,7 +189,11 @@ void FileTests::testWriteRead()
 
 	// Read the created file back
 	{
+#ifndef _WIN32
 		File newFile("testdir/newFile");
+#else
+		File newFile("testdir\\newFile");
+#endif
 
 		CPPUNIT_ASSERT(newFile.isValid());
 
@@ -191,7 +234,11 @@ void FileTests::testSeek()
 
 	{
 		// Create the test file
+#ifndef _WIN32
 		File testFile("testdir/testFile", false, true, true);
+#else
+		File testFile("testdir\\testFile", false, true, true);
+#endif
 
 		CPPUNIT_ASSERT(testFile.isValid());
 
@@ -200,7 +247,11 @@ void FileTests::testSeek()
 	}
 
 	// Open the test file for reading
+#ifndef _WIN32
 	File testFile("testdir/testFile");
+#else
+	File testFile("testdir\\testFile");
+#endif
 
 	CPPUNIT_ASSERT(testFile.isValid());
 
@@ -251,7 +302,12 @@ void FileTests::testSeek()
 
 bool FileTests::exists(std::string name)
 {
+#ifndef _WIN32
 	Directory dir("./testdir");
+#else
+	Directory dir(".\\testdir");
+#endif
+
 
 	CPPUNIT_ASSERT(dir.isValid());
 

--- a/src/lib/object_store/test/ObjectFileTests.cpp
+++ b/src/lib/object_store/test/ObjectFileTests.cpp
@@ -30,6 +30,7 @@
  Contains test cases to test the object file implementation
  *****************************************************************************/
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -38,6 +39,8 @@
 #include "File.h"
 #include "Directory.h"
 #include "OSAttribute.h"
+#include "CryptoFactory.h"
+#include "RNG.h"
 #include "cryptoki.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ObjectFileTests);
@@ -46,21 +49,27 @@ CPPUNIT_TEST_SUITE_REGISTRATION(ObjectFileTests);
 
 void ObjectFileTests::setUp()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
 	CPPUNIT_ASSERT(!system("mkdir testdir"));
 }
 
 void ObjectFileTests::tearDown()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("rm -rf testdir"));
+#else
+	CPPUNIT_ASSERT(!system("rmdir /s /q testdir 2> nul"));
+#endif
 }
 
 void ObjectFileTests::testBoolAttr()
 {
 	// Create the test object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -85,7 +94,11 @@ void ObjectFileTests::testBoolAttr()
 
 	// Now read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -122,7 +135,11 @@ void ObjectFileTests::testULongAttr()
 {
 	// Create the test object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -147,7 +164,11 @@ void ObjectFileTests::testULongAttr()
 
 	// Now read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -189,7 +210,11 @@ void ObjectFileTests::testByteStrAttr()
 
 	// Create the test object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -208,7 +233,11 @@ void ObjectFileTests::testByteStrAttr()
 
 	// Now read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -246,7 +275,11 @@ void ObjectFileTests::testMixedAttr()
 
 	// Create the test object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -264,7 +297,11 @@ void ObjectFileTests::testMixedAttr()
 
 	// Now read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -290,7 +327,11 @@ void ObjectFileTests::testDoubleAttr()
 
 	// Create the test object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -308,7 +349,11 @@ void ObjectFileTests::testDoubleAttr()
 
 	// Now read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -351,7 +396,11 @@ void ObjectFileTests::testDoubleAttr()
 
 	// Now re-read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -380,7 +429,11 @@ void ObjectFileTests::testRefresh()
 
 	// Create the test object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -398,7 +451,11 @@ void ObjectFileTests::testRefresh()
 
 	// Now read back the object
 	{
+#ifndef _WIN32
 		ObjectFile testObject(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 		CPPUNIT_ASSERT(testObject.isValid());
 
@@ -439,7 +496,11 @@ void ObjectFileTests::testRefresh()
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS)->getByteStringValue() == value3a);
 
 		// Open the object a second time
+#ifndef _WIN32
 		ObjectFile testObject2(NULL, "testdir/testobject");
+#else
+		ObjectFile testObject2(NULL, "testdir\\testobject");
+#endif
 
 		// Check the attributes on the second instance
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN)->isBooleanAttribute());
@@ -486,9 +547,24 @@ void ObjectFileTests::testRefresh()
 
 void ObjectFileTests::testCorruptFile()
 {
-	CPPUNIT_ASSERT(system("dd if=/dev/urandom of=testdir/testobject bs=13 count=24") != -1);
+#ifndef _WIN32
+	FILE* stream = fopen("testdir/testobject", "w");
+#else
+	FILE* stream = fopen("testdir\\testobject", "wb");
+#endif
+	RNG* rng = CryptoFactory::i()->getRNG();
+	ByteString randomData;
 
+	CPPUNIT_ASSERT(stream != NULL);
+	CPPUNIT_ASSERT(rng->generateRandom(randomData, 312));
+	CPPUNIT_ASSERT(fwrite(randomData.const_byte_str(), 1, randomData.size(), stream) == randomData.size());
+	CPPUNIT_ASSERT(!fclose(stream));
+
+#ifndef _WIN32
 	ObjectFile testObject(NULL, "testdir/testobject");
+#else
+	ObjectFile testObject(NULL, "testdir\\testobject");
+#endif
 
 	CPPUNIT_ASSERT(!testObject.isValid());
 }
@@ -496,7 +572,11 @@ void ObjectFileTests::testCorruptFile()
 void ObjectFileTests::testTransactions()
 {
 	// Create test object instance
+#ifndef _WIN32
 	ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+	ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -513,7 +593,11 @@ void ObjectFileTests::testTransactions()
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
 
 	// Create secondary instance for the same object
+#ifndef _WIN32
 	ObjectFile testObject2(NULL, "testdir/testobject");
+#else
+	ObjectFile testObject2(NULL, "testdir\\testobject");
+#endif
 
 	CPPUNIT_ASSERT(testObject2.isValid());
 
@@ -623,7 +707,11 @@ void ObjectFileTests::testTransactions()
 void ObjectFileTests::testDestroyObjectFails()
 {
 	// Create test object instance
+#ifndef _WIN32
 	ObjectFile testObject(NULL, "testdir/testobject", true);
+#else
+	ObjectFile testObject(NULL, "testdir\\testobject", true);
+#endif
 
 	CPPUNIT_ASSERT(testObject.isValid());
 

--- a/src/lib/object_store/test/ObjectStoreTests.cpp
+++ b/src/lib/object_store/test/ObjectStoreTests.cpp
@@ -49,20 +49,26 @@ CPPUNIT_TEST_SUITE_REGISTRATION(ObjectStoreTests);
 
 void ObjectStoreTests::setUp()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
 	CPPUNIT_ASSERT(!system("mkdir testdir"));
 }
 
 void ObjectStoreTests::tearDown()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("rm -rf testdir"));
+#else
+	CPPUNIT_ASSERT(!system("rmdir /s /q testdir 2> nul"));
+#endif
 }
 
 void ObjectStoreTests::testEmptyStore()
 {
 	// Create the store for an empty dir
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	CPPUNIT_ASSERT(store.getTokenCount() == 0);
 }
@@ -74,7 +80,11 @@ void ObjectStoreTests::testNewTokens()
 
 	{
 		// Create an empty store
+#ifndef _WIN32
 		ObjectStore store("./testdir");
+#else
+		ObjectStore store(".\\testdir");
+#endif
 
 		CPPUNIT_ASSERT(store.getTokenCount() == 0);
 
@@ -94,7 +104,11 @@ void ObjectStoreTests::testNewTokens()
 	}
 
 	// Now reopen that same store
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	CPPUNIT_ASSERT(store.getTokenCount() == 2);
 
@@ -126,8 +140,13 @@ void ObjectStoreTests::testExistingTokens()
 	ByteString serial1 = "0011001100110011";
 	ByteString serial2 = "2233223322332233";
 
+#ifndef _WIN32
 	OSToken* token1 = OSToken::createToken("./testdir", "token1", label1, serial1);
 	OSToken* token2 = OSToken::createToken("./testdir", "token2", label2, serial2);
+#else
+	OSToken* token1 = OSToken::createToken(".\\testdir", "token1", label1, serial1);
+	OSToken* token2 = OSToken::createToken(".\\testdir", "token2", label2, serial2);
+#endif
 
 	CPPUNIT_ASSERT((token1 != NULL) && (token2 != NULL));
 
@@ -135,7 +154,11 @@ void ObjectStoreTests::testExistingTokens()
 	delete token2;
 
 	// Now associate a store with the test directory
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	CPPUNIT_ASSERT(store.getTokenCount() == 2);
 
@@ -169,8 +192,13 @@ void ObjectStoreTests::testDeleteToken()
 	ByteString serial1 = "0011001100110011";
 	ByteString serial2 = "2233223322332233";
 
+#ifndef _WIN32
 	OSToken* token1 = OSToken::createToken("./testdir", "token1", label1, serial1);
 	OSToken* token2 = OSToken::createToken("./testdir", "token2", label2, serial2);
+#else
+	OSToken* token1 = OSToken::createToken(".\\testdir", "token1", label1, serial1);
+	OSToken* token2 = OSToken::createToken(".\\testdir", "token2", label2, serial2);
+#endif
 
 	CPPUNIT_ASSERT((token1 != NULL) && (token2 != NULL));
 
@@ -178,7 +206,11 @@ void ObjectStoreTests::testDeleteToken()
 	delete token2;
 
 	// Now associate a store with the test directory
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	CPPUNIT_ASSERT(store.getTokenCount() == 2);
 

--- a/src/lib/slot_mgr/Token.cpp
+++ b/src/lib/slot_mgr/Token.cpp
@@ -32,7 +32,11 @@
 #include "ByteString.h"
 #include "SecureDataManager.h"
 
+#ifndef _WIN32
 #include <sys/time.h>
+#else
+#include <time.h>
+#endif
 
 // Constructor
 Token::Token()

--- a/src/lib/slot_mgr/test/SlotManagerTests.cpp
+++ b/src/lib/slot_mgr/test/SlotManagerTests.cpp
@@ -47,24 +47,28 @@
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SlotManagerTests);
 
-// FIXME: all pathnames in this file are *NIX/BSD specific
-
 void SlotManagerTests::setUp()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
 	CPPUNIT_ASSERT(!system("mkdir testdir"));
 }
 
 void SlotManagerTests::tearDown()
 {
-	// FIXME: this only works on *NIX/BSD, not on other platforms
+#ifndef _WIN32
 	CPPUNIT_ASSERT(!system("rm -rf testdir"));
+#else
+	CPPUNIT_ASSERT(!system("rmdir /s /q testdir 2> nul"));
+#endif
 }
 
 void SlotManagerTests::testNoExistingTokens()
 {
 	// Create an empty object store
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	// Create the slot manager
 	SlotManager slotManager(&store);
@@ -103,7 +107,11 @@ void SlotManagerTests::testNoExistingTokens()
 void SlotManagerTests::testExistingTokens()
 {
 	// Create an empty object store
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	// Create two tokens
 	ByteString label1 = "DEADBEEF";
@@ -178,7 +186,11 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 {
 	{
 		// Create an empty object store
+#ifndef _WIN32
 		ObjectStore store("./testdir");
+#else
+		ObjectStore store(".\\testdir");
+#endif
 	
 		// Create the slot manager
 		SlotManager slotManager(&store);
@@ -233,7 +245,11 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 	}
 
 	// Attach a fresh slot manager
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 	SlotManager slotManager(&store);
 
 	CPPUNIT_ASSERT(slotManager.getSlots().size() == 2);
@@ -285,7 +301,11 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 void SlotManagerTests::testReinitialiseExistingToken()
 {
 	// Create an empty object store
+#ifndef _WIN32
 	ObjectStore store("./testdir");
+#else
+	ObjectStore store(".\\testdir");
+#endif
 
 	// Create two tokens
 	ByteString label1 = "DEADBEEF";

--- a/src/lib/test/DigestTests.cpp
+++ b/src/lib/test/DigestTests.cpp
@@ -30,6 +30,7 @@
  Contains test cases to C_DigestInit, C_Digest, C_DigestUpdate, C_DigestFinal
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,7 +43,11 @@ void DigestTests::setUp()
 {
 //    printf("\nDigestTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
 	CK_ULONG pinLength = sizeof(pin) - 1;
@@ -66,7 +71,7 @@ void DigestTests::tearDown()
 void DigestTests::testDigestInit()
 {
 	CK_RV rv;
-	CK_SESSION_HANDLE hSession;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 	CK_MECHANISM mechanism = {
 		CKM_VENDOR_DEFINED, NULL_PTR, 0
 	};
@@ -103,7 +108,7 @@ void DigestTests::testDigestInit()
 void DigestTests::testDigest()
 {
 	CK_RV rv;
-	CK_SESSION_HANDLE hSession;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 	CK_MECHANISM mechanism = {
 		CKM_SHA512, NULL_PTR, 0
 	};
@@ -158,7 +163,7 @@ void DigestTests::testDigest()
 void DigestTests::testDigestUpdate()
 {
 	CK_RV rv;
-	CK_SESSION_HANDLE hSession;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 	CK_MECHANISM mechanism = {
 		CKM_SHA512, NULL_PTR, 0
 	};
@@ -195,7 +200,7 @@ void DigestTests::testDigestUpdate()
 void DigestTests::testDigestFinal()
 {
 	CK_RV rv;
-	CK_SESSION_HANDLE hSession;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 	CK_MECHANISM mechanism = {
 		CKM_SHA512, NULL_PTR, 0
 	};

--- a/src/lib/test/EncryptDecryptTests.cpp
+++ b/src/lib/test/EncryptDecryptTests.cpp
@@ -35,6 +35,7 @@
 
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -56,7 +57,11 @@ void EncryptDecryptTests::setUp()
 {
 //    printf("\nObjectTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_RV rv;
 	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;

--- a/src/lib/test/InfoTests.cpp
+++ b/src/lib/test/InfoTests.cpp
@@ -31,6 +31,7 @@
  C_GetSlotInfo, C_GetTokenInfo, C_GetMechanismList, and C_GetMechanismInfo
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -43,7 +44,11 @@ void InfoTests::setUp()
 {
 //    printf("\nInfoTests\n");
 
+#ifndef _WIN32
     setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+    setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
 	CK_ULONG pinLength = sizeof(pin) - 1;
@@ -282,7 +287,7 @@ void InfoTests::testGetMechanismInfo()
 	rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, CKM_VENDOR_DEFINED, &info);
 	CPPUNIT_ASSERT(rv == CKR_MECHANISM_INVALID);
 
-	for (int i = 0; i < ulMechCount; i++)
+	for (unsigned int i = 0; i < ulMechCount; i++)
 	{
 		rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, pMechanismList[i], &info);
 		CPPUNIT_ASSERT(rv == CKR_OK);

--- a/src/lib/test/InitTests.cpp
+++ b/src/lib/test/InitTests.cpp
@@ -43,7 +43,11 @@ void InitTests::setUp()
 {
 //    printf("\nInitTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 }
 
 void InitTests::tearDown()
@@ -73,6 +77,10 @@ void InitTests::testInit2()
 {
 	CK_C_INITIALIZE_ARGS InitArgs;
 	CK_RV rv;
+
+#ifdef CreateMutex
+#undef CreateMutex
+#endif
 
 	InitArgs.CreateMutex = NULL_PTR;
 	InitArgs.DestroyMutex = NULL_PTR;

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -67,6 +67,7 @@
 
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -100,7 +101,11 @@ void ObjectTests::setUp()
 {
 //    printf("\nObjectTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_RV rv;
 	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
@@ -548,7 +553,6 @@ void ObjectTests::checkCommonRSAPrivateKeyAttributes(CK_SESSION_HANDLE hSession,
 
 CK_RV ObjectTests::createDataObjectMinimal(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hObject)
 {
-	CK_RV rv;
 	CK_OBJECT_CLASS cClass = CKO_DATA;
 	CK_UTF8CHAR label[] = "A data object";
 	CK_ATTRIBUTE objTemplate[] = {
@@ -1425,6 +1429,7 @@ void ObjectTests::testDefaultX509CertAttributes()
 	// Check attributes in X509 certificate object
 	checkCommonObjectAttributes(hSession, hObject, objClass);
 	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_FALSE, CK_TRUE, NULL_PTR, 0, CK_TRUE);
+	memset(&emptyDate, 0, sizeof(emptyDate));
 	checkCommonCertificateObjectAttributes(hSession, hObject, CKC_X_509, CK_FALSE, 0, NULL_PTR, 0, emptyDate, 0, emptyDate, 0);
 	checkX509CertificateObjectAttributes(hSession, hObject, pSubject, sizeof(pSubject)-1, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, pValue, sizeof(pValue)-1, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, 0, CKM_SHA_1);
 }
@@ -1478,6 +1483,7 @@ void ObjectTests::testDefaultRSAPubAttributes()
 	// Check attributes in RSA public key object
 	checkCommonObjectAttributes(hSession, hObject, objClass);
 	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_FALSE, CK_TRUE, NULL_PTR, 0, CK_TRUE);
+	memset(&emptyDate, 0, sizeof(emptyDate));
 	checkCommonKeyAttributes(hSession, hObject, objType, NULL_PTR, 0, emptyDate, 0, emptyDate, 0, CK_FALSE, CK_FALSE, CK_UNAVAILABLE_INFORMATION, NULL_PTR, 0);
 	checkCommonPublicKeyAttributes(hSession, hObject, NULL_PTR, 0, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_FALSE, NULL_PTR, 0);
 	checkCommonRSAPublicKeyAttributes(hSession, hObject, pN, sizeof(pN), 512, pE, sizeof(pE));
@@ -1543,6 +1549,7 @@ void ObjectTests::testDefaultRSAPrivAttributes()
 	// Check attributes in RSA public key object
 	checkCommonObjectAttributes(hSession, hObject, objClass);
 	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_FALSE, CK_TRUE, NULL_PTR, 0, CK_TRUE);
+	memset(&emptyDate, 0, sizeof(emptyDate));
 	checkCommonKeyAttributes(hSession, hObject, objType, NULL_PTR, 0, emptyDate, 0, emptyDate, 0, CK_FALSE, CK_FALSE, CK_UNAVAILABLE_INFORMATION, NULL_PTR, 0);
 	checkCommonPrivateKeyAttributes(hSession, hObject, NULL_PTR, 0, CK_FALSE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_FALSE, CK_FALSE, CK_FALSE, NULL_PTR, 0, CK_FALSE);
 	checkCommonRSAPrivateKeyAttributes(hSession, hObject, pN, sizeof(pN), NULL_PTR, 0, pD, sizeof(pD), NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0);

--- a/src/lib/test/RandomTests.cpp
+++ b/src/lib/test/RandomTests.cpp
@@ -30,6 +30,7 @@
  Contains test cases to C_SeedRandom and C_GenerateRandom
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,7 +43,11 @@ void RandomTests::setUp()
 {
 //    printf("\nRandomTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
 	CK_ULONG pinLength = sizeof(pin) - 1;

--- a/src/lib/test/SessionTests.cpp
+++ b/src/lib/test/SessionTests.cpp
@@ -31,6 +31,7 @@
  C_GetSessionInfo
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -43,7 +44,11 @@ void SessionTests::setUp()
 {
 //    printf("\nSessionTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
 	CK_ULONG pinLength = sizeof(pin) - 1;
@@ -66,7 +71,7 @@ void SessionTests::tearDown()
 
 void SessionTests::testOpenSession()
 {
-    CK_RV rv;
+	CK_RV rv;
 	CK_SESSION_HANDLE hSession;
 
     // Just make sure that we finalize any previous tests
@@ -99,8 +104,8 @@ void SessionTests::testOpenSession()
 
 void SessionTests::testCloseSession()
 {
-    CK_RV rv;
-	CK_SESSION_HANDLE hSession;
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
 	C_Finalize(NULL_PTR);
@@ -163,8 +168,8 @@ void SessionTests::testCloseAllSessions()
 
 void SessionTests::testGetSessionInfo()
 {
-    CK_RV rv;
-	CK_SESSION_HANDLE hSession;
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 	CK_SESSION_INFO info;
 
 	// Just make sure that we finalize any previous tests

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -39,6 +39,7 @@
 
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -60,7 +61,11 @@ void SignVerifyTests::setUp()
 {
 //    printf("\nSignVerifyTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_RV rv;
 	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
@@ -287,9 +292,14 @@ void SignVerifyTests::testRsaSignVerify()
 
 CK_RV SignVerifyTests::generateKey(CK_SESSION_HANDLE hSession, CK_KEY_TYPE keyType, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey)
 {
+#ifndef WITH_BOTAN
+#define GEN_KEY_LEN	75
+#else
+#define GEN_KEY_LEN	55
+#endif
 	CK_RV rv;
 	CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
-	CK_BYTE val[75];
+	CK_BYTE val[GEN_KEY_LEN];
 	//CK_BBOOL bFalse = CK_FALSE;
 	CK_BBOOL bTrue = CK_TRUE;
 	CK_ATTRIBUTE kAttribs[] = {
@@ -303,7 +313,7 @@ CK_RV SignVerifyTests::generateKey(CK_SESSION_HANDLE hSession, CK_KEY_TYPE keyTy
 		{ CKA_VALUE, &val[0], sizeof(val) }
 	};
 
-	rv = C_GenerateRandom(hSession, val, 75);
+	rv = C_GenerateRandom(hSession, val, GEN_KEY_LEN);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	hKey = CK_INVALID_HANDLE;

--- a/src/lib/test/TokenTests.cpp
+++ b/src/lib/test/TokenTests.cpp
@@ -30,6 +30,7 @@
  Contains test cases to C_InitToken
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,7 +43,11 @@ void TokenTests::setUp()
 {
 //    printf("\nTokenTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 }
 
 void TokenTests::tearDown()

--- a/src/lib/test/UserTests.cpp
+++ b/src/lib/test/UserTests.cpp
@@ -30,6 +30,7 @@
  Contains test cases to C_InitPIN, C_SetPIN, C_Login, and C_Logout
  *****************************************************************************/
 
+#include <config.h>
 #include <stdlib.h>
 #include <string.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,7 +43,11 @@ void UserTests::setUp()
 {
 //    printf("\nUserTests\n");
 
+#ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 
 	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
 	CK_ULONG pinLength = sizeof(pin) - 1;
@@ -71,7 +76,7 @@ void UserTests::testInitPIN()
 	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
 	CK_ULONG sopinLength = sizeof(sopin) - 1;
-	CK_SESSION_HANDLE hSession;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
 	C_Finalize(NULL_PTR);
@@ -189,7 +194,7 @@ void UserTests::testLogout()
 	CK_RV rv;
 	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
 	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_SESSION_HANDLE hSession;
+	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
 	C_Finalize(NULL_PTR);

--- a/src/lib/test/softhsm2.conf.win32
+++ b/src/lib/test/softhsm2.conf.win32
@@ -1,0 +1,3 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = .\tokens

--- a/src/lib/win32/dllmain.cc
+++ b/src/lib/win32/dllmain.cc
@@ -1,0 +1,18 @@
+#include <windows.h>
+
+__declspec(dllexport) BOOL WINAPI
+DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpvReserved)
+{
+    hModule = hModule;
+    lpvReserved = lpvReserved;
+    
+    switch (ul_reason_for_call) { 
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH: 
+    case DLL_THREAD_DETACH: 
+    case DLL_PROCESS_DETACH: 
+    default:
+        break;
+    }
+    return (TRUE);
+}

--- a/src/lib/win32/setenv.cpp
+++ b/src/lib/win32/setenv.cpp
@@ -1,0 +1,20 @@
+#include <config.h>
+#include <stdlib.h>
+#include <string>
+
+#ifdef _WIN32
+
+int
+setenv(const char *name, const char *value, int overwrite)
+{
+	std::string vv = name;
+	vv += "=";
+	vv += value;
+
+	if (overwrite != 1)
+		return false;
+
+	return _putenv(vv.c_str()) == 0;
+}
+
+#endif

--- a/src/lib/win32/syslog.cpp
+++ b/src/lib/win32/syslog.cpp
@@ -1,0 +1,66 @@
+#include <config.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#ifdef _WIN32
+
+static HANDLE hEventLog = NULL;
+
+/*
+ * Close the Handle to the application Event Log
+ */
+void
+closelog() {
+	DeregisterEventSource(hEventLog);
+}
+
+/*
+ * Initialize event logging
+ */
+void
+openlog(const char *ident, int logopt, int facility) {
+	/* Get a handle to the Application event log */
+	hEventLog = RegisterEventSourceA(NULL, ident);
+}
+
+/*
+ * Log to the NT Event Log
+ */
+void
+syslog(int priority, const char *message, ...) {
+	va_list ap;
+	char buf[1024];
+	LPCSTR str[1];
+
+	str[0] = buf;
+
+	va_start(ap, message);
+	vsprintf(buf, message, ap);
+	va_end(ap);
+
+	/* Make sure that the channel is open to write the event */
+	if (hEventLog != NULL) {
+		switch (priority) {
+		case LOG_INFO:
+		case LOG_NOTICE:
+		case LOG_DEBUG:
+			ReportEventA(hEventLog, EVENTLOG_INFORMATION_TYPE, 0,
+				     0x40000003, NULL, 1, 0, str, NULL);
+			break;
+		case LOG_WARNING:
+			ReportEventA(hEventLog, EVENTLOG_WARNING_TYPE, 0,
+				     0x80000002, NULL, 1, 0, str, NULL);
+			break;
+		default:
+			ReportEventA(hEventLog, EVENTLOG_ERROR_TYPE, 0,
+				     0xc0000001, NULL, 1, 0, str, NULL);
+			break;
+		}
+	}
+}
+
+#endif

--- a/src/lib/win32/syslog.h
+++ b/src/lib/win32/syslog.h
@@ -1,0 +1,46 @@
+#ifndef _SYSLOG_H
+#define _SYSLOG_H
+
+#include <stdio.h>
+
+/* priorities */
+#define LOG_EMERG       0       /* system is unusable */
+#define LOG_ALERT       1       /* action must be taken immediately */
+#define LOG_CRIT        2       /* critical conditions */
+#define LOG_ERR         3       /* error conditions */
+#define LOG_WARNING     4       /* warning conditions */
+#define LOG_NOTICE      5       /* normal but signification condition */
+#define LOG_INFO        6       /* informational */
+#define LOG_DEBUG       7       /* debug-level messages */
+
+/* NT event log does not support facility level */
+#define LOG_KERN	0
+#define LOG_USER	0
+#define LOG_MAIL	0
+#define LOG_DAEMON	0
+#define LOG_AUTH	0
+#define LOG_SYSLOG	0
+#define LOG_LPR		0
+#define LOG_LOCAL0	0
+#define LOG_LOCAL1	0
+#define LOG_LOCAL2	0
+#define LOG_LOCAL3	0
+#define LOG_LOCAL4	0
+#define LOG_LOCAL5	0
+#define LOG_LOCAL6	0
+#define LOG_LOCAL7	0
+
+/* Constant definitions for openlog() */
+#define LOG_PID		1
+#define LOG_CONS	2
+
+void
+closelog(void);
+
+void
+openlog(const char *ident, int logopt, int facility);
+
+void
+syslog(int priority, const char *message, ...);
+
+#endif

--- a/win32+botan/convarch/convarch.vcxproj
+++ b/win32+botan/convarch/convarch.vcxproj
@@ -1,0 +1,277 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\common\Configuration.h" />
+    <ClInclude Include="..\..\src\lib\common\fatal.h" />
+    <ClInclude Include="..\..\src\lib\common\HandleFactory.h" />
+    <ClInclude Include="..\..\src\lib\common\IPCSignal.h" />
+    <ClInclude Include="..\..\src\lib\common\log.h" />
+    <ClInclude Include="..\..\src\lib\common\MutexFactory.h" />
+    <ClInclude Include="..\..\src\lib\common\osmutex.h" />
+    <ClInclude Include="..\..\src\lib\common\Semaphore.h" />
+    <ClInclude Include="..\..\src\lib\common\Serialisable.h" />
+    <ClInclude Include="..\..\src\lib\common\SimpleConfigLoader.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AESKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanAES.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanCryptoFactory.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDES.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDH.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDHKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDHPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDHPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSA.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSAKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDH.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDHKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDHPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDHPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSA.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSAKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOST.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTR3411.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanHashAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanHMAC.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanMacAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanMD5.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanRNG.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSA.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSAKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA1.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA224.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA256.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA384.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA512.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanSymmetricAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\BotanUtil.h" />
+    <ClInclude Include="..\..\src\lib\crypto\CryptoFactory.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DESKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DHParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DHPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DHPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DSAParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\ECParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\ECPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\ECPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\HashAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\MacAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\PrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\PublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RNG.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RSAParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricKey.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\ByteString.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\RFC4880.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\salloc.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureAllocator.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureDataManager.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.h" />
+    <ClInclude Include="..\..\src\lib\handle_mgr\Handle.h" />
+    <ClInclude Include="..\..\src\lib\handle_mgr\HandleManager.h" />
+    <ClInclude Include="..\..\src\lib\object_store\Directory.h" />
+    <ClInclude Include="..\..\src\lib\object_store\File.h" />
+    <ClInclude Include="..\..\src\lib\object_store\FindOperation.h" />
+    <ClInclude Include="..\..\src\lib\object_store\ObjectFile.h" />
+    <ClInclude Include="..\..\src\lib\object_store\ObjectStore.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSAttribute.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSAttributes.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSObject.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSPathSep.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSToken.h" />
+    <ClInclude Include="..\..\src\lib\object_store\SessionObject.h" />
+    <ClInclude Include="..\..\src\lib\object_store\SessionObjectStore.h" />
+    <ClInclude Include="..\..\src\lib\object_store\UUID.h" />
+    <ClInclude Include="..\..\src\lib\session_mgr\Session.h" />
+    <ClInclude Include="..\..\src\lib\session_mgr\SessionManager.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\Slot.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\SlotManager.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\Token.h" />
+    <ClInclude Include="..\..\src\lib\win32\syslog.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\common\Configuration.cpp" />
+    <ClCompile Include="..\..\src\lib\common\fatal.cpp" />
+    <ClCompile Include="..\..\src\lib\common\IPCSignal.cpp" />
+    <ClCompile Include="..\..\src\lib\common\log.cpp" />
+    <ClCompile Include="..\..\src\lib\common\MutexFactory.cpp" />
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp" />
+    <ClCompile Include="..\..\src\lib\common\Semaphore.cpp" />
+    <ClCompile Include="..\..\src\lib\common\SimpleConfigLoader.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanAES.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanCryptoFactory.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDES.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDH.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDHKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDHPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDHPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSA.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSAKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDH.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDHKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDHPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDHPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSA.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSAKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOST.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTR3411.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanHashAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanHMAC.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanMacAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanMD5.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanRNG.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSA.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSAKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA1.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA224.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA256.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA384.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA512.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanSymmetricAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\BotanUtil.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\CryptoFactory.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DESKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DHParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DHPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DHPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DSAParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\ECParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\ECPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\ECPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\HashAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\MacAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\RSAParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\RSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\RSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricKey.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\ByteString.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\RFC4880.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\salloc.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureDataManager.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.cpp" />
+    <ClCompile Include="..\..\src\lib\handle_mgr\Handle.cpp" />
+    <ClCompile Include="..\..\src\lib\handle_mgr\HandleManager.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\Directory.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\File.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\FindOperation.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\ObjectFile.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\ObjectStore.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\OSAttribute.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\OSToken.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\SessionObject.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\SessionObjectStore.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\UUID.cpp" />
+    <ClCompile Include="..\..\src\lib\session_mgr\Session.cpp" />
+    <ClCompile Include="..\..\src\lib\session_mgr\SessionManager.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\Slot.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\SlotManager.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\Token.cpp" />
+    <ClCompile Include="..\..\src\lib\win32\syslog.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>convarch</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;..\..\src\lib\data_mgr;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;..\..\src\lib\data_mgr;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/convarch/convarch.vcxproj.filters
+++ b/win32+botan/convarch/convarch.vcxproj.filters
@@ -1,0 +1,668 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common Header Files">
+      <UniqueIdentifier>{b657b1af-4cc4-4d97-ba6a-0a7231c5f243}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{aacfc93a-d2e0-4935-aa15-ea0d3690fbcd}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Crypto Header Files">
+      <UniqueIdentifier>{6337c51f-53e3-440a-9ab9-40f0b9a4f26e}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Crypto Source Files">
+      <UniqueIdentifier>{8566a5d1-d688-41da-bbc3-3d860f2db764}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Data Mgr Header Files">
+      <UniqueIdentifier>{b427db7b-49c3-47b0-982a-7da01cf39c8e}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Data Mgr Source Files">
+      <UniqueIdentifier>{04a46825-a433-4b5c-9c3f-8c489978cb8a}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Handle Mgr Header Files">
+      <UniqueIdentifier>{9e67afe5-3252-4c46-a24f-096e4a35e174}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Handle Mgr Source Files">
+      <UniqueIdentifier>{b8a7e894-ebbe-43de-ad66-3c45d91aac8e}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Object Store Header Files">
+      <UniqueIdentifier>{0c47956d-aa5e-4c26-bee4-63ec89c0ab64}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Object Store Source Files">
+      <UniqueIdentifier>{45c69303-5073-4bde-8b63-2f2e2a688362}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Session Mgr Header Files">
+      <UniqueIdentifier>{d1a8b25d-8ebb-4a79-ae8c-70ef3c0bed5f}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Session Mgr Source Files">
+      <UniqueIdentifier>{cb379241-3d4b-4f7c-b7d1-c6c83d3a1b62}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Slot Mgr Header Files">
+      <UniqueIdentifier>{5420eba7-6b85-4daf-a916-c85421362984}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Slot Mgr Source Files">
+      <UniqueIdentifier>{3c9f55a5-d1a8-4716-a416-ec172a676e63}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Source Files">
+      <UniqueIdentifier>{63e3d8a2-0853-4f98-bcaa-de05da380d37}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Header Files">
+      <UniqueIdentifier>{59b2221a-36a3-4f2c-9883-6173599baf5a}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\common\Configuration.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\fatal.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\HandleFactory.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\IPCSignal.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\log.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\MutexFactory.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\osmutex.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\Semaphore.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\Serialisable.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\SimpleConfigLoader.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AESKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\CryptoFactory.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DESKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DHParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DHPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DHPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DSAParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\ECParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\ECPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\ECPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\HashAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\MacAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\PrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\PublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RNG.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RSAParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\ByteString.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\RFC4880.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\salloc.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureAllocator.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureDataManager.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\handle_mgr\Handle.h">
+      <Filter>Handle Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\handle_mgr\HandleManager.h">
+      <Filter>Handle Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\Directory.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\File.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\FindOperation.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\ObjectFile.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\ObjectStore.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSAttribute.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSAttributes.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSObject.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSPathSep.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSToken.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\SessionObject.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\SessionObjectStore.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\UUID.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\session_mgr\Session.h">
+      <Filter>Session Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\session_mgr\SessionManager.h">
+      <Filter>Session Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\Slot.h">
+      <Filter>Slot Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\SlotManager.h">
+      <Filter>Slot Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\Token.h">
+      <Filter>Slot Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\win32\syslog.h">
+      <Filter>Win32 Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanAES.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanCryptoFactory.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDES.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDH.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDHKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDHPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDHPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSA.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSAKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDH.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDHKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDHPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDHPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSA.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSAKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanECDSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOST.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanGOSTR3411.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanHashAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanHMAC.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanMacAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanMD5.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanRNG.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanDSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSA.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSAKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanRSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA1.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA224.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA256.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA384.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanSHA512.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanSymmetricAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\BotanUtil.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\common\Configuration.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\fatal.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\IPCSignal.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\log.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\MutexFactory.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\Semaphore.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\SimpleConfigLoader.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\CryptoFactory.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DESKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DHParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DHPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DHPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DSAParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\ECParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\ECPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\ECPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\HashAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\MacAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\RSAParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\RSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\RSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\ByteString.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\RFC4880.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\salloc.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureDataManager.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\handle_mgr\Handle.cpp">
+      <Filter>Handle Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\handle_mgr\HandleManager.cpp">
+      <Filter>Handle Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\Directory.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\File.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\FindOperation.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\ObjectFile.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\ObjectStore.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\OSAttribute.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\OSToken.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\SessionObject.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\SessionObjectStore.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\UUID.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\session_mgr\Session.cpp">
+      <Filter>Session Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\session_mgr\SessionManager.cpp">
+      <Filter>Session Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\Slot.cpp">
+      <Filter>Slot Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\SlotManager.cpp">
+      <Filter>Slot Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\Token.cpp">
+      <Filter>Slot Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\win32\syslog.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanAES.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanCryptoFactory.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDES.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDH.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDHKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDHPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDHPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSA.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSAKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanDSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDH.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDHKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDHPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDHPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSA.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSAKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanECDSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOST.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanGOSTR3411.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanHashAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanHMAC.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanMacAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanMD5.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanRNG.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSA.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSAKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanRSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA1.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA224.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA256.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA384.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanSHA512.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanSymmetricAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\BotanUtil.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/convarch/convarch.vcxproj.user
+++ b/win32+botan/convarch/convarch.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/cryptotest/cryptotest.vcxproj
+++ b/win32+botan/cryptotest/cryptotest.vcxproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{07E03E0B-C525-4A72-88C6-2238896A4D8C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>cryptotest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\crypto;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\data_mgr;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>openssl version
+</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\crypto;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\data_mgr;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>openssl version
+</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\AESTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\DESTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\DHTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\DSATests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDHTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDSATests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\ent.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\GOSTTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\HashTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\iso8859.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\MacTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\randtest.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\RNGTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\RSATests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\crypto\test\AESTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\chisq.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\cryptotest.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\DESTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\DHTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\DSATests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDHTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDSATests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\ent.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\GOSTTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\HashTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\iso8859.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\MacTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\randtest.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\RNGTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\RSATests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/cryptotest/cryptotest.vcxproj.filters
+++ b/win32+botan/cryptotest/cryptotest.vcxproj.filters
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\crypto\test\DHTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\DSATests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDHTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDSATests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\ent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\GOSTTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\iso8859.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\randtest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\RNGTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\RSATests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\AESTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\DESTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\HashTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\MacTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\crypto\test\chisq.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\cryptotest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\DHTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\DSATests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDHTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDSATests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\ent.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\GOSTTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\iso8859.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\randtest.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\RNGTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\RSATests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\AESTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\DESTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\HashTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\MacTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/cryptotest/cryptotest.vcxproj.user
+++ b/win32+botan/cryptotest/cryptotest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/datamgrtest/datamgrtest.vcxproj
+++ b/win32+botan/datamgrtest/datamgrtest.vcxproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E20315B5-B49E-46D7-B7EC-1A439F347C95}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>datamgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\data_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\data_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\test\ByteStringTests.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\test\RFC4880Tests.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\ByteStringTests.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\test\datamgrtest.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\test\RFC4880Tests.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/datamgrtest/datamgrtest.vcxproj.filters
+++ b/win32+botan/datamgrtest/datamgrtest.vcxproj.filters
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\test\ByteStringTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\test\RFC4880Tests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\ByteStringTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\datamgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\RFC4880Tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/datamgrtest/datamgrtest.vcxproj.user
+++ b/win32+botan/datamgrtest/datamgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/handlemgrtest/handlemgrtest.vcxproj
+++ b/win32+botan/handlemgrtest/handlemgrtest.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{014B1E10-EC68-4BEC-B992-F92CA2B6816F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>handlemgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\handle_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\handle_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.cpp" />
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\handlemgrtest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/handlemgrtest/handlemgrtest.vcxproj.filters
+++ b/win32+botan/handlemgrtest/handlemgrtest.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\handlemgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/handlemgrtest/handlemgrtest.vcxproj.user
+++ b/win32+botan/handlemgrtest/handlemgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/keyconv/keyconv.vcxproj
+++ b/win32+botan/keyconv/keyconv.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9B003E52-F02A-47EA-9942-2D9AE8738161}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>keyconv</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h" />
+    <ClInclude Include="..\..\src\bin\common\library.h" />
+    <ClInclude Include="..\..\src\bin\keyconv\softhsm-keyconv.h" />
+    <ClInclude Include="..\..\src\bin\win32\getopt.h" />
+    <ClInclude Include="..\config.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp" />
+    <ClCompile Include="..\..\src\bin\common\library.cpp" />
+    <ClCompile Include="..\..\src\bin\keyconv\base64.c" />
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv-botan.cpp" />
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/keyconv/keyconv.vcxproj.filters
+++ b/win32+botan/keyconv/keyconv.vcxproj.filters
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Header Files">
+      <UniqueIdentifier>{6f8944db-01c2-47c3-a4b4-265d91e99ba0}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{b6a2e68c-2518-456b-8592-561c011e0390}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Source Files">
+      <UniqueIdentifier>{14914ba7-3ec3-4f58-a83a-4596a7f52075}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Header Files">
+      <UniqueIdentifier>{3253c2c0-ca7a-4902-8b31-87ab6c4c754f}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\common\library.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\keyconv\softhsm-keyconv.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\win32\getopt.h">
+      <Filter>Win32 Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\common\library.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\keyconv\base64.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv-botan.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/keyconv/keyconv.vcxproj.user
+++ b/win32+botan/keyconv/keyconv.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/objstoretest/objstoretest.vcxproj
+++ b/win32+botan/objstoretest/objstoretest.vcxproj
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{44F77533-A4A1-4175-8C4C-07106B3F9C08}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>objstoretest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\object_store;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\object_store;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\DirectoryTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\FileTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectFileTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectStoreTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\OSTokenTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\UUIDTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\object_store\test\DirectoryTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\FileTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectFileTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectStoreTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\objstoretest.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\OSTokenTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\UUIDTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/objstoretest/objstoretest.vcxproj.filters
+++ b/win32+botan/objstoretest/objstoretest.vcxproj.filters
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\DirectoryTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\FileTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectFileTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectStoreTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\OSTokenTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\UUIDTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\object_store\test\DirectoryTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\FileTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectFileTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectStoreTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\OSTokenTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\objstoretest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\UUIDTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/objstoretest/objstoretest.vcxproj.user
+++ b/win32+botan/objstoretest/objstoretest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/p11test/p11test.vcxproj
+++ b/win32+botan/p11test/p11test.vcxproj
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7C5EE7FC-B5FC-47BF-8164-A452FE689472}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>p11test</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\softhsm2.conf
+mkdir ..\..\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in ..\..\tokens\dummy
+
+copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\"win32+botan"\p11test\softhsm2.conf
+mkdir  ..\..\"win32+botan"\p11test\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in  ..\..\"win32+botan"\p11test\tokens\dummy</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\softhsm2.conf
+mkdir ..\..\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in ..\..\tokens\dummy
+
+copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\"win32+botan"\p11test\softhsm2.conf
+mkdir  ..\..\"win32+botan"\p11test\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in  ..\..\"win32+botan"\p11test\tokens\dummy</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\access.h" />
+    <ClInclude Include="..\..\src\lib\common\osmutex.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\P11Attributes.h" />
+    <ClInclude Include="..\..\src\lib\P11Objects.h" />
+    <ClInclude Include="..\..\src\lib\SoftHSM.h" />
+    <ClInclude Include="..\..\src\lib\test\DigestTests.h" />
+    <ClInclude Include="..\..\src\lib\test\EncryptDecryptTests.h" />
+    <ClInclude Include="..\..\src\lib\test\InfoTests.h" />
+    <ClInclude Include="..\..\src\lib\test\InitTests.h" />
+    <ClInclude Include="..\..\src\lib\test\ObjectTests.h" />
+    <ClInclude Include="..\..\src\lib\test\RandomTests.h" />
+    <ClInclude Include="..\..\src\lib\test\SessionTests.h" />
+    <ClInclude Include="..\..\src\lib\test\SignVerifyTests.h" />
+    <ClInclude Include="..\..\src\lib\test\testconfig.h" />
+    <ClInclude Include="..\..\src\lib\test\TokenTests.h" />
+    <ClInclude Include="..\..\src\lib\test\UserTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\access.cpp" />
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp" />
+    <ClCompile Include="..\..\src\lib\main.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp" />
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp" />
+    <ClCompile Include="..\..\src\lib\test\DigestTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\EncryptDecryptTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\InfoTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\InitTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\ObjectTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\p11test.cpp" />
+    <ClCompile Include="..\..\src\lib\test\RandomTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\SessionTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\SignVerifyTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\TokenTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\UserTests.cpp" />
+    <ClCompile Include="..\..\src\lib\win32\setenv.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/p11test/p11test.vcxproj.filters
+++ b/win32+botan/p11test/p11test.vcxproj.filters
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Lib Header Files">
+      <UniqueIdentifier>{8440d7eb-5530-4f5e-a355-a43435742c60}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Lib Source Files">
+      <UniqueIdentifier>{3c33d54e-4bd1-43e0-bcc7-0d6adcfd5dc7}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Other Header Files">
+      <UniqueIdentifier>{ff435d2e-c67a-4f47-9731-28d88617e559}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Other Source Files">
+      <UniqueIdentifier>{5df8b0a3-ecc7-4876-aea2-8421c0846535}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\test\DigestTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\EncryptDecryptTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\InfoTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\InitTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\ObjectTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\RandomTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\SessionTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\SignVerifyTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\testconfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\TokenTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\UserTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\osmutex.h">
+      <Filter>Other Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\access.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Other Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Attributes.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Objects.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\SoftHSM.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\test\DigestTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\EncryptDecryptTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\InfoTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\InitTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\ObjectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\RandomTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\SessionTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\SignVerifyTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\TokenTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\UserTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp">
+      <Filter>Other Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\win32\setenv.cpp">
+      <Filter>Other Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\access.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\main.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\p11test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/p11test/p11test.vcxproj.user
+++ b/win32+botan/p11test/p11test.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/sessionmgrtest/sessionmgrtest.vcxproj
+++ b/win32+botan/sessionmgrtest/sessionmgrtest.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>sessionmgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\session_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\object_store;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\session_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\object_store;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\session_mgr\test\SessionManagerTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\session_mgr\test\SessionManagerTests.cpp" />
+    <ClCompile Include="..\..\src\lib\session_mgr\test\sessionmgrtest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/sessionmgrtest/sessionmgrtest.vcxproj.filters
+++ b/win32+botan/sessionmgrtest/sessionmgrtest.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\session_mgr\test\SessionManagerTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\session_mgr\test\SessionManagerTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\session_mgr\test\sessionmgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/sessionmgrtest/sessionmgrtest.vcxproj.user
+++ b/win32+botan/sessionmgrtest/sessionmgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/slotmgrtest/slotmgrtest.vcxproj
+++ b/win32+botan/slotmgrtest/slotmgrtest.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>slotmgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\slot_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\slot_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\slotmgrtest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/slotmgrtest/slotmgrtest.vcxproj.filters
+++ b/win32+botan/slotmgrtest/slotmgrtest.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\slotmgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/slotmgrtest/slotmgrtest.vcxproj.user
+++ b/win32+botan/slotmgrtest/slotmgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/softhsm2.sln
+++ b/win32+botan/softhsm2.sln
@@ -1,0 +1,86 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual C++ Express 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "softhsm2", "softhsm2\softhsm2.vcxproj", "{801F5AB2-7A62-4085-B129-D15E2D717219}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795} = {F64541B6-FFBF-4368-B93A-A5CA8ADAD795}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "keyconv", "keyconv\keyconv.vcxproj", "{9B003E52-F02A-47EA-9942-2D9AE8738161}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "util", "util\util.vcxproj", "{05901466-4184-47C8-9D6C-3BB99BBF5378}"
+	ProjectSection(ProjectDependencies) = postProject
+		{801F5AB2-7A62-4085-B129-D15E2D717219} = {801F5AB2-7A62-4085-B129-D15E2D717219}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "p11test", "p11test\p11test.vcxproj", "{7C5EE7FC-B5FC-47BF-8164-A452FE689472}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cryptotest", "cryptotest\cryptotest.vcxproj", "{07E03E0B-C525-4A72-88C6-2238896A4D8C}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "datamgrtest", "datamgrtest\datamgrtest.vcxproj", "{E20315B5-B49E-46D7-B7EC-1A439F347C95}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "handlemgrtest", "handlemgrtest\handlemgrtest.vcxproj", "{014B1E10-EC68-4BEC-B992-F92CA2B6816F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "objstoretest", "objstoretest\objstoretest.vcxproj", "{44F77533-A4A1-4175-8C4C-07106B3F9C08}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sessionmgrtest", "sessionmgrtest\sessionmgrtest.vcxproj", "{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slotmgrtest", "slotmgrtest\slotmgrtest.vcxproj", "{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "convarch", "convarch\convarch.vcxproj", "{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Debug|Win32.ActiveCfg = Debug|Win32
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Debug|Win32.Build.0 = Debug|Win32
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Release|Win32.ActiveCfg = Release|Win32
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Release|Win32.Build.0 = Release|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Debug|Win32.ActiveCfg = Debug|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Debug|Win32.Build.0 = Debug|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Release|Win32.ActiveCfg = Release|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Release|Win32.Build.0 = Release|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Debug|Win32.ActiveCfg = Debug|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Debug|Win32.Build.0 = Debug|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Release|Win32.ActiveCfg = Release|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Release|Win32.Build.0 = Release|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Debug|Win32.Build.0 = Debug|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Release|Win32.ActiveCfg = Release|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Release|Win32.Build.0 = Release|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Debug|Win32.Build.0 = Debug|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Release|Win32.ActiveCfg = Release|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Release|Win32.Build.0 = Release|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Debug|Win32.Build.0 = Debug|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Release|Win32.ActiveCfg = Release|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Release|Win32.Build.0 = Release|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Debug|Win32.Build.0 = Debug|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Release|Win32.ActiveCfg = Release|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Release|Win32.Build.0 = Release|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Debug|Win32.ActiveCfg = Debug|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Debug|Win32.Build.0 = Debug|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Release|Win32.ActiveCfg = Release|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Release|Win32.Build.0 = Release|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Debug|Win32.Build.0 = Debug|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Release|Win32.ActiveCfg = Release|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Release|Win32.Build.0 = Release|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Debug|Win32.ActiveCfg = Debug|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Debug|Win32.Build.0 = Debug|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Release|Win32.ActiveCfg = Release|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Release|Win32.Build.0 = Release|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Debug|Win32.ActiveCfg = Debug|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Debug|Win32.Build.0 = Debug|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Release|Win32.ActiveCfg = Release|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/win32+botan/softhsm2/softhsm2.vcxproj
+++ b/win32+botan/softhsm2/softhsm2.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{801F5AB2-7A62-4085-B129-D15E2D717219}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>softhsm2</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;SOFTHSM2_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;botand.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;SOFTHSM2_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\access.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\P11Attributes.h" />
+    <ClInclude Include="..\..\src\lib\P11Objects.h" />
+    <ClInclude Include="..\..\src\lib\SoftHSM.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\access.cpp" />
+    <ClCompile Include="..\..\src\lib\main.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp" />
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp" />
+    <ClCompile Include="..\..\src\lib\win32\dllmain.cc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/softhsm2/softhsm2.vcxproj.filters
+++ b/win32+botan/softhsm2/softhsm2.vcxproj.filters
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\access.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Attributes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Objects.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\SoftHSM.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\access.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\win32\dllmain.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/softhsm2/softhsm2.vcxproj.user
+++ b/win32+botan/softhsm2/softhsm2.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+botan/util/util.vcxproj
+++ b/win32+botan/util/util.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{05901466-4184-47C8-9D6C-3BB99BBF5378}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>util</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\btn\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\..\..\btn\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h" />
+    <ClInclude Include="..\..\src\bin\common\library.h" />
+    <ClInclude Include="..\..\src\bin\util\softhsm-util-botan.h" />
+    <ClInclude Include="..\..\src\bin\util\softhsm-util.h" />
+    <ClInclude Include="..\..\src\bin\win32\getopt.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp" />
+    <ClCompile Include="..\..\src\bin\common\library.cpp" />
+    <ClCompile Include="..\..\src\bin\util\softhsm-util-botan.cpp" />
+    <ClCompile Include="..\..\src\bin\util\softhsm-util.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+botan/util/util.vcxproj.filters
+++ b/win32+botan/util/util.vcxproj.filters
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common Header Files">
+      <UniqueIdentifier>{21eda3a1-8da0-4a99-967c-f218e4eecd08}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{fd946626-7e24-4f78-834b-a4c0ac6dc2f5}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Win32 Header Files">
+      <UniqueIdentifier>{f3a7acce-323d-4465-95bf-a326189dcdd5}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Win32 Source Files">
+      <UniqueIdentifier>{2b77905a-99da-49cf-9cac-aa72e7e3182b}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\common\library.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\util\softhsm-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\win32\getopt.h">
+      <Filter>Win32 Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\util\softhsm-util-botan.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\common\library.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\util\softhsm-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\util\softhsm-util-botan.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+botan/util/util.vcxproj.user
+++ b/win32+botan/util/util.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/config.h
+++ b/win32+openssl/config.h
@@ -1,0 +1,128 @@
+/* config.h for WIN32 */
+
+/* The default PKCS#11 library */
+#define DEFAULT_PKCS11_LIB "softhsm2.dll"
+
+/* The default location of softhsm2.conf */
+#define DEFAULT_SOFTHSM2_CONF "softhsm2.conf"
+
+/* The default location of the token directory */
+#define DEFAULT_TOKENDIR "tokens"
+
+/* Define to 1 if you have the `crypto' library (-lcrypto). */
+#define HAVE_LIBCRYPTO 1
+
+/* Whether LoadLibrary is available */
+#define HAVE_LOADLIBRARY 1
+
+/* Define to 1 if you have the <sqlite3.h> header file. */
+#undef HAVE_SQLITE3_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Maximum PIN length */
+#define MAX_PIN_LEN 255
+
+/* Minimum PIN length */
+#define MIN_PIN_LEN 4
+
+/* Name of package */
+#define PACKAGE "softhsm"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "SoftHSM"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "SoftHSM 2.0.0a1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "softhsm"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION  "2.0.0a1"
+
+/* Non-paged memory for secure storage */
+#undef SENSITIVE_NON_PAGE
+
+/* The log level set by the user */
+#define SOFTLOGLEVEL 3
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Version number of package */
+#define VERSION  "2.0.0a1"
+
+/* SoftHSM major version number via PKCS#11 */
+#define VERSION_MAJOR 2
+
+/* SoftHSM minor version number via PKCS#11 */
+#define VERSION_MINOR 0
+
+/* Compile with Botan support */
+#undef WITH_BOTAN
+
+/* Compile with ECC support */
+#define WITH_ECC 1
+
+/* Compile with GOST support */
+#define WITH_GOST 1
+
+/* Compile with OpenSSL support */
+#define WITH_OPENSSL 1
+
+/* Define to 1 if you have getpassphrase(). */
+#define HAVE_GETPASSPHRASE
+
+/* Addition things */
+
+char *getpassphrase(const char *prompt);
+int setenv(const char *name, const char *value, int overwrite);
+
+/* At least Vista */
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
+#define snprintf _snprintf
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+
+/* Prevent inclusion of winsock.h in windows.h */
+
+#define WIN32_LEAN_AND_MEAN 1
+
+#include <windows.h>
+
+/* avoid collision from min and max macros */
+
+#undef min
+#undef max
+
+/* Temporary for debug */
+
+#define DEBUG_LOG_STDERR 1
+
+/* To avoid unsafe warnings (off) */
+
+// #pragma warning(disable: 4996)

--- a/win32+openssl/convarch/convarch.vcxproj
+++ b/win32+openssl/convarch/convarch.vcxproj
@@ -1,0 +1,271 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\common\Configuration.h" />
+    <ClInclude Include="..\..\src\lib\common\fatal.h" />
+    <ClInclude Include="..\..\src\lib\common\HandleFactory.h" />
+    <ClInclude Include="..\..\src\lib\common\IPCSignal.h" />
+    <ClInclude Include="..\..\src\lib\common\log.h" />
+    <ClInclude Include="..\..\src\lib\common\MutexFactory.h" />
+    <ClInclude Include="..\..\src\lib\common\osmutex.h" />
+    <ClInclude Include="..\..\src\lib\common\Semaphore.h" />
+    <ClInclude Include="..\..\src\lib\common\Serialisable.h" />
+    <ClInclude Include="..\..\src\lib\common\SimpleConfigLoader.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AESKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\CryptoFactory.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DESKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DHParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DHPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DHPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DSAParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\DSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\ECParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\ECPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\ECPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\HashAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\MacAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLAES.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLCryptoFactory.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDES.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDH.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDHKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDHPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDHPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSA.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSAKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECDH.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECDSA.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLEVPHashAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLEVPMacAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLEVPSymmetricAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOST.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTR3411.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLHMAC.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLMD5.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRNG.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSA.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSAKeyPair.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA1.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA224.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA256.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA384.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA512.h" />
+    <ClInclude Include="..\..\src\lib\crypto\OSSLUtil.h" />
+    <ClInclude Include="..\..\src\lib\crypto\PrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\PublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RNG.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RSAParameters.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RSAPrivateKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\RSAPublicKey.h" />
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricAlgorithm.h" />
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricKey.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\ByteString.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\RFC4880.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\salloc.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureAllocator.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureDataManager.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.h" />
+    <ClInclude Include="..\..\src\lib\handle_mgr\Handle.h" />
+    <ClInclude Include="..\..\src\lib\handle_mgr\HandleManager.h" />
+    <ClInclude Include="..\..\src\lib\object_store\Directory.h" />
+    <ClInclude Include="..\..\src\lib\object_store\File.h" />
+    <ClInclude Include="..\..\src\lib\object_store\FindOperation.h" />
+    <ClInclude Include="..\..\src\lib\object_store\ObjectFile.h" />
+    <ClInclude Include="..\..\src\lib\object_store\ObjectStore.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSAttribute.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSAttributes.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSObject.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSPathSep.h" />
+    <ClInclude Include="..\..\src\lib\object_store\OSToken.h" />
+    <ClInclude Include="..\..\src\lib\object_store\SessionObject.h" />
+    <ClInclude Include="..\..\src\lib\object_store\SessionObjectStore.h" />
+    <ClInclude Include="..\..\src\lib\object_store\UUID.h" />
+    <ClInclude Include="..\..\src\lib\session_mgr\Session.h" />
+    <ClInclude Include="..\..\src\lib\session_mgr\SessionManager.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\Slot.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\SlotManager.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\Token.h" />
+    <ClInclude Include="..\..\src\lib\win32\syslog.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\common\Configuration.cpp" />
+    <ClCompile Include="..\..\src\lib\common\fatal.cpp" />
+    <ClCompile Include="..\..\src\lib\common\IPCSignal.cpp" />
+    <ClCompile Include="..\..\src\lib\common\log.cpp" />
+    <ClCompile Include="..\..\src\lib\common\MutexFactory.cpp" />
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp" />
+    <ClCompile Include="..\..\src\lib\common\Semaphore.cpp" />
+    <ClCompile Include="..\..\src\lib\common\SimpleConfigLoader.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\CryptoFactory.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DESKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DHParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DHPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DHPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DSAParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\DSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\ECParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\ECPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\ECPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\HashAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\MacAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLAES.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLCryptoFactory.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDES.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDH.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDHKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDHPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDHPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSA.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSAKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECDH.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECDSA.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLEVPHashAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLEVPMacAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLEVPSymmetricAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOST.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTR3411.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLHMAC.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLMD5.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRNG.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSA.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSAKeyPair.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA1.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA224.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA256.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA384.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA512.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\OSSLUtil.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\RSAParameters.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\RSAPrivateKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\RSAPublicKey.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricAlgorithm.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricKey.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\ByteString.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\RFC4880.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\salloc.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureDataManager.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.cpp" />
+    <ClCompile Include="..\..\src\lib\handle_mgr\Handle.cpp" />
+    <ClCompile Include="..\..\src\lib\handle_mgr\HandleManager.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\Directory.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\File.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\FindOperation.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\ObjectFile.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\ObjectStore.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\OSAttribute.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\OSToken.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\SessionObject.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\SessionObjectStore.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\UUID.cpp" />
+    <ClCompile Include="..\..\src\lib\session_mgr\Session.cpp" />
+    <ClCompile Include="..\..\src\lib\session_mgr\SessionManager.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\Slot.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\SlotManager.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\Token.cpp" />
+    <ClCompile Include="..\..\src\lib\win32\syslog.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>convarch</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;..\..\src\lib\data_mgr;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;..\..\src\lib\data_mgr;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/convarch/convarch.vcxproj.filters
+++ b/win32+openssl/convarch/convarch.vcxproj.filters
@@ -1,0 +1,650 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common Header Files">
+      <UniqueIdentifier>{b657b1af-4cc4-4d97-ba6a-0a7231c5f243}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{aacfc93a-d2e0-4935-aa15-ea0d3690fbcd}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Crypto Header Files">
+      <UniqueIdentifier>{6337c51f-53e3-440a-9ab9-40f0b9a4f26e}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Crypto Source Files">
+      <UniqueIdentifier>{8566a5d1-d688-41da-bbc3-3d860f2db764}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Data Mgr Header Files">
+      <UniqueIdentifier>{b427db7b-49c3-47b0-982a-7da01cf39c8e}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Data Mgr Source Files">
+      <UniqueIdentifier>{04a46825-a433-4b5c-9c3f-8c489978cb8a}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Handle Mgr Header Files">
+      <UniqueIdentifier>{9e67afe5-3252-4c46-a24f-096e4a35e174}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Handle Mgr Source Files">
+      <UniqueIdentifier>{b8a7e894-ebbe-43de-ad66-3c45d91aac8e}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Object Store Header Files">
+      <UniqueIdentifier>{0c47956d-aa5e-4c26-bee4-63ec89c0ab64}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Object Store Source Files">
+      <UniqueIdentifier>{45c69303-5073-4bde-8b63-2f2e2a688362}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Session Mgr Header Files">
+      <UniqueIdentifier>{d1a8b25d-8ebb-4a79-ae8c-70ef3c0bed5f}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Session Mgr Source Files">
+      <UniqueIdentifier>{cb379241-3d4b-4f7c-b7d1-c6c83d3a1b62}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Slot Mgr Header Files">
+      <UniqueIdentifier>{5420eba7-6b85-4daf-a916-c85421362984}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Slot Mgr Source Files">
+      <UniqueIdentifier>{3c9f55a5-d1a8-4716-a416-ec172a676e63}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Source Files">
+      <UniqueIdentifier>{63e3d8a2-0853-4f98-bcaa-de05da380d37}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Header Files">
+      <UniqueIdentifier>{59b2221a-36a3-4f2c-9883-6173599baf5a}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\common\Configuration.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\fatal.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\HandleFactory.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\IPCSignal.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\log.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\MutexFactory.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\osmutex.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\Semaphore.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\Serialisable.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\SimpleConfigLoader.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AESKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\AsymmetricParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\CryptoFactory.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DESKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DHParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DHPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DHPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DSAParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\DSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\ECParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\ECPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\ECPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\GOSTPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\HashAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\MacAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLAES.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLCryptoFactory.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDES.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDH.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDHKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDHPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDHPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSA.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSAKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLDSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECDH.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECDSA.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLECPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLEVPHashAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLEVPMacAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLEVPSymmetricAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOST.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLGOSTR3411.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLHMAC.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLMD5.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRNG.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSA.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSAKeyPair.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLRSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA1.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA224.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA256.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA384.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLSHA512.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\OSSLUtil.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\PrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\PublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RNG.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RSAParameters.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RSAPrivateKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\RSAPublicKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricAlgorithm.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\SymmetricKey.h">
+      <Filter>Crypto Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\ByteString.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\RFC4880.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\salloc.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureAllocator.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\SecureDataManager.h">
+      <Filter>Data Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\handle_mgr\Handle.h">
+      <Filter>Handle Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\handle_mgr\HandleManager.h">
+      <Filter>Handle Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\Directory.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\File.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\FindOperation.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\ObjectFile.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\ObjectStore.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSAttribute.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSAttributes.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSObject.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSPathSep.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\OSToken.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\SessionObject.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\SessionObjectStore.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\UUID.h">
+      <Filter>Object Store Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\session_mgr\Session.h">
+      <Filter>Session Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\session_mgr\SessionManager.h">
+      <Filter>Session Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\Slot.h">
+      <Filter>Slot Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\SlotManager.h">
+      <Filter>Slot Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\Token.h">
+      <Filter>Slot Mgr Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\win32\syslog.h">
+      <Filter>Win32 Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\common\Configuration.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\fatal.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\IPCSignal.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\log.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\MutexFactory.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\Semaphore.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\SimpleConfigLoader.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\AsymmetricKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\CryptoFactory.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DESKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DHParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DHPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DHPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DSAParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\DSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\ECParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\ECPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\ECPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\GOSTPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\HashAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\MacAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLAES.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLCryptoFactory.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDES.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDH.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDHKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDHPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDHPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSA.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSAKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLDSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECDH.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECDSA.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLECPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLEVPHashAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLEVPMacAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLEVPSymmetricAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOST.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLGOSTR3411.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLHMAC.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLMD5.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRNG.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSA.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSAKeyPair.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA1.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA224.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA256.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA384.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLSHA512.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLUtil.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\RSAParameters.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\RSAPrivateKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\RSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricAlgorithm.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\SymmetricKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\ByteString.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\RFC4880.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\salloc.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureDataManager.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\SecureMemoryRegistry.cpp">
+      <Filter>Data Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\handle_mgr\Handle.cpp">
+      <Filter>Handle Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\handle_mgr\HandleManager.cpp">
+      <Filter>Handle Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\Directory.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\File.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\FindOperation.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\ObjectFile.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\ObjectStore.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\OSAttribute.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\OSToken.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\SessionObject.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\SessionObjectStore.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\UUID.cpp">
+      <Filter>Object Store Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\session_mgr\Session.cpp">
+      <Filter>Session Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\session_mgr\SessionManager.cpp">
+      <Filter>Session Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\Slot.cpp">
+      <Filter>Slot Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\SlotManager.cpp">
+      <Filter>Slot Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\Token.cpp">
+      <Filter>Slot Mgr Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\win32\syslog.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\OSSLRSAPublicKey.cpp">
+      <Filter>Crypto Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/convarch/convarch.vcxproj.user
+++ b/win32+openssl/convarch/convarch.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/cryptotest/cryptotest.vcxproj
+++ b/win32+openssl/cryptotest/cryptotest.vcxproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{07E03E0B-C525-4A72-88C6-2238896A4D8C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>cryptotest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\crypto;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\data_mgr;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>openssl version
+</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\crypto;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\data_mgr;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>openssl version
+</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\AESTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\DESTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\DHTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\DSATests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDHTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDSATests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\ent.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\GOSTTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\HashTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\iso8859.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\MacTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\randtest.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\RNGTests.h" />
+    <ClInclude Include="..\..\src\lib\crypto\test\RSATests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\crypto\test\AESTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\chisq.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\cryptotest.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\DESTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\DHTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\DSATests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDHTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDSATests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\ent.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\GOSTTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\HashTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\iso8859.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\MacTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\randtest.c" />
+    <ClCompile Include="..\..\src\lib\crypto\test\RNGTests.cpp" />
+    <ClCompile Include="..\..\src\lib\crypto\test\RSATests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/cryptotest/cryptotest.vcxproj.filters
+++ b/win32+openssl/cryptotest/cryptotest.vcxproj.filters
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\crypto\test\DHTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\DSATests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDHTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\ECDSATests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\ent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\GOSTTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\iso8859.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\randtest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\RNGTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\RSATests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\AESTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\DESTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\HashTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\crypto\test\MacTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\crypto\test\chisq.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\cryptotest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\DHTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\DSATests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDHTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\ECDSATests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\ent.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\GOSTTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\iso8859.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\randtest.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\RNGTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\RSATests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\AESTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\DESTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\HashTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\crypto\test\MacTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/cryptotest/cryptotest.vcxproj.user
+++ b/win32+openssl/cryptotest/cryptotest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/datamgrtest/datamgrtest.vcxproj
+++ b/win32+openssl/datamgrtest/datamgrtest.vcxproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E20315B5-B49E-46D7-B7EC-1A439F347C95}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>datamgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\data_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\data_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\test\ByteStringTests.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\test\RFC4880Tests.h" />
+    <ClInclude Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\ByteStringTests.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\test\datamgrtest.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\test\RFC4880Tests.cpp" />
+    <ClCompile Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/datamgrtest/datamgrtest.vcxproj.filters
+++ b/win32+openssl/datamgrtest/datamgrtest.vcxproj.filters
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\test\ByteStringTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\test\RFC4880Tests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\ByteStringTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\datamgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\RFC4880Tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\data_mgr\test\SecureDataMgrTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/datamgrtest/datamgrtest.vcxproj.user
+++ b/win32+openssl/datamgrtest/datamgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/handlemgrtest/handlemgrtest.vcxproj
+++ b/win32+openssl/handlemgrtest/handlemgrtest.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{014B1E10-EC68-4BEC-B992-F92CA2B6816F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>handlemgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\handle_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\handle_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.cpp" />
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\handlemgrtest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/handlemgrtest/handlemgrtest.vcxproj.filters
+++ b/win32+openssl/handlemgrtest/handlemgrtest.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\HandleManagerTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\handle_mgr\test\handlemgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/handlemgrtest/handlemgrtest.vcxproj.user
+++ b/win32+openssl/handlemgrtest/handlemgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/keyconv/keyconv.vcxproj
+++ b/win32+openssl/keyconv/keyconv.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9B003E52-F02A-47EA-9942-2D9AE8738161}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>keyconv</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h" />
+    <ClInclude Include="..\..\src\bin\common\library.h" />
+    <ClInclude Include="..\..\src\bin\keyconv\softhsm-keyconv.h" />
+    <ClInclude Include="..\..\src\bin\win32\getopt.h" />
+    <ClInclude Include="..\config.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp" />
+    <ClCompile Include="..\..\src\bin\common\library.cpp" />
+    <ClCompile Include="..\..\src\bin\keyconv\base64.c" />
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv-ossl.cpp" />
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/keyconv/keyconv.vcxproj.filters
+++ b/win32+openssl/keyconv/keyconv.vcxproj.filters
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Header Files">
+      <UniqueIdentifier>{6f8944db-01c2-47c3-a4b4-265d91e99ba0}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{b6a2e68c-2518-456b-8592-561c011e0390}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Source Files">
+      <UniqueIdentifier>{14914ba7-3ec3-4f58-a83a-4596a7f52075}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Win32 Header Files">
+      <UniqueIdentifier>{3253c2c0-ca7a-4902-8b31-87ab6c4c754f}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\common\library.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\keyconv\softhsm-keyconv.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\win32\getopt.h">
+      <Filter>Win32 Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\keyconv\softhsm-keyconv-ossl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\common\library.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\keyconv\base64.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/keyconv/keyconv.vcxproj.user
+++ b/win32+openssl/keyconv/keyconv.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/objstoretest/objstoretest.vcxproj
+++ b/win32+openssl/objstoretest/objstoretest.vcxproj
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{44F77533-A4A1-4175-8C4C-07106B3F9C08}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>objstoretest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\object_store;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\object_store;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\DirectoryTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\FileTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectFileTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectStoreTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\OSTokenTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectTests.h" />
+    <ClInclude Include="..\..\src\lib\object_store\test\UUIDTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\object_store\test\DirectoryTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\FileTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectFileTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectStoreTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\objstoretest.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\OSTokenTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectTests.cpp" />
+    <ClCompile Include="..\..\src\lib\object_store\test\UUIDTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/objstoretest/objstoretest.vcxproj.filters
+++ b/win32+openssl/objstoretest/objstoretest.vcxproj.filters
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\DirectoryTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\FileTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectFileTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\ObjectStoreTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\OSTokenTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\SessionObjectTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\object_store\test\UUIDTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\object_store\test\DirectoryTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\FileTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectFileTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\ObjectStoreTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\OSTokenTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\objstoretest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectStoreTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\SessionObjectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\object_store\test\UUIDTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/objstoretest/objstoretest.vcxproj.user
+++ b/win32+openssl/objstoretest/objstoretest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/p11test/p11test.vcxproj
+++ b/win32+openssl/p11test/p11test.vcxproj
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7C5EE7FC-B5FC-47BF-8164-A452FE689472}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>p11test</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\softhsm2.conf
+mkdir ..\..\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in ..\..\tokens\dummy
+
+copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\"win32+openssl"\p11test\softhsm2.conf
+mkdir  ..\..\"win32+openssl"\p11test\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in  ..\..\"win32+openssl"\p11test\tokens\dummy</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\data_mgr;..\..\src\lib\session_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\softhsm2.conf
+mkdir ..\..\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in ..\..\tokens\dummy
+
+copy ..\..\src\lib\test\softhsm2.conf.win32 ..\..\"win32+openssl"\p11test\softhsm2.conf
+mkdir  ..\..\"win32+openssl"\p11test\tokens 2&gt; nul
+copy ..\..\src\lib\test\tokens\dummy.in  ..\..\"win32+openssl"\p11test\tokens\dummy</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\access.h" />
+    <ClInclude Include="..\..\src\lib\common\osmutex.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\P11Attributes.h" />
+    <ClInclude Include="..\..\src\lib\P11Objects.h" />
+    <ClInclude Include="..\..\src\lib\SoftHSM.h" />
+    <ClInclude Include="..\..\src\lib\test\DigestTests.h" />
+    <ClInclude Include="..\..\src\lib\test\EncryptDecryptTests.h" />
+    <ClInclude Include="..\..\src\lib\test\InfoTests.h" />
+    <ClInclude Include="..\..\src\lib\test\InitTests.h" />
+    <ClInclude Include="..\..\src\lib\test\ObjectTests.h" />
+    <ClInclude Include="..\..\src\lib\test\RandomTests.h" />
+    <ClInclude Include="..\..\src\lib\test\SessionTests.h" />
+    <ClInclude Include="..\..\src\lib\test\SignVerifyTests.h" />
+    <ClInclude Include="..\..\src\lib\test\testconfig.h" />
+    <ClInclude Include="..\..\src\lib\test\TokenTests.h" />
+    <ClInclude Include="..\..\src\lib\test\UserTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\access.cpp" />
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp" />
+    <ClCompile Include="..\..\src\lib\main.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp" />
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp" />
+    <ClCompile Include="..\..\src\lib\test\DigestTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\EncryptDecryptTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\InfoTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\InitTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\ObjectTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\p11test.cpp" />
+    <ClCompile Include="..\..\src\lib\test\RandomTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\SessionTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\SignVerifyTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\TokenTests.cpp" />
+    <ClCompile Include="..\..\src\lib\test\UserTests.cpp" />
+    <ClCompile Include="..\..\src\lib\win32\setenv.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/p11test/p11test.vcxproj.filters
+++ b/win32+openssl/p11test/p11test.vcxproj.filters
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Lib Header Files">
+      <UniqueIdentifier>{8440d7eb-5530-4f5e-a355-a43435742c60}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Lib Source Files">
+      <UniqueIdentifier>{3c33d54e-4bd1-43e0-bcc7-0d6adcfd5dc7}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Other Header Files">
+      <UniqueIdentifier>{ff435d2e-c67a-4f47-9731-28d88617e559}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Other Source Files">
+      <UniqueIdentifier>{5df8b0a3-ecc7-4876-aea2-8421c0846535}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\test\DigestTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\EncryptDecryptTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\InfoTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\InitTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\ObjectTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\RandomTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\SessionTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\SignVerifyTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\testconfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\TokenTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\test\UserTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\common\osmutex.h">
+      <Filter>Other Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\access.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Other Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Attributes.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Objects.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\SoftHSM.h">
+      <Filter>Lib Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\test\DigestTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\EncryptDecryptTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\InfoTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\InitTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\ObjectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\RandomTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\SessionTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\SignVerifyTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\TokenTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\UserTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\common\osmutex.cpp">
+      <Filter>Other Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\win32\setenv.cpp">
+      <Filter>Other Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\access.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\main.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp">
+      <Filter>Lib Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\test\p11test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/p11test/p11test.vcxproj.user
+++ b/win32+openssl/p11test/p11test.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/sessionmgrtest/sessionmgrtest.vcxproj
+++ b/win32+openssl/sessionmgrtest/sessionmgrtest.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>sessionmgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\session_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\object_store;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\session_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\data_mgr;..\..\src\lib\slot_mgr;..\..\src\lib\object_store;..\..\src\lib\win32;..\..\..\cu\include;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\session_mgr\test\SessionManagerTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\session_mgr\test\SessionManagerTests.cpp" />
+    <ClCompile Include="..\..\src\lib\session_mgr\test\sessionmgrtest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/sessionmgrtest/sessionmgrtest.vcxproj.filters
+++ b/win32+openssl/sessionmgrtest/sessionmgrtest.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\session_mgr\test\SessionManagerTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\session_mgr\test\SessionManagerTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\session_mgr\test\sessionmgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/sessionmgrtest/sessionmgrtest.vcxproj.user
+++ b/win32+openssl/sessionmgrtest/sessionmgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/slotmgrtest/slotmgrtest.vcxproj
+++ b/win32+openssl/slotmgrtest/slotmgrtest.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>slotmgrtest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\slot_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunitd.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\slot_mgr;..\..\src\lib\common;..\..\src\lib\cryptoki_compat;..\..\src\lib\crypto;..\..\src\lib\object_store;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\win32;..\..\..\cu\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\cu\lib;..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;cppunit.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.cpp" />
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\slotmgrtest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/slotmgrtest/slotmgrtest.vcxproj.filters
+++ b/win32+openssl/slotmgrtest/slotmgrtest.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\SlotManagerTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\slot_mgr\test\slotmgrtest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/slotmgrtest/slotmgrtest.vcxproj.user
+++ b/win32+openssl/slotmgrtest/slotmgrtest.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/softhsm2.sln
+++ b/win32+openssl/softhsm2.sln
@@ -1,0 +1,86 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual C++ Express 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "softhsm2", "softhsm2\softhsm2.vcxproj", "{801F5AB2-7A62-4085-B129-D15E2D717219}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795} = {F64541B6-FFBF-4368-B93A-A5CA8ADAD795}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "keyconv", "keyconv\keyconv.vcxproj", "{9B003E52-F02A-47EA-9942-2D9AE8738161}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "util", "util\util.vcxproj", "{05901466-4184-47C8-9D6C-3BB99BBF5378}"
+	ProjectSection(ProjectDependencies) = postProject
+		{801F5AB2-7A62-4085-B129-D15E2D717219} = {801F5AB2-7A62-4085-B129-D15E2D717219}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "p11test", "p11test\p11test.vcxproj", "{7C5EE7FC-B5FC-47BF-8164-A452FE689472}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cryptotest", "cryptotest\cryptotest.vcxproj", "{07E03E0B-C525-4A72-88C6-2238896A4D8C}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "datamgrtest", "datamgrtest\datamgrtest.vcxproj", "{E20315B5-B49E-46D7-B7EC-1A439F347C95}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "handlemgrtest", "handlemgrtest\handlemgrtest.vcxproj", "{014B1E10-EC68-4BEC-B992-F92CA2B6816F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "objstoretest", "objstoretest\objstoretest.vcxproj", "{44F77533-A4A1-4175-8C4C-07106B3F9C08}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sessionmgrtest", "sessionmgrtest\sessionmgrtest.vcxproj", "{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "slotmgrtest", "slotmgrtest\slotmgrtest.vcxproj", "{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "convarch", "convarch\convarch.vcxproj", "{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Debug|Win32.ActiveCfg = Debug|Win32
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Debug|Win32.Build.0 = Debug|Win32
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Release|Win32.ActiveCfg = Release|Win32
+		{801F5AB2-7A62-4085-B129-D15E2D717219}.Release|Win32.Build.0 = Release|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Debug|Win32.ActiveCfg = Debug|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Debug|Win32.Build.0 = Debug|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Release|Win32.ActiveCfg = Release|Win32
+		{9B003E52-F02A-47EA-9942-2D9AE8738161}.Release|Win32.Build.0 = Release|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Debug|Win32.ActiveCfg = Debug|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Debug|Win32.Build.0 = Debug|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Release|Win32.ActiveCfg = Release|Win32
+		{05901466-4184-47C8-9D6C-3BB99BBF5378}.Release|Win32.Build.0 = Release|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Debug|Win32.Build.0 = Debug|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Release|Win32.ActiveCfg = Release|Win32
+		{7C5EE7FC-B5FC-47BF-8164-A452FE689472}.Release|Win32.Build.0 = Release|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Debug|Win32.Build.0 = Debug|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Release|Win32.ActiveCfg = Release|Win32
+		{07E03E0B-C525-4A72-88C6-2238896A4D8C}.Release|Win32.Build.0 = Release|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Debug|Win32.Build.0 = Debug|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Release|Win32.ActiveCfg = Release|Win32
+		{E20315B5-B49E-46D7-B7EC-1A439F347C95}.Release|Win32.Build.0 = Release|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Debug|Win32.Build.0 = Debug|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Release|Win32.ActiveCfg = Release|Win32
+		{014B1E10-EC68-4BEC-B992-F92CA2B6816F}.Release|Win32.Build.0 = Release|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Debug|Win32.ActiveCfg = Debug|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Debug|Win32.Build.0 = Debug|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Release|Win32.ActiveCfg = Release|Win32
+		{44F77533-A4A1-4175-8C4C-07106B3F9C08}.Release|Win32.Build.0 = Release|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Debug|Win32.Build.0 = Debug|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Release|Win32.ActiveCfg = Release|Win32
+		{45E2ABF6-91A7-4AA5-A82B-0C8E54BCCCB9}.Release|Win32.Build.0 = Release|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Debug|Win32.ActiveCfg = Debug|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Debug|Win32.Build.0 = Debug|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Release|Win32.ActiveCfg = Release|Win32
+		{F62E31E5-0F8D-4B70-8F26-44AFA1A9E645}.Release|Win32.Build.0 = Release|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Debug|Win32.ActiveCfg = Debug|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Debug|Win32.Build.0 = Debug|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Release|Win32.ActiveCfg = Release|Win32
+		{F64541B6-FFBF-4368-B93A-A5CA8ADAD795}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/win32+openssl/softhsm2/softhsm2.vcxproj
+++ b/win32+openssl/softhsm2/softhsm2.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{801F5AB2-7A62-4085-B129-D15E2D717219}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>softhsm2</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;SOFTHSM2_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;SOFTHSM2_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\lib;..\..\src\lib\cryptoki_compat;..\..\src\lib\common;..\..\src\lib\object_store;..\..\src\lib\slot_mgr;..\..\src\lib\session_mgr;..\..\src\lib\data_mgr;..\..\src\lib\handle_mgr;..\..\src\lib\crypto;..\..\src\lib\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\$(Configuration);..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>convarch.lib;libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\access.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+    <ClInclude Include="..\..\src\lib\P11Attributes.h" />
+    <ClInclude Include="..\..\src\lib\P11Objects.h" />
+    <ClInclude Include="..\..\src\lib\SoftHSM.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\access.cpp" />
+    <ClCompile Include="..\..\src\lib\main.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp" />
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp" />
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp" />
+    <ClCompile Include="..\..\src\lib\win32\dllmain.cc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/softhsm2/softhsm2.vcxproj.filters
+++ b/win32+openssl/softhsm2/softhsm2.vcxproj.filters
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\lib\access.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Attributes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\P11Objects.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\SoftHSM.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\lib\access.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Attributes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\P11Objects.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\lib\SoftHSM.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib\win32\dllmain.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/softhsm2/softhsm2.vcxproj.user
+++ b/win32+openssl/softhsm2/softhsm2.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/win32+openssl/util/util.vcxproj
+++ b/win32+openssl/util/util.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{05901466-4184-47C8-9D6C-3BB99BBF5378}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>util</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\src\bin\common;..\..\src\bin\win32;..\..\src\lib\cryptoki_compat;..\..\..\ssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>..\..\..\ssl\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libeay32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h" />
+    <ClInclude Include="..\..\src\bin\common\library.h" />
+    <ClInclude Include="..\..\src\bin\util\softhsm-util-ossl.h" />
+    <ClInclude Include="..\..\src\bin\util\softhsm-util.h" />
+    <ClInclude Include="..\..\src\bin\win32\getopt.h" />
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp" />
+    <ClCompile Include="..\..\src\bin\common\library.cpp" />
+    <ClCompile Include="..\..\src\bin\util\softhsm-util-ossl.cpp" />
+    <ClCompile Include="..\..\src\bin\util\softhsm-util.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp" />
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32+openssl/util/util.vcxproj.filters
+++ b/win32+openssl/util/util.vcxproj.filters
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common Header Files">
+      <UniqueIdentifier>{21eda3a1-8da0-4a99-967c-f218e4eecd08}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{fd946626-7e24-4f78-834b-a4c0ac6dc2f5}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Win32 Header Files">
+      <UniqueIdentifier>{f3a7acce-323d-4465-95bf-a326189dcdd5}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Win32 Source Files">
+      <UniqueIdentifier>{2b77905a-99da-49cf-9cac-aa72e7e3182b}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\bin\common\getpw.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\common\library.h">
+      <Filter>Common Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\util\softhsm-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\util\softhsm-util-ossl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\lib\cryptoki_compat\pkcs11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bin\win32\getopt.h">
+      <Filter>Win32 Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\bin\common\getpw.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\common\library.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\util\softhsm-util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\util\softhsm-util-ossl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getopt.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bin\win32\getpassphase.cpp">
+      <Filter>Win32 Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/win32+openssl/util/util.vcxproj.user
+++ b/win32+openssl/util/util.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>


### PR DESCRIPTION
tested with VS 2010 C++ Express and OpenSSL 1.0.1e / (fixed) Botan 1.10.5

self tests and an application work

note as in Debug the C++ runtime is far stricter than g++ some &foo[0] where foo is a zero length vector were caught and fixed, so some changes are not for WIN32...

for WIN32 details are in WIN32-NOTES
