### PR TITLE
Botan 1.11 / C++11 support

### DIFF
--- a/m4/acx_botan.m4
+++ b/m4/acx_botan.m4
@@ -8,12 +8,18 @@ AC_DEFUN([ACX_BOTAN],[
 			BOTAN_PATH="/usr/local"
 		])
 
+	BOTAN_VERSION_MINOR=10
 	AC_MSG_CHECKING(what are the Botan includes)
-	BOTAN_INCLUDES="-I$BOTAN_PATH/include/botan-1.10"
+	AC_CHECK_FILE($BOTAN_PATH/include/botan-1.10/botan/init.h,
+		      BOTAN_VERSION_MINOR=10,
+		      AC_CHECK_FILE($BOTAN_PATH/include/botan-1.11/botan/init.h,
+				    BOTAN_VERSION_MINOR=11,
+				    AC_MSG_ERROR([Cannot find Botan includes])))
+	BOTAN_INCLUDES="-I$BOTAN_PATH/include/botan-1.$BOTAN_VERSION_MINOR"
 	AC_MSG_RESULT($BOTAN_INCLUDES)
 
 	AC_MSG_CHECKING(what are the Botan libs)
-	BOTAN_LIBS="-L$BOTAN_PATH/lib -lbotan-1.10"
+	BOTAN_LIBS="-L$BOTAN_PATH/lib -lbotan-1.$BOTAN_VERSION_MINOR"
 	AC_MSG_RESULT($BOTAN_LIBS)
 
 	tmp_CPPFLAGS=$CPPFLAGS
@@ -49,4 +55,5 @@ AC_DEFUN([ACX_BOTAN],[
 
 	AC_SUBST(BOTAN_INCLUDES)
 	AC_SUBST(BOTAN_LIBS)
+	AC_SUBST(BOTAN_VERSION_MINOR)
 ])

--- a/m4/acx_botan_ecc.m4
+++ b/m4/acx_botan_ecc.m4
@@ -18,8 +18,13 @@ AC_DEFUN([ACX_BOTAN_ECC],[
 				const Botan::OID oid(Botan::OIDS::lookup(name));
 				const Botan::EC_Group ecg(oid);
 				try {
+#if BOTAN_VERSION_MINOR == 11
+					const std::vector<Botan::byte> der =
+					    ecg.DER_encode(Botan::EC_DOMPAR_ENC_OID);
+#else
 					const Botan::SecureVector<Botan::byte> der =
 					    ecg.DER_encode(Botan::EC_DOMPAR_ENC_OID);
+#endif
 				} catch(...) {
 					return 1;
 				}

--- a/src/bin/dump/softhsm-dump.cpp
+++ b/src/bin/dump/softhsm-dump.cpp
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <map>
+#include <string>
 #include <stdexcept>
 #include <vector>
 #include "tables.h"

--- a/src/bin/keyconv/softhsm-keyconv-botan.cpp
+++ b/src/bin/keyconv/softhsm-keyconv-botan.cpp
@@ -102,7 +102,7 @@ int save_rsa_pkcs8(char* out_path, char* file_pin, key_material_t* pkey)
 	}
 
 	std::ofstream priv_file(out_path);
-	if (priv_file == NULL)
+	if (!priv_file.is_open())
 	{
 		fprintf(stderr, "ERROR: Could not open file for output.\n");
 		delete rng;
@@ -118,7 +118,11 @@ int save_rsa_pkcs8(char* out_path, char* file_pin, key_material_t* pkey)
 		}
 		else
 		{
+#if BOTAN_VERSION_MINOR == 11
+			priv_file << Botan::PKCS8::PEM_encode(*priv_key, *rng, file_pin, std::chrono::milliseconds(300), "PBE-PKCS5v15(MD5,DES/CBC)");
+#else
 			priv_file << Botan::PKCS8::PEM_encode(*priv_key, *rng, file_pin, "PBE-PKCS5v15(MD5,DES/CBC)");
+#endif
 		}
 
 		printf("The key has been written to %s\n", out_path);
@@ -178,7 +182,7 @@ int save_dsa_pkcs8(char* out_path, char* file_pin, key_material_t* pkey)
 	}
 
 	std::ofstream priv_file(out_path);
-	if (priv_file == NULL)
+	if (!priv_file.is_open())
 	{
 		fprintf(stderr, "ERROR: Could not open file for output.\n");
 		delete rng;
@@ -194,7 +198,11 @@ int save_dsa_pkcs8(char* out_path, char* file_pin, key_material_t* pkey)
 		}
 		else
 		{
+#if BOTAN_VERSION_MINOR == 11
+			priv_file << Botan::PKCS8::PEM_encode(*priv_key, *rng, file_pin, std::chrono::milliseconds(300), "PBE-PKCS5v15(MD5,DES/CBC)");
+#else
 			priv_file << Botan::PKCS8::PEM_encode(*priv_key, *rng, file_pin, "PBE-PKCS5v15(MD5,DES/CBC)");
+#endif
 		}
 
 		printf("The key has been written to %s\n", out_path);

--- a/src/bin/util/softhsm-util-botan.cpp
+++ b/src/bin/util/softhsm-util-botan.cpp
@@ -45,6 +45,7 @@
 #include <botan/auto_rng.h>
 #include <botan/pkcs8.h>
 #include <botan/bigint.h>
+#include <botan/libstate.h>
 
 bool was_initialized = false;
 

--- a/src/lib/crypto/BotanDSA.cpp
+++ b/src/lib/crypto/BotanDSA.cpp
@@ -108,7 +108,11 @@ bool BotanDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -126,7 +130,11 @@ bool BotanDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete signer;
 	signer = NULL;
@@ -253,7 +261,11 @@ bool BotanDSA::signFinal(ByteString& signature)
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -271,7 +283,11 @@ bool BotanDSA::signFinal(ByteString& signature)
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete signer;
 	signer = NULL;

--- a/src/lib/crypto/BotanECDSA.cpp
+++ b/src/lib/crypto/BotanECDSA.cpp
@@ -108,7 +108,11 @@ bool BotanECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign, Byte
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -126,7 +130,11 @@ bool BotanECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign, Byte
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete signer;
 	signer = NULL;

--- a/src/lib/crypto/BotanGOST.cpp
+++ b/src/lib/crypto/BotanGOST.cpp
@@ -167,7 +167,11 @@ bool BotanGOST::signFinal(ByteString& signature)
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -185,7 +189,11 @@ bool BotanGOST::signFinal(ByteString& signature)
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete signer;
 	signer = NULL;

--- a/src/lib/crypto/BotanMacAlgorithm.cpp
+++ b/src/lib/crypto/BotanMacAlgorithm.cpp
@@ -134,7 +134,11 @@ bool BotanMacAlgorithm::signFinal(ByteString& signature)
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	Botan::secure_vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		signResult = hmac->final();
@@ -151,7 +155,11 @@ bool BotanMacAlgorithm::signFinal(ByteString& signature)
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete hmac;
 	hmac = NULL;
@@ -241,7 +249,11 @@ bool BotanMacAlgorithm::verifyFinal(ByteString& signature)
 	}
 
 	// Perform the verify operation
+#if BOTAN_VERSION_MINOR == 11
+	Botan::secure_vector<Botan::byte> macResult;
+#else
 	Botan::SecureVector<Botan::byte> macResult;
+#endif
 	try
 	{
 		macResult = hmac->final();
@@ -269,5 +281,9 @@ bool BotanMacAlgorithm::verifyFinal(ByteString& signature)
 	delete hmac;
 	hmac = NULL;
 
+#if BOTAN_VERSION_MINOR == 11
+	return memcmp(&signature[0], macResult.data(), macResult.size()) == 0;
+#else
 	return memcmp(&signature[0], macResult.begin(), macResult.size()) == 0;
+#endif
 }

--- a/src/lib/crypto/BotanRSA.cpp
+++ b/src/lib/crypto/BotanRSA.cpp
@@ -109,7 +109,11 @@ std::string mechanism)
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -127,7 +131,11 @@ std::string mechanism)
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete signer;
 	signer = NULL;
@@ -262,7 +270,11 @@ bool BotanRSA::signFinal(ByteString& signature)
 	}
 
 	// Perform the signature operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> signResult;
+#else
 	Botan::SecureVector<Botan::byte> signResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -280,7 +292,11 @@ bool BotanRSA::signFinal(ByteString& signature)
 
 	// Return the result
 	signature.resize(signResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&signature[0], signResult.data(), signResult.size());
+#else
 	memcpy(&signature[0], signResult.begin(), signResult.size());
+#endif
 
 	delete signer;
 	signer = NULL;
@@ -569,7 +585,11 @@ bool BotanRSA::encrypt(PublicKey* publicKey, const ByteString& data, ByteString&
 	}
 
 	// Perform the encryption operation
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> encResult;
+#else
 	Botan::SecureVector<Botan::byte> encResult;
+#endif
 	try
 	{
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
@@ -586,7 +606,11 @@ bool BotanRSA::encrypt(PublicKey* publicKey, const ByteString& data, ByteString&
 
 	// Return the result
 	encryptedData.resize(encResult.size());
+#if BOTAN_VERSION_MINOR == 11
+	memcpy(&encryptedData[0], encResult.data(), encResult.size());
+#else
 	memcpy(&encryptedData[0], encResult.begin(), encResult.size());
+#endif
 
 	delete encryptor;
 
@@ -651,7 +675,11 @@ bool BotanRSA::decrypt(PrivateKey* privateKey, const ByteString& encryptedData, 
 	}
 
 	// Perform the decryption operation
+#if BOTAN_VERSION_MINOR == 11
+	Botan::secure_vector<Botan::byte> decResult;
+#else
 	Botan::SecureVector<Botan::byte> decResult;
+#endif
 	try
 	{
 		decResult = decryptor->decrypt(encryptedData.const_byte_str(), encryptedData.size());
@@ -672,12 +700,20 @@ bool BotanRSA::decrypt(PrivateKey* privateKey, const ByteString& encryptedData, 
 		int modSize = pk->getN().size();
 		int decSize = decResult.size();
 		data.resize(modSize);
+#if BOTAN_VERSION_MINOR == 11
+		memcpy(&data[0] + modSize - decSize, decResult.data(), decSize);
+#else
 		memcpy(&data[0] + modSize - decSize, decResult.begin(), decSize);
+#endif
 	}
 	else
 	{
 		data.resize(decResult.size());
+#if BOTAN_VERSION_MINOR == 11
+		memcpy(&data[0], decResult.data(), decResult.size());
+#else
 		memcpy(&data[0], decResult.begin(), decResult.size());
+#endif
 	}
 
 	delete decryptor;

--- a/src/lib/crypto/BotanUtil.cpp
+++ b/src/lib/crypto/BotanUtil.cpp
@@ -57,14 +57,24 @@ Botan::BigInt BotanUtil::byteString2bigInt(const ByteString& byteString)
 // Convert a Botan EC group to a ByteString
 ByteString BotanUtil::ecGroup2ByteString(const Botan::EC_Group& ecGroup)
 {
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> der = ecGroup.DER_encode(Botan::EC_DOMPAR_ENC_OID);
+#else
 	Botan::SecureVector<Botan::byte> der = ecGroup.DER_encode(Botan::EC_DOMPAR_ENC_OID);
+#endif
 	return ByteString(&der[0], der.size());
 }
 
 // Convert a ByteString to a Botan EC group
 Botan::EC_Group BotanUtil::byteString2ECGroup(const ByteString& byteString)
 {
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> der(byteString.size());
+	memcpy(&der[0], byteString.const_byte_str(), byteString.size());
+	return Botan::EC_Group(der);
+#else
 	return Botan::EC_Group(Botan::MemoryVector<Botan::byte>(byteString.const_byte_str(), byteString.size()));
+#endif
 }
 
 // Convert a Botan EC point to a ByteString
@@ -74,8 +84,15 @@ ByteString BotanUtil::ecPoint2ByteString(const Botan::PointGFp& ecPoint)
 
 	try
 	{
+#if BOTAN_VERSION_MINOR == 11
+		Botan::secure_vector<Botan::byte> repr = Botan::EC2OSP(ecPoint, Botan::PointGFp::UNCOMPRESSED);
+		Botan::secure_vector<Botan::byte> der;
+#else
 		Botan::SecureVector<Botan::byte> repr = Botan::EC2OSP(ecPoint, Botan::PointGFp::UNCOMPRESSED);
 		Botan::SecureVector<Botan::byte> der;
+#endif
+
+
 		der = Botan::DER_Encoder()
 			.encode(repr, Botan::OCTET_STRING)
 			.get_contents();
@@ -92,7 +109,11 @@ ByteString BotanUtil::ecPoint2ByteString(const Botan::PointGFp& ecPoint)
 // Convert a ByteString to a Botan EC point
 Botan::PointGFp BotanUtil::byteString2ECPoint(const ByteString& byteString, const Botan::EC_Group& ecGroup)
 {
+#if BOTAN_VERSION_MINOR == 11
+	std::vector<Botan::byte> repr;
+#else
 	Botan::SecureVector<Botan::byte> repr;
+#endif
 	Botan::BER_Decoder(byteString.const_byte_str(), byteString.size())
 		.decode(repr, Botan::OCTET_STRING)
 		.verify_end();


### PR DESCRIPTION
Botan 1.1/C++11 patch. Note the Botan 1.11 on some systems (my Linux Fedora 19 64 bit VM for instance) crashes on a destruction order (locking allocator destroyed too soon) which is not yet fixed.
A simple solution is to disable it as it is for OS X (aka darwin).
Anyway the C++11 part is interesting by itself.
