### PR TITLE
add GCC visibility hidding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,22 @@ Configure the installation/compilation scripts:
 Options:
 
 	--disable-non-paged-memory
-	                        Disable non-paged memory for secure storage
-	                        (default enabled)
-	--enable-ecc            Enable support for ECC (default enabled)
+				Disable non-paged memory for secure storage
+				(default enabled)
+	--disable-ecc		Enable support for ECC (default enabled)
 	--enable-gost		Enable support for GOST (default disabled)
-	--with-crypto-backend   Select crypto backend (openssl|botan)
-	--with-openssl=PATH     Specify prefix of path of OpenSSL
-	--with-botan=PATH       Specify prefix of path of Botan
-	--with-loglevel=INT     The log level. 0=No log 1=Error 2=Warning 3=Info
-	                        4=Debug (default INT=3)
-	--with-migrate          Build the migration tool. Used when migrating
-	                        a SoftHSM v1 token database. Requires SQLite3.
-	--with-sqlite3=PATH     Specify prefix of path of SQLite3
+	--enable-visibility	Enable -fvisibility=hidden GCC flags so
+				only the PKCS#11 C_* entry points are kept
+	--with-crypto-backend	Select crypto backend (openssl|botan)
+	--with-openssl=PATH	Specify prefix of path of OpenSSL
+	--with-botan=PATH	Specify prefix of path of Botan
+	--with-loglevel=INT	The log level. 0=No log 1=Error 2=Warning
+				3=Info 4=Debug (default INT=3)
+	--with-migrate		Build the migration tool. Used when migrating
+				a SoftHSM v1 token database. Requires SQLite3
+	--with-objectstore-backend-db
+				Build with database object store (SQLite3)
+	--with-sqlite3=PATH	Specify prefix of path of SQLite3
 
 For more options:
 

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ else
 	AC_MSG_RESULT(no)
 fi
 
+# Set visibility flags so only PKCS#11 entry points are exported
+ACX_VISIBILITY
+
 # Set full directory paths
 full_sysconfdir=`eval eval eval eval eval echo "${sysconfdir}" | sed "s#NONE#${prefix}#" | sed "s#NONE#${ac_default_prefix}#"`
 full_localstatedir=`eval eval eval eval eval echo "${localstatedir}" | sed "s#NONE#${prefix}#" | sed "s#NONE#${ac_default_prefix}#"`

--- a/src/lib/cryptoki_compat/pkcs11.h
+++ b/src/lib/cryptoki_compat/pkcs11.h
@@ -92,7 +92,11 @@ extern "C" {
 
 #else
 
+#if defined(CRYPTOKI_VISIBILITY) && defined(CRYPTOKI_EXPORTS)
+#define CK_SPEC __attribute__((visibility("default")))
+#else
 #define CK_SPEC
+#endif
 
 #endif
 


### PR DESCRIPTION
Compile with -fvisibility=hidden with PKCS#11 C_\* entry points still with default visibility.
As the result symbols become local so can be stripped (strip -x) and are no longer visible by dynamic loader, i.e., what you know in WIN32 as a DLL…
BTW even it is not very sensible in theory it makes dlopen() far faster and not only in theory the libsofthsm.so file strippable so smaller (e.g., for embedded devices).
