### PR TITLE
improve C_GetObjectSize

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1377,15 +1377,27 @@ CK_RV SoftHSM::C_DestroyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObj
 }
 
 // Determine the size of the specified object
-CK_RV SoftHSM::C_GetObjectSize(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE /*hObject*/, CK_ULONG_PTR /*pulSize*/)
+CK_RV SoftHSM::C_GetObjectSize(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_ULONG_PTR pulSize)
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
+
+	if (pulSize == NULL) return CKR_ARGUMENTS_BAD;
 
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	// Get the token
+	Token* token = session->getToken();
+	if (token == NULL_PTR) return CKR_GENERAL_ERROR;
+
+	// Check the object handle.
+	OSObject *object = (OSObject *)handleManager->getObject(hObject);
+	if (object == NULL_PTR || !object->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+
+	*pulSize = CK_UNAVAILABLE_INFORMATION;
+
+	return CKR_OK;
 }
 
 // Retrieve the specified attributes for the given object

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -1087,6 +1087,42 @@ void ObjectTests::testDestroyObject()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
+void ObjectTests::testGetObjectSize()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession;
+	CK_OBJECT_HANDLE hObject;
+
+	// Just make sure that we finalize any previous tests
+	C_Finalize(NULL_PTR);
+
+	// Open read-only session on when the token is not initialized should fail
+	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
+
+	// Initialize the library and start the test.
+	rv = C_Initialize(NULL_PTR);
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Open a session
+	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Get an object
+	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PUBLIC, hObject);
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Get the object size
+	CK_ULONG objectSize;
+	rv = C_GetObjectSize(hSession, hObject, &objectSize);
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	CPPUNIT_ASSERT(objectSize == CK_UNAVAILABLE_INFORMATION);
+
+	// Close session
+	rv = C_CloseSession(hSession);
+	CPPUNIT_ASSERT(rv == CKR_OK);
+}
+
 void ObjectTests::testGetAttributeValue()
 {
 	CK_RV rv;

--- a/src/lib/test/ObjectTests.h
+++ b/src/lib/test/ObjectTests.h
@@ -44,6 +44,7 @@ class ObjectTests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testCreateObject);
 	CPPUNIT_TEST(testCopyObject);
 	CPPUNIT_TEST(testDestroyObject);
+	CPPUNIT_TEST(testGetObjectSize);
 	CPPUNIT_TEST(testGetAttributeValue);
 	CPPUNIT_TEST(testSetAttributeValue);
 	CPPUNIT_TEST(testFindObjects);
@@ -61,6 +62,7 @@ public:
 	void testCreateObject();
 	void testCopyObject();
 	void testDestroyObject();
+	void testGetObjectSize();
 	void testGetAttributeValue();
 	void testSetAttributeValue();
 	void testFindObjects();


### PR DESCRIPTION
Essentially put CK_UNAVAILABLE_INFORMATION in the size as already done by C_GetTokenInfo.
