### PR TITLE
fix severe memory leak

### DIFF
--- a/src/lib/data_mgr/SecureAllocator.h
+++ b/src/lib/data_mgr/SecureAllocator.h
@@ -175,6 +175,7 @@ public:
 #else
 		VirtualFree((const void*) r, MEM_RELEASE);
 #endif
+#else
 		// Release the memory
 		::operator delete((void*) p);
 #endif // SENSITIVE_NON_PAGED


### PR DESCRIPTION
Because of a missing #else the deallocate() function never calls delete
so _all_ memories allocated by the SecureAllocator leak.
I pushed it on wrap0 too...
