### PR TITLE
SOFTHSM-62: Update the autoconf script for the crypto backed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Options:
 	--disable-non-paged-memory
 				Disable non-paged memory for secure storage
 				(default enabled)
-	--disable-ecc		Enable support for ECC (default enabled)
-	--enable-gost		Enable support for GOST (default disabled)
+	--disable-ecc		Disable support for ECC (default enabled)
+	--disable-gost		Disable support for GOST (default enabled)
 	--enable-visibility	Enable -fvisibility=hidden GCC flags so
 				only the PKCS#11 C_* entry points are kept
 	--with-crypto-backend	Select crypto backend (openssl|botan)

--- a/m4/acx_crypto_backend.m4
+++ b/m4/acx_crypto_backend.m4
@@ -24,10 +24,10 @@ AC_DEFUN([ACX_CRYPTO_BACKEND],[
 
 	AC_ARG_ENABLE(gost,
 		AC_HELP_STRING([--enable-gost],
-			[Enable support for GOST (default disabled)]
+			[Enable support for GOST (default enabled)]
 		),
 		[enable_gost="${enableval}"],
-		[enable_gost="no"]
+		[enable_gost="yes"]
 	)
 	AC_MSG_CHECKING(for GOST support)
 	if test "x${enable_gost}" = "xyes"; then


### PR DESCRIPTION
OpenSSL version has been bumped to 1.0.0 in the documentation because of the usage of HMAC_xxx return value.

See:
https://github.com/opendnssec/SoftHSMv2/commit/ca06c3c5fad0887da330153c99ef6cb1e2566eaa

All required versions of Botan and OpenSSL will thus support GOST. Enable GOST by default and fix the version checks.
