### PR TITLE
SOFTHSM-78: Correct the attribute checks for a number of objects.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ SoftHSM develop
 
 Bugfixes:
 * SOFTHSM-69: GOST did not work when you disabled ECC.
+* SOFTHSM-78: Correct the attribute checks for a number of objects.
 * Fixed a number of memory leaks.
 
 

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -356,7 +356,6 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 			{
 				// attr is already retrieved and verified to be an Array
 				rv = retrieveArray((CK_ATTRIBUTE_PTR)pValue, attr->getArrayValue());
-					
 			}
 		}
 		*pulValueLen = attrSize;

--- a/src/lib/P11Attributes.h
+++ b/src/lib/P11Attributes.h
@@ -75,11 +75,11 @@ public:
 		ck5=0x10,       //  5  Must be specified when object is unwrapped with C_UnwrapKey.
 		ck6=0x20,       //  6  Must not be specified when object is unwrapped with C_UnwrapKey.
 		ck7=0x40,       //  7  Cannot be revealed if object has its CKA_SENSITIVE attribute set to CK_TRUE or
-						//      its CKA_EXTRACTABLE attribute set to CK_FALSE.
+		                //      its CKA_EXTRACTABLE attribute set to CK_FALSE.
 		ck8=0x80,       //  8  May be modified after object is created with a C_SetAttributeValue call
-						//      or in the process of copying an object with a C_CopyObject call.
-						//      However, it is possible that a particular token may not permit modification of
-						//      the attribute during the course of a C_CopyObject call.
+		                //      or in the process of copying an object with a C_CopyObject call.
+		                //      However, it is possible that a particular token may not permit modification of
+		                //      the attribute during the course of a C_CopyObject call.
 		ck9=0x100,      //  9  Default value is token-specific, and may depend on the values of other attributes.
 		ck10=0x200,     // 10  Can only be set to CK_TRUE by the SO user.
 		ck11=0x400,     // 11  Attribute cannot be changed once set to CK_TRUE. It becomes a read only attribute.
@@ -152,7 +152,7 @@ class P11AttrKeyType : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrKeyType(OSObject* osobject) : P11Attribute(osobject) { type = CKA_KEY_TYPE; size = sizeof(CK_KEY_TYPE); checks = ck1|ck5; }
+	P11AttrKeyType(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_KEY_TYPE; size = sizeof(CK_KEY_TYPE); checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -413,21 +413,13 @@ protected:
 
 /*****************************************
  * CKA_START_DATE
- * Because this attribute is used in a
- * certificate object where the CKA_VALUE
- * containing the certificate data is not
- * modifiable, we assume that this attribute
- * is also not modifiable.
- * There is also no explicit mention of
- * this CKA_START_DATE attribute being
- * modifiable,
  *****************************************/
 
 class P11AttrStartDate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrStartDate(OSObject* osobject) : P11Attribute(osobject) { type = CKA_START_DATE; checks = 0; }
+	P11AttrStartDate(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_START_DATE; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -439,21 +431,13 @@ protected:
 
 /*****************************************
  * CKA_END_DATE
- * Because this attribute is used in a
- * certificate object where the CKA_VALUE
- * containing the certificate data is not
- * modifiable, we assume that this attribute
- * is also not modifiable.
- * There is also no explicit mention of
- * this CKA_END_DATE attribute being
- * modifiable,
  *****************************************/
 
 class P11AttrEndDate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrEndDate(OSObject* osobject) : P11Attribute(osobject) { type = CKA_END_DATE; checks = 0; }
+	P11AttrEndDate(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_END_DATE; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -729,7 +713,7 @@ class P11AttrLocal : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrLocal(OSObject* osobject) : P11Attribute(osobject) { type = CKA_LOCAL; size = sizeof(CK_BBOOL); checks = ck2|ck4|ck6; }
+	P11AttrLocal(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_LOCAL; size = sizeof(CK_BBOOL); checks = ck2|ck4|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -783,7 +767,7 @@ class P11AttrNeverExtractable : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrNeverExtractable(OSObject* osobject) : P11Attribute(osobject) { type = CKA_NEVER_EXTRACTABLE; size = sizeof(CK_BBOOL); checks = ck2|ck4; }
+	P11AttrNeverExtractable(OSObject* osobject) : P11Attribute(osobject) { type = CKA_NEVER_EXTRACTABLE; size = sizeof(CK_BBOOL); checks = ck2|ck4|ck6; }
 
 protected:
 	// Set the default value of the attribute
@@ -873,7 +857,7 @@ class P11AttrModulus : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrModulus(OSObject* osobject) : P11Attribute(osobject) { type = CKA_MODULUS; checks = ck1|ck4|ck6; }
+	P11AttrModulus(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_MODULUS; checks = ck1|ck4|inchecks; }
 
 protected:
 	// Set the default value of the attribute

--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -346,8 +346,12 @@ bool P11CertificateObj::init(OSObject *osobject)
 	P11Attribute* attrCertificateCategory = new P11AttrCertificateCategory(osobject);
 	// TODO: CKA_CHECK_VALUE is accepted, but we do not calculate it
 	P11Attribute* attrCheckValue = new P11AttrCheckValue(osobject);
-	P11Attribute* attrStartDate = new P11AttrStartDate(osobject);
-	P11Attribute* attrEndDate = new P11AttrEndDate(osobject);
+	// NOTE: Because these attributes are used in a certificate object
+	//  where the CKA_VALUE containing the certificate data is not
+	//  modifiable, we assume that this attribute is also not modifiable.
+	//  There is also no explicit mention of these attributes being modifiable.
+	P11Attribute* attrStartDate = new P11AttrStartDate(osobject,0);
+	P11Attribute* attrEndDate = new P11AttrEndDate(osobject,0);
 
 	// Initialize the attributes
 	if
@@ -516,14 +520,14 @@ bool P11KeyObj::init(OSObject *osobject)
 	if (!P11Object::init(osobject)) return false;
 
 	// Create attributes
-	P11Attribute* attrKeyType = new P11AttrKeyType(osobject);
+	P11Attribute* attrKeyType = new P11AttrKeyType(osobject,P11Attribute::ck5);
 	P11Attribute* attrID = new P11AttrID(osobject);
-	P11Attribute* attrStartDate = new P11AttrStartDate(osobject);
-	P11Attribute* attrEndDate = new P11AttrEndDate(osobject);
+	P11Attribute* attrStartDate = new P11AttrStartDate(osobject,P11Attribute::ck8);
+	P11Attribute* attrEndDate = new P11AttrEndDate(osobject,P11Attribute::ck8);
 	P11Attribute* attrDerive = new P11AttrDerive(osobject);
-	P11Attribute* attrLocal = new P11AttrLocal(osobject);
+	P11Attribute* attrLocal = new P11AttrLocal(osobject,P11Attribute::ck6);
 	P11Attribute* attrKeyGenMechanism = new P11AttrKeyGenMechanism(osobject);
-	// CKA_ALLOWED_MECHANISMS is not supported
+	// TODO: CKA_ALLOWED_MECHANISMS is not supported
 
 	// Initialize the attributes
 	if
@@ -885,6 +889,7 @@ bool P11PrivateKeyObj::init(OSObject *osobject)
 	P11Attribute* attrNeverExtractable = new P11AttrNeverExtractable(osobject);
 	P11Attribute* attrWrapWithTrusted = new P11AttrWrapWithTrusted(osobject);
 	P11Attribute* attrUnwrapTemplate = new P11AttrUnwrapTemplate(osobject);
+	// TODO: CKA_ALWAYS_AUTHENTICATE is accepted, but we do not use it
 	P11Attribute* attrAlwaysAuthenticate = new P11AttrAlwaysAuthenticate(osobject);
 
 	// Initialize the attributes
@@ -947,7 +952,7 @@ bool P11RSAPrivateKeyObj::init(OSObject *osobject)
 	if (initialized) return true;
 
 	// Create attributes
-	P11Attribute* attrModulus = new P11AttrModulus(osobject);
+	P11Attribute* attrModulus = new P11AttrModulus(osobject,P11Attribute::ck6);
 	P11Attribute* attrPublicExponent = new P11AttrPublicExponent(osobject,P11Attribute::ck4|P11Attribute::ck6);
 	P11Attribute* attrPrivateExponent = new P11AttrPrivateExponent(osobject);
 	P11Attribute* attrPrime1 = new P11AttrPrime1(osobject);
@@ -1103,6 +1108,7 @@ bool P11DHPrivateKeyObj::init(OSObject *osobject)
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4|P11Attribute::ck6);
 	P11Attribute* attrBase = new P11AttrBase(osobject,P11Attribute::ck4|P11Attribute::ck6);
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
+	// TODO: Missing CKA_VALUE_BITS
 
 	// Initialize the attributes
 	if
@@ -1530,18 +1536,18 @@ bool P11DSADomainObj::init(OSObject *osobject)
 	if (!P11DomainObj::init(osobject)) return false;
 
 	// Create attributes
+	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4);
+	P11Attribute* attrSubPrime = new P11AttrSubPrime(osobject,P11Attribute::ck4);
+	P11Attribute* attrBase = new P11AttrBase(osobject,P11Attribute::ck4);
 	P11Attribute* attrPrimeBits = new P11AttrPrimeBits(osobject);
-	P11Attribute* attrPrime = new P11AttrPrime(osobject);
-	P11Attribute* attrSubPrime = new P11AttrSubPrime(osobject);
-	P11Attribute* attrBase = new P11AttrBase(osobject);
 
 	// Initialize the attributes
 	if
 	(
-		!attrPrimeBits->init() ||
 		!attrPrime->init() ||
 		!attrSubPrime->init() ||
-		!attrBase->init()
+		!attrBase->init() ||
+		!attrPrimeBits->init()
 	)
 	{
 		ERROR_MSG("Could not initialize the attribute");
@@ -1549,10 +1555,10 @@ bool P11DSADomainObj::init(OSObject *osobject)
 	}
 
 	// Add them to the map
-	attributes[attrPrimeBits->getType()] = attrPrimeBits;
 	attributes[attrPrime->getType()] = attrPrime;
 	attributes[attrSubPrime->getType()] = attrSubPrime;
 	attributes[attrBase->getType()] = attrBase;
+	attributes[attrPrimeBits->getType()] = attrPrimeBits;
 
 	initialized = true;
 	return true;
@@ -1580,16 +1586,16 @@ bool P11DHDomainObj::init(OSObject *osobject)
 	if (!P11DomainObj::init(osobject)) return false;
 
 	// Create attributes
+	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4);
+	P11Attribute* attrBase = new P11AttrBase(osobject,P11Attribute::ck4);
 	P11Attribute* attrPrimeBits = new P11AttrPrimeBits(osobject);
-	P11Attribute* attrPrime = new P11AttrPrime(osobject);
-	P11Attribute* attrBase = new P11AttrBase(osobject);
 
 	// Initialize the attributes
 	if
 	(
-		!attrPrimeBits->init() ||
 		!attrPrime->init() ||
-		!attrBase->init()
+		!attrBase->init() ||
+		!attrPrimeBits->init()
 	)
 	{
 		ERROR_MSG("Could not initialize the attribute");
@@ -1597,9 +1603,9 @@ bool P11DHDomainObj::init(OSObject *osobject)
 	}
 
 	// Add them to the map
-	attributes[attrPrimeBits->getType()] = attrPrimeBits;
 	attributes[attrPrime->getType()] = attrPrime;
 	attributes[attrBase->getType()] = attrBase;
+	attributes[attrPrimeBits->getType()] = attrPrimeBits;
 
 	initialized = true;
 	return true;


### PR DESCRIPTION
Many objects are sharing the same attribute types, but the checks
are in some cases different.
