### PR TITLE
SOFTHSM-68: The OID issue also applies to GOST.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ NEWS for SoftHSM -- History of user visible changes
 SoftHSM develop
 
 * SOFTHSM-68: Display a better configure message when there is a 
-  version of Botan with a broken ECC/OID implementation.
+  version of Botan with a broken ECC/GOST/OID implementation.
 * SOFTHSM-70: Improved handling of the database backend.
 * SOFTHSM-71: Supporting Botan 1.11.
 * SOFTHSM-76: Do not generate RSA keys smaller than 1024 bit when 

--- a/m4/acx_botan_gost.m4
+++ b/m4/acx_botan_gost.m4
@@ -18,7 +18,19 @@ AC_DEFUN([ACX_BOTAN_GOST],[
 				Botan::LibraryInitializer::initialize();
 				const std::string name("gost_256A");
 				const Botan::OID oid(Botan::OIDS::lookup(name));
-				const Botan::EC_Group group(oid);
+				const Botan::EC_Group ecg(oid);
+				try {
+#if BOTAN_VERSION_MINOR == 11
+					const std::vector<Botan::byte> der =
+					    ecg.DER_encode(Botan::EC_DOMPAR_ENC_OID);
+#else
+					const Botan::SecureVector<Botan::byte> der =
+					    ecg.DER_encode(Botan::EC_DOMPAR_ENC_OID);
+#endif
+				} catch(...) {
+					return 1;
+				}
+
 				return 0;
 			}
 		]])
@@ -26,7 +38,11 @@ AC_DEFUN([ACX_BOTAN_GOST],[
 		AC_MSG_RESULT([Found GOST])
 	],[
 		AC_MSG_RESULT([Cannot find GOST])
-		AC_MSG_ERROR([Botan library has no GOST support])
+		AC_MSG_ERROR([
+Botan library has no valid GOST support. Please upgrade to a later version 
+of Botan, above or including version 1.10.6 or 1.11.5.
+Alternatively disable GOST support in SoftHSM with --disable-gost
+])
 	],[])
 	AC_LANG_POP([C++])
 


### PR DESCRIPTION
To build using Botan 1.10.5 or lower, you must disable both GOST and ECC.
