### PR TITLE
SOFTHSM-88: Accept NULL_PTR for pTemplate in C_GenerateKey

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ SoftHSM develop
 * SOFTHSM-76: Do not generate RSA keys smaller than 1024 bit when 
   using the Botan crypto backend.
 * SOFTHSM-83: Support CKA_VALUE_BITS for CKK_DH private key object.
+* SUPPORT-129: Possible to use an empty template in C_GenerateKey.
+  The class and key type are inherited from the generation mechanism.
+  Some mechanisms do however require a length attribute. [SOFTHSM-88]
 
 Bugfixes:
 * SOFTHSM-69: GOST did not work when you disabled ECC.

--- a/src/lib/test/SymmetricAlgorithmTests.h
+++ b/src/lib/test/SymmetricAlgorithmTests.h
@@ -42,12 +42,14 @@ class SymmetricAlgorithmTests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testAesEncryptDecrypt);
 	CPPUNIT_TEST(testDesEncryptDecrypt);
 	CPPUNIT_TEST(testAesWrapUnwrap);
+	CPPUNIT_TEST(testNullTemplate);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
 	void testAesEncryptDecrypt();
 	void testDesEncryptDecrypt();
 	void testAesWrapUnwrap();
+	void testNullTemplate();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
The changes are also applied to C_GenerateKeyPair, but all those mechanisms require some attributes as part of the key generation process. The difference is that it will return CKR_TEMPLATE_INCOMPLETE and not CKR_ARGUMENTS_BAD.
