### PR TITLE
SOFTHSM-91: Fix a warning from static code analysis.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,7 @@ Bugfixes:
 * SOFTHSM-69: GOST did not work when you disabled ECC.
 * SOFTHSM-78: Correct the attribute checks for a number of objects.
 * SOFTHSM-80: Prevent segfault in OpenSSL GOST HMAC code.
+* SOFTHSM-91: Fix a warning from static code analysis.
 * Fixed a number of memory leaks.
 
 

--- a/src/bin/util/softhsm2-util.cpp
+++ b/src/bin/util/softhsm2-util.cpp
@@ -555,7 +555,7 @@ char* hexStrToBin(char* objectID, int idLength, size_t* newLen)
 {
 	char* bytes = NULL;
 
-	if (idLength % 2 != 0)
+	if (idLength < 2 || idLength % 2 != 0)
 	{
 		fprintf(stderr, "ERROR: Invalid length on hex string.\n");
 		return NULL;


### PR DESCRIPTION
Fix malloc(0) warning in clang.
