### PR TITLE
Allow wrapping of objects with CKA_SENSITIVE=TRUE

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -4879,9 +4879,6 @@ CK_RV SoftHSM::C_WrapKey
 		return CKR_KEY_UNEXTRACTABLE;
 	if ((key->attributeExists(CKA_WRAP_WITH_TRUSTED) && key->getAttribute(CKA_WRAP_WITH_TRUSTED)->getBooleanValue()) && (!wrapKey->attributeExists(CKA_TRUSTED) || wrapKey->getAttribute(CKA_TRUSTED)->getBooleanValue() == false))
 		return CKR_KEY_NOT_WRAPPABLE;
-	// If a sensible key may be wrapped, it may be unwrapped as not sensible
-	if (key->attributeExists(CKA_SENSITIVE) && key->getAttribute(CKA_SENSITIVE)->getBooleanValue())
-		return CKR_KEY_NOT_WRAPPABLE;
 
 	// Check the class
 	CK_OBJECT_CLASS keyClass = key->getAttribute(CKA_CLASS)->getUnsignedLongValue();

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -351,7 +351,7 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 		{ CKA_KEY_TYPE, &genKeyType, sizeof(genKeyType) },
 		{ CKA_TOKEN, &bFalse, sizeof(bFalse) },
 		{ CKA_PRIVATE, &bTrue, sizeof(bTrue) },
-		{ CKA_SENSITIVE, &bFalse, sizeof(bFalse) },
+		{ CKA_SENSITIVE, &bTrue, sizeof(bTrue) }, // Wrapping is allowed even on sensitive objects
 		{ CKA_VALUE, keyPtr, keyLen }
 	};
 	CK_OBJECT_HANDLE hSecret;


### PR DESCRIPTION
This change was dicussed on http://lists.opendnssec.org/pipermail/softhsm-develop/2014-July/000002.html
