### PR TITLE
In Mutex, call MutexFactory wrapper functions instead of directly callin...

### DIFF
--- a/src/lib/common/MutexFactory.cpp
+++ b/src/lib/common/MutexFactory.cpp
@@ -43,7 +43,7 @@
 // Constructor
 Mutex::Mutex()
 {
-	isValid = (MutexFactory::i()->createMutex(&handle) == CKR_OK);	
+	isValid = (MutexFactory::i()->CreateMutex(&handle) == CKR_OK);
 }
 
 // Destructor
@@ -51,14 +51,14 @@ Mutex::~Mutex()
 {
 	if (isValid)
 	{
-		MutexFactory::i()->destroyMutex(handle);
+		MutexFactory::i()->DestroyMutex(handle);
 	}
 }
 
 // Lock the mutex
 bool Mutex::lock()
 {
-	return (isValid && (MutexFactory::i()->lockMutex(handle) == CKR_OK));
+	return (isValid && (MutexFactory::i()->LockMutex(handle) == CKR_OK));
 }
 	 
 // Unlock the mutex
@@ -66,7 +66,7 @@ void Mutex::unlock()
 {
 	if (isValid) 
 	{
-		MutexFactory::i()->unlockMutex(handle);
+		MutexFactory::i()->UnlockMutex(handle);
 	}
 }
 


### PR DESCRIPTION
...g the function pointers so the MutexFactory enabled bool has effect.

This was detected when testing initializing with mutex functions and then reinitializing without them and they where still called. V1 destroys the MutexFactory instance on finalize so its recreated on the next initialize, V2 does not do anything with the MutexFactory on finalize so the next initialize just disable it but since the Mutex called the functions pointers directly it did not have the desired effect. Maybe the Mutex class shouldn't be a friend to the MutexFactory class.