### PR TITLE
Return detailed error message to loadLibrary().

### DIFF
--- a/src/bin/common/library.cpp
+++ b/src/bin/common/library.cpp
@@ -40,12 +40,15 @@
 #endif
 
 // Load the PKCS#11 library
-CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle)
+CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle,
+				char **pErrMsg)
 {
 	CK_C_GetFunctionList pGetFunctionList = NULL;
 
 #if defined(HAVE_LOADLIBRARY)
 	HINSTANCE hDLL = NULL;
+	DWORD dw = NULL;
+	static const char errMsg[100];
 
 	// Load PKCS #11 library
 	if (module)
@@ -60,11 +63,24 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle)
 	if (hDLL == NULL)
 	{
 		// Failed to load the PKCS #11 library
+		dw = GetLastError();
+		snprintf(errMsg, sizeof(errMsg), "LoadLibraryA failed: 0x%x", dw);
+		pErrMsg = &errMsg;
 		return NULL;
+	}
+	else
+	{
+		pErrMsg = NULL;
 	}
 
 	// Retrieve the entry point for C_GetFunctionList
 	pGetFunctionList = (CK_C_GetFunctionList) GetProcAddress(hDLL, "C_GetFunctionList");
+	if (pGetFunctionList == NULL)
+	{
+		dw = GetLastError();
+		snprintf(errMsg, sizeof(errMsg), "getProcAddress failed: 0x%x", dw);
+		pErrMsg = &errMsg;
+	}
 
 	// Store the handle so we can FreeLibrary it later
 	*moduleHandle = hDLL;
@@ -82,7 +98,8 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle)
 		pDynLib = dlopen(DEFAULT_PKCS11_LIB, RTLD_NOW | RTLD_LOCAL);
 	}
 
-	if (pDynLib == NULL)
+	*pErrMsg = dlerror();
+	if (pDynLib == NULL || *pErrMsg != NULL)
 	{
 		// Failed to load the PKCS #11 library
 		return NULL;
@@ -93,6 +110,9 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle)
 
 	// Store the handle so we can dlclose it later
 	*moduleHandle = pDynLib;
+	*pErrMsg = dlerror();
+	if (*pErrMsg != NULL) // An error occured during dlsym()
+		return NULL;
 
 #else
 	fprintf(stderr, "ERROR: Not compiled with library support.\n");

--- a/src/bin/common/library.h
+++ b/src/bin/common/library.h
@@ -35,7 +35,8 @@
 
 #include "pkcs11.h"
 
-CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle);
+CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle,
+				char **pErrMsg);
 void unloadLibrary(void* moduleHandle);
 
 #endif // !_SOFTHSM_V2_BIN_LIBRARY_H

--- a/src/bin/migrate/softhsm2-migrate.cpp
+++ b/src/bin/migrate/softhsm2-migrate.cpp
@@ -109,6 +109,7 @@ int main(int argc, char* argv[])
 	char* userPIN = NULL;
 	char* module = NULL;
 	char* slot = NULL;
+	char *errMsg = NULL;
 	int noPublicKey = 0;
 
 	int result = 0;
@@ -157,10 +158,10 @@ int main(int argc, char* argv[])
 	}
 
 	// Get a pointer to the function list for PKCS#11 library
-	CK_C_GetFunctionList pGetFunctionList = loadLibrary(module, &moduleHandle);
+	CK_C_GetFunctionList pGetFunctionList = loadLibrary(module, &moduleHandle, &errMsg);
 	if (pGetFunctionList == NULL)
 	{
-		fprintf(stderr, "ERROR: Could not load the library.\n");
+		fprintf(stderr, "ERROR: Could not load the library: %s\n", errMsg);
 		exit(1);
 	}
 

--- a/src/bin/util/softhsm2-util.cpp
+++ b/src/bin/util/softhsm2-util.cpp
@@ -137,6 +137,7 @@ int main(int argc, char* argv[])
 	char* module = NULL;
 	char* objectID = NULL;
 	char* slot = NULL;
+	char* errMsg = NULL;
 	int forceExec = 0;
 	int freeToken = 0;
 	int noPublicKey = 0;
@@ -220,10 +221,10 @@ int main(int argc, char* argv[])
 	else
 	{
 		// Get a pointer to the function list for PKCS#11 library
-		CK_C_GetFunctionList pGetFunctionList = loadLibrary(module, &moduleHandle);
+		CK_C_GetFunctionList pGetFunctionList = loadLibrary(module, &moduleHandle, &errMsg);
 		if (!pGetFunctionList)
 		{
-			fprintf(stderr, "ERROR: Could not load the library.\n");
+			fprintf(stderr, "ERROR: Could not load the library: %s\n", errMsg);
 			exit(1);
 		}
 


### PR DESCRIPTION
This makes command line utilities much more useful when debugging library related problems. dlopen() version works fine on Fedora 21, LoadLibrary version is untested.