### PR TITLE
SOFTHSM-115: Fix static analysis warnings

### DIFF
--- a/src/bin/common/library.cpp
+++ b/src/bin/common/library.cpp
@@ -101,6 +101,8 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle,
 	*pErrMsg = dlerror();
 	if (pDynLib == NULL || *pErrMsg != NULL)
 	{
+		if (pDynLib != NULL) dlclose(pDynLib);
+
 		// Failed to load the PKCS #11 library
 		return NULL;
 	}
@@ -109,11 +111,16 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle,
 	pGetFunctionList = (CK_C_GetFunctionList) dlsym(pDynLib, "C_GetFunctionList");
 
 	// Store the handle so we can dlclose it later
-	*moduleHandle = pDynLib;
 	*pErrMsg = dlerror();
-	if (*pErrMsg != NULL) // An error occured during dlsym()
-		return NULL;
+	if (*pErrMsg != NULL)
+	{
+		dlclose(pDynLib);
 
+		// An error occured during dlsym()
+		return NULL;
+	}
+
+	*moduleHandle = pDynLib;
 #else
 	fprintf(stderr, "ERROR: Not compiled with library support.\n");
 

--- a/src/bin/util/softhsm2-util.cpp
+++ b/src/bin/util/softhsm2-util.cpp
@@ -232,8 +232,8 @@ int main(int argc, char* argv[])
 		(*pGetFunctionList)(&p11);
 
 		// Initialize the library
-		CK_RV rv = p11->C_Initialize(NULL_PTR);
-		if (rv != CKR_OK)
+		CK_RV p11rv = p11->C_Initialize(NULL_PTR);
+		if (p11rv != CKR_OK)
 		{
 			fprintf(stderr, "ERROR: Could not initialize the library.\n");
 			exit(1);

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -37,9 +37,9 @@
 #include <stdlib.h>
 
 // Constructor
-P11Attribute::P11Attribute(OSObject* osobject)
+P11Attribute::P11Attribute(OSObject* inobject)
 {
-	this->osobject = osobject;
+	osobject = inobject;
 	type = CKA_VENDOR_DEFINED;
 	size = (CK_ULONG)-1;
 	checks = 0;

--- a/src/lib/P11Attributes.h
+++ b/src/lib/P11Attributes.h
@@ -102,7 +102,7 @@ public:
 	};
 protected:
 	// Constructor
-	P11Attribute(OSObject* osobject);
+	P11Attribute(OSObject* inobject);
 
 	// The object
 	OSObject* osobject;
@@ -137,7 +137,7 @@ class P11AttrClass : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrClass(OSObject* osobject) : P11Attribute(osobject) { type = CKA_CLASS; size = sizeof(CK_OBJECT_CLASS); checks = ck1; }
+	P11AttrClass(OSObject* inobject) : P11Attribute(inobject) { type = CKA_CLASS; size = sizeof(CK_OBJECT_CLASS); checks = ck1; }
 
 protected:
 	// Set the default value of the attribute
@@ -155,7 +155,7 @@ class P11AttrKeyType : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrKeyType(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_KEY_TYPE; size = sizeof(CK_KEY_TYPE); checks = ck1|inchecks; }
+	P11AttrKeyType(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_KEY_TYPE; size = sizeof(CK_KEY_TYPE); checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -173,7 +173,7 @@ class P11AttrCertificateType : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrCertificateType(OSObject* osobject) : P11Attribute(osobject) { type = CKA_CERTIFICATE_TYPE; size = sizeof(CK_CERTIFICATE_TYPE); checks = ck1; }
+	P11AttrCertificateType(OSObject* inobject) : P11Attribute(inobject) { type = CKA_CERTIFICATE_TYPE; size = sizeof(CK_CERTIFICATE_TYPE); checks = ck1; }
 
 protected:
 	// Set the default value of the attribute
@@ -191,7 +191,7 @@ class P11AttrToken : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrToken(OSObject* osobject) : P11Attribute(osobject) { type = CKA_TOKEN; size = sizeof(CK_BBOOL); checks = ck17; }
+	P11AttrToken(OSObject* inobject) : P11Attribute(inobject) { type = CKA_TOKEN; size = sizeof(CK_BBOOL); checks = ck17; }
 
 protected:
 	// Set the default value of the attribute
@@ -209,7 +209,7 @@ class P11AttrPrivate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPrivate(OSObject* osobject) : P11Attribute(osobject) { type = CKA_PRIVATE; size = sizeof(CK_BBOOL); checks = ck17; }
+	P11AttrPrivate(OSObject* inobject) : P11Attribute(inobject) { type = CKA_PRIVATE; size = sizeof(CK_BBOOL); checks = ck17; }
 
 protected:
 	// Set the default value of the attribute
@@ -227,7 +227,7 @@ class P11AttrModifiable : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrModifiable(OSObject* osobject) : P11Attribute(osobject) { type = CKA_MODIFIABLE; size = sizeof(CK_BBOOL); checks = ck17; }
+	P11AttrModifiable(OSObject* inobject) : P11Attribute(inobject) { type = CKA_MODIFIABLE; size = sizeof(CK_BBOOL); checks = ck17; }
 
 protected:
 	// Set the default value of the attribute
@@ -245,7 +245,7 @@ class P11AttrLabel : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrLabel(OSObject* osobject) : P11Attribute(osobject) { type = CKA_LABEL;  checks = ck8; }
+	P11AttrLabel(OSObject* inobject) : P11Attribute(inobject) { type = CKA_LABEL;  checks = ck8; }
 
 protected:
 	// Set the default value of the attribute
@@ -260,7 +260,7 @@ class P11AttrCopyable : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrCopyable(OSObject* osobject) : P11Attribute(osobject) { type = CKA_COPYABLE; size = sizeof(CK_BBOOL); checks = ck12; }
+	P11AttrCopyable(OSObject* inobject) : P11Attribute(inobject) { type = CKA_COPYABLE; size = sizeof(CK_BBOOL); checks = ck12; }
 
 protected:
 	// Set the default value of the attribute
@@ -278,7 +278,7 @@ class P11AttrApplication : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrApplication(OSObject* osobject) : P11Attribute(osobject) { type = CKA_APPLICATION; checks = 0; }
+	P11AttrApplication(OSObject* inobject) : P11Attribute(inobject) { type = CKA_APPLICATION; checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -293,7 +293,7 @@ class P11AttrObjectID : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrObjectID(OSObject* osobject) : P11Attribute(osobject) { type = CKA_OBJECT_ID; checks = 0; }
+	P11AttrObjectID(OSObject* inobject) : P11Attribute(inobject) { type = CKA_OBJECT_ID; checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -308,7 +308,7 @@ class P11AttrCheckValue : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrCheckValue(OSObject* osobject) : P11Attribute(osobject) { type = CKA_CHECK_VALUE; checks = 0; }
+	P11AttrCheckValue(OSObject* inobject) : P11Attribute(inobject) { type = CKA_CHECK_VALUE; checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -323,7 +323,7 @@ class P11AttrID : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrID(OSObject* osobject) : P11Attribute(osobject) { type = CKA_ID; checks = ck8; }
+	P11AttrID(OSObject* inobject) : P11Attribute(inobject) { type = CKA_ID; checks = ck8; }
 
 protected:
 	// Set the default value of the attribute
@@ -338,7 +338,7 @@ class P11AttrValue : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrValue(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_VALUE; checks = inchecks; }
+	P11AttrValue(OSObject* inobject, CK_ULONG inchecks) : P11Attribute(inobject) { type = CKA_VALUE; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -356,7 +356,7 @@ class P11AttrSubject : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrSubject(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_SUBJECT; checks = inchecks; }
+	P11AttrSubject(OSObject* inobject, CK_ULONG inchecks) : P11Attribute(inobject) { type = CKA_SUBJECT; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -371,7 +371,7 @@ class P11AttrIssuer : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrIssuer(OSObject* osobject) : P11Attribute(osobject) { type = CKA_ISSUER; checks = ck8; }
+	P11AttrIssuer(OSObject* inobject) : P11Attribute(inobject) { type = CKA_ISSUER; checks = ck8; }
 
 protected:
 	// Set the default value of the attribute
@@ -386,7 +386,7 @@ class P11AttrTrusted : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrTrusted(OSObject* osobject) : P11Attribute(osobject) { type = CKA_TRUSTED; size = sizeof(CK_BBOOL); checks = ck10; }
+	P11AttrTrusted(OSObject* inobject) : P11Attribute(inobject) { type = CKA_TRUSTED; size = sizeof(CK_BBOOL); checks = ck10; }
 
 protected:
 	// Set the default value of the attribute
@@ -404,7 +404,7 @@ class P11AttrCertificateCategory : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrCertificateCategory(OSObject* osobject) : P11Attribute(osobject) { type = CKA_CERTIFICATE_CATEGORY; size = sizeof(CK_ULONG); checks = 0; }
+	P11AttrCertificateCategory(OSObject* inobject) : P11Attribute(inobject) { type = CKA_CERTIFICATE_CATEGORY; size = sizeof(CK_ULONG); checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -422,7 +422,7 @@ class P11AttrStartDate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrStartDate(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_START_DATE; checks = inchecks; }
+	P11AttrStartDate(OSObject* inobject, CK_ULONG inchecks) : P11Attribute(inobject) { type = CKA_START_DATE; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -440,7 +440,7 @@ class P11AttrEndDate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrEndDate(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_END_DATE; checks = inchecks; }
+	P11AttrEndDate(OSObject* inobject, CK_ULONG inchecks) : P11Attribute(inobject) { type = CKA_END_DATE; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -458,7 +458,7 @@ class P11AttrSerialNumber : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrSerialNumber(OSObject* osobject) : P11Attribute(osobject) { type = CKA_SERIAL_NUMBER; checks = ck8; }
+	P11AttrSerialNumber(OSObject* inobject) : P11Attribute(inobject) { type = CKA_SERIAL_NUMBER; checks = ck8; }
 
 protected:
 	// Set the default value of the attribute
@@ -473,7 +473,7 @@ class P11AttrURL : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrURL(OSObject* osobject) : P11Attribute(osobject) { type = CKA_URL; checks = ck15; }
+	P11AttrURL(OSObject* inobject) : P11Attribute(inobject) { type = CKA_URL; checks = ck15; }
 
 protected:
 	// Set the default value of the attribute
@@ -488,7 +488,7 @@ class P11AttrHashOfSubjectPublicKey : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrHashOfSubjectPublicKey(OSObject* osobject) : P11Attribute(osobject) { type = CKA_HASH_OF_SUBJECT_PUBLIC_KEY; checks = ck16; }
+	P11AttrHashOfSubjectPublicKey(OSObject* inobject) : P11Attribute(inobject) { type = CKA_HASH_OF_SUBJECT_PUBLIC_KEY; checks = ck16; }
 
 protected:
 	// Set the default value of the attribute
@@ -503,7 +503,7 @@ class P11AttrHashOfIssuerPublicKey : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrHashOfIssuerPublicKey(OSObject* osobject) : P11Attribute(osobject) { type = CKA_HASH_OF_ISSUER_PUBLIC_KEY; checks = ck16; }
+	P11AttrHashOfIssuerPublicKey(OSObject* inobject) : P11Attribute(inobject) { type = CKA_HASH_OF_ISSUER_PUBLIC_KEY; checks = ck16; }
 
 protected:
 	// Set the default value of the attribute
@@ -518,7 +518,7 @@ class P11AttrJavaMidpSecurityDomain : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrJavaMidpSecurityDomain(OSObject* osobject) : P11Attribute(osobject) { type = CKA_JAVA_MIDP_SECURITY_DOMAIN; size = sizeof(CK_ULONG); checks = 0; }
+	P11AttrJavaMidpSecurityDomain(OSObject* inobject) : P11Attribute(inobject) { type = CKA_JAVA_MIDP_SECURITY_DOMAIN; size = sizeof(CK_ULONG); checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -536,7 +536,7 @@ class P11AttrNameHashAlgorithm : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrNameHashAlgorithm(OSObject* osobject) : P11Attribute(osobject) { type = CKA_NAME_HASH_ALGORITHM; size = sizeof(CK_MECHANISM_TYPE); checks = 0; }
+	P11AttrNameHashAlgorithm(OSObject* inobject) : P11Attribute(inobject) { type = CKA_NAME_HASH_ALGORITHM; size = sizeof(CK_MECHANISM_TYPE); checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -554,7 +554,7 @@ class P11AttrDerive : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrDerive(OSObject* osobject) : P11Attribute(osobject) { type = CKA_DERIVE; size = sizeof(CK_BBOOL); checks = ck8;}
+	P11AttrDerive(OSObject* inobject) : P11Attribute(inobject) { type = CKA_DERIVE; size = sizeof(CK_BBOOL); checks = ck8;}
 
 protected:
 	// Set the default value of the attribute
@@ -572,7 +572,7 @@ class P11AttrEncrypt : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrEncrypt(OSObject* osobject) : P11Attribute(osobject) { type = CKA_ENCRYPT; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrEncrypt(OSObject* inobject) : P11Attribute(inobject) { type = CKA_ENCRYPT; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -590,7 +590,7 @@ class P11AttrVerify : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrVerify(OSObject* osobject) : P11Attribute(osobject) { type = CKA_VERIFY; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrVerify(OSObject* inobject) : P11Attribute(inobject) { type = CKA_VERIFY; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -608,7 +608,7 @@ class P11AttrVerifyRecover : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrVerifyRecover(OSObject* osobject) : P11Attribute(osobject) { type = CKA_VERIFY_RECOVER; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrVerifyRecover(OSObject* inobject) : P11Attribute(inobject) { type = CKA_VERIFY_RECOVER; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -626,7 +626,7 @@ class P11AttrWrap : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrWrap(OSObject* osobject) : P11Attribute(osobject) { type = CKA_WRAP; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrWrap(OSObject* inobject) : P11Attribute(inobject) { type = CKA_WRAP; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -644,7 +644,7 @@ class P11AttrDecrypt : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrDecrypt(OSObject* osobject) : P11Attribute(osobject) { type = CKA_DECRYPT; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrDecrypt(OSObject* inobject) : P11Attribute(inobject) { type = CKA_DECRYPT; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -662,7 +662,7 @@ class P11AttrSign : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrSign(OSObject* osobject) : P11Attribute(osobject) { type = CKA_SIGN; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrSign(OSObject* inobject) : P11Attribute(inobject) { type = CKA_SIGN; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -680,7 +680,7 @@ class P11AttrSignRecover : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrSignRecover(OSObject* osobject) : P11Attribute(osobject) { type = CKA_SIGN_RECOVER; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrSignRecover(OSObject* inobject) : P11Attribute(inobject) { type = CKA_SIGN_RECOVER; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -698,7 +698,7 @@ class P11AttrUnwrap : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrUnwrap(OSObject* osobject) : P11Attribute(osobject) { type = CKA_UNWRAP; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
+	P11AttrUnwrap(OSObject* inobject) : P11Attribute(inobject) { type = CKA_UNWRAP; size = sizeof(CK_BBOOL); checks = ck8|ck9; }
 
 protected:
 	// Set the default value of the attribute
@@ -716,7 +716,7 @@ class P11AttrLocal : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrLocal(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_LOCAL; size = sizeof(CK_BBOOL); checks = ck2|ck4|inchecks; }
+	P11AttrLocal(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_LOCAL; size = sizeof(CK_BBOOL); checks = ck2|ck4|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -734,7 +734,7 @@ class P11AttrKeyGenMechanism : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrKeyGenMechanism(OSObject* osobject) : P11Attribute(osobject) { type = CKA_KEY_GEN_MECHANISM; size = sizeof(CK_MECHANISM_TYPE); checks = ck2|ck4|ck6; }
+	P11AttrKeyGenMechanism(OSObject* inobject) : P11Attribute(inobject) { type = CKA_KEY_GEN_MECHANISM; size = sizeof(CK_MECHANISM_TYPE); checks = ck2|ck4|ck6; }
 
 protected:
 	// Set the default value of the attribute
@@ -752,7 +752,7 @@ class P11AttrAlwaysSensitive : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrAlwaysSensitive(OSObject* osobject) : P11Attribute(osobject) { type = CKA_ALWAYS_SENSITIVE; size = sizeof(CK_BBOOL); checks = ck2|ck4|ck6; }
+	P11AttrAlwaysSensitive(OSObject* inobject) : P11Attribute(inobject) { type = CKA_ALWAYS_SENSITIVE; size = sizeof(CK_BBOOL); checks = ck2|ck4|ck6; }
 
 protected:
 	// Set the default value of the attribute
@@ -770,7 +770,7 @@ class P11AttrNeverExtractable : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrNeverExtractable(OSObject* osobject) : P11Attribute(osobject) { type = CKA_NEVER_EXTRACTABLE; size = sizeof(CK_BBOOL); checks = ck2|ck4|ck6; }
+	P11AttrNeverExtractable(OSObject* inobject) : P11Attribute(inobject) { type = CKA_NEVER_EXTRACTABLE; size = sizeof(CK_BBOOL); checks = ck2|ck4|ck6; }
 
 protected:
 	// Set the default value of the attribute
@@ -788,7 +788,7 @@ class P11AttrSensitive : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrSensitive(OSObject* osobject) : P11Attribute(osobject) { type = CKA_SENSITIVE; size = sizeof(CK_BBOOL); checks = ck8|ck9|ck11; }
+	P11AttrSensitive(OSObject* inobject) : P11Attribute(inobject) { type = CKA_SENSITIVE; size = sizeof(CK_BBOOL); checks = ck8|ck9|ck11; }
 
 protected:
 	// Set the default value of the attribute
@@ -806,7 +806,7 @@ class P11AttrExtractable : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrExtractable(OSObject* osobject) : P11Attribute(osobject) { type = CKA_EXTRACTABLE; size = sizeof(CK_BBOOL); checks = ck8|ck9|ck12; }
+	P11AttrExtractable(OSObject* inobject) : P11Attribute(inobject) { type = CKA_EXTRACTABLE; size = sizeof(CK_BBOOL); checks = ck8|ck9|ck12; }
 
 protected:
 	// Set the default value of the attribute
@@ -824,7 +824,7 @@ class P11AttrWrapWithTrusted : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrWrapWithTrusted(OSObject* osobject) : P11Attribute(osobject) { type = CKA_WRAP_WITH_TRUSTED; size = sizeof(CK_BBOOL); checks = ck11; }
+	P11AttrWrapWithTrusted(OSObject* inobject) : P11Attribute(inobject) { type = CKA_WRAP_WITH_TRUSTED; size = sizeof(CK_BBOOL); checks = ck11; }
 
 protected:
 	// Set the default value of the attribute
@@ -842,7 +842,7 @@ class P11AttrAlwaysAuthenticate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrAlwaysAuthenticate(OSObject* osobject) : P11Attribute(osobject) { type = CKA_ALWAYS_AUTHENTICATE; size = sizeof(CK_BBOOL); checks = 0; }
+	P11AttrAlwaysAuthenticate(OSObject* inobject) : P11Attribute(inobject) { type = CKA_ALWAYS_AUTHENTICATE; size = sizeof(CK_BBOOL); checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -860,7 +860,7 @@ class P11AttrModulus : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrModulus(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_MODULUS; checks = ck1|ck4|inchecks; }
+	P11AttrModulus(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_MODULUS; checks = ck1|ck4|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -878,7 +878,7 @@ class P11AttrPublicExponent : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPublicExponent(OSObject* osobject, CK_ULONG inchecks) : P11Attribute(osobject) { type = CKA_PUBLIC_EXPONENT; checks = inchecks; }
+	P11AttrPublicExponent(OSObject* inobject, CK_ULONG inchecks) : P11Attribute(inobject) { type = CKA_PUBLIC_EXPONENT; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -893,7 +893,7 @@ class P11AttrPrivateExponent : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPrivateExponent(OSObject* osobject) : P11Attribute(osobject) { type = CKA_PRIVATE_EXPONENT; checks = ck1|ck4|ck6|ck7; }
+	P11AttrPrivateExponent(OSObject* inobject) : P11Attribute(inobject) { type = CKA_PRIVATE_EXPONENT; checks = ck1|ck4|ck6|ck7; }
 
 protected:
 	// Set the default value of the attribute
@@ -908,7 +908,7 @@ class P11AttrPrime1 : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPrime1(OSObject* osobject) : P11Attribute(osobject) { type = CKA_PRIME_1; checks = ck4|ck6|ck7; }
+	P11AttrPrime1(OSObject* inobject) : P11Attribute(inobject) { type = CKA_PRIME_1; checks = ck4|ck6|ck7; }
 
 protected:
 	// Set the default value of the attribute
@@ -923,7 +923,7 @@ class P11AttrPrime2 : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPrime2(OSObject* osobject) : P11Attribute(osobject) { type = CKA_PRIME_2; checks = ck4|ck6|ck7; }
+	P11AttrPrime2(OSObject* inobject) : P11Attribute(inobject) { type = CKA_PRIME_2; checks = ck4|ck6|ck7; }
 
 protected:
 	// Set the default value of the attribute
@@ -938,7 +938,7 @@ class P11AttrExponent1 : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrExponent1(OSObject* osobject) : P11Attribute(osobject) { type = CKA_EXPONENT_1; checks = ck4|ck6|ck7; }
+	P11AttrExponent1(OSObject* inobject) : P11Attribute(inobject) { type = CKA_EXPONENT_1; checks = ck4|ck6|ck7; }
 
 protected:
 	// Set the default value of the attribute
@@ -953,7 +953,7 @@ class P11AttrExponent2 : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrExponent2(OSObject* osobject) : P11Attribute(osobject) { type = CKA_EXPONENT_2; checks = ck4|ck6|ck7; }
+	P11AttrExponent2(OSObject* inobject) : P11Attribute(inobject) { type = CKA_EXPONENT_2; checks = ck4|ck6|ck7; }
 
 protected:
 	// Set the default value of the attribute
@@ -968,7 +968,7 @@ class P11AttrCoefficient : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrCoefficient(OSObject* osobject) : P11Attribute(osobject) { type = CKA_COEFFICIENT; checks = ck4|ck6|ck7; }
+	P11AttrCoefficient(OSObject* inobject) : P11Attribute(inobject) { type = CKA_COEFFICIENT; checks = ck4|ck6|ck7; }
 
 protected:
 	// Set the default value of the attribute
@@ -983,7 +983,7 @@ class P11AttrModulusBits : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrModulusBits(OSObject* osobject) : P11Attribute(osobject) { type = CKA_MODULUS_BITS; size = sizeof(CK_ULONG); checks = ck2|ck3;}
+	P11AttrModulusBits(OSObject* inobject) : P11Attribute(inobject) { type = CKA_MODULUS_BITS; size = sizeof(CK_ULONG); checks = ck2|ck3;}
 
 protected:
 	// Set the default value of the attribute
@@ -1001,7 +1001,7 @@ class P11AttrPrime : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPrime(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_PRIME; checks = ck1|inchecks; }
+	P11AttrPrime(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_PRIME; checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1019,7 +1019,7 @@ class P11AttrSubPrime : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrSubPrime(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_SUBPRIME; checks = ck1|inchecks; }
+	P11AttrSubPrime(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_SUBPRIME; checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1034,7 +1034,7 @@ class P11AttrBase : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrBase(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_BASE; checks = ck1|inchecks; }
+	P11AttrBase(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_BASE; checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1049,7 +1049,7 @@ class P11AttrPrimeBits : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrPrimeBits(OSObject* osobject) : P11Attribute(osobject) { type = CKA_PRIME_BITS; size = sizeof(CK_ULONG); checks = ck2|ck3;}
+	P11AttrPrimeBits(OSObject* inobject) : P11Attribute(inobject) { type = CKA_PRIME_BITS; size = sizeof(CK_ULONG); checks = ck2|ck3;}
 
 protected:
 	// Set the default value of the attribute
@@ -1067,7 +1067,7 @@ class P11AttrValueBits : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrValueBits(OSObject* osobject) : P11Attribute(osobject) { type = CKA_VALUE_BITS; size = sizeof(CK_ULONG); checks = ck2|ck6;}
+	P11AttrValueBits(OSObject* inobject) : P11Attribute(inobject) { type = CKA_VALUE_BITS; size = sizeof(CK_ULONG); checks = ck2|ck6;}
 
 protected:
 	// Set the default value of the attribute
@@ -1085,7 +1085,7 @@ class P11AttrEcParams : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrEcParams(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_EC_PARAMS; checks = ck1|inchecks; }
+	P11AttrEcParams(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_EC_PARAMS; checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1100,7 +1100,7 @@ class P11AttrEcPoint : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrEcPoint(OSObject* osobject) : P11Attribute(osobject) { type = CKA_EC_POINT; checks = ck1|ck4; }
+	P11AttrEcPoint(OSObject* inobject) : P11Attribute(inobject) { type = CKA_EC_POINT; checks = ck1|ck4; }
 
 protected:
 	// Set the default value of the attribute
@@ -1115,7 +1115,7 @@ class P11AttrGostR3410Params : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrGostR3410Params(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_GOSTR3410_PARAMS; checks = ck1|inchecks; }
+	P11AttrGostR3410Params(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_GOSTR3410_PARAMS; checks = ck1|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1130,7 +1130,7 @@ class P11AttrGostR3411Params : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrGostR3411Params(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_GOSTR3411_PARAMS; checks = ck1|ck8|inchecks; }
+	P11AttrGostR3411Params(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_GOSTR3411_PARAMS; checks = ck1|ck8|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1145,7 +1145,7 @@ class P11AttrGost28147Params : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrGost28147Params(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_GOST28147_PARAMS; checks = inchecks; }
+	P11AttrGost28147Params(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_GOST28147_PARAMS; checks = inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1160,7 +1160,7 @@ class P11AttrValueLen : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrValueLen(OSObject* osobject, CK_ULONG inchecks = 0) : P11Attribute(osobject) { type = CKA_VALUE_LEN; size = sizeof(CK_ULONG); checks = ck2|ck3|inchecks; }
+	P11AttrValueLen(OSObject* inobject, CK_ULONG inchecks = 0) : P11Attribute(inobject) { type = CKA_VALUE_LEN; size = sizeof(CK_ULONG); checks = ck2|ck3|inchecks; }
 
 protected:
 	// Set the default value of the attribute
@@ -1178,7 +1178,7 @@ class P11AttrWrapTemplate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrWrapTemplate(OSObject* osobject) : P11Attribute(osobject) { type = CKA_WRAP_TEMPLATE; checks = 0; }
+	P11AttrWrapTemplate(OSObject* inobject) : P11Attribute(inobject) { type = CKA_WRAP_TEMPLATE; checks = 0; }
 
 protected:
 	// Set the default value of the attribute
@@ -1196,7 +1196,7 @@ class P11AttrUnwrapTemplate : public P11Attribute
 {
 public:
 	// Constructor
-	P11AttrUnwrapTemplate(OSObject* osobject) : P11Attribute(osobject) { type = CKA_UNWRAP_TEMPLATE; checks = 0; }
+	P11AttrUnwrapTemplate(OSObject* inobject) : P11Attribute(inobject) { type = CKA_UNWRAP_TEMPLATE; checks = 0; }
 
 protected:
 	// Set the default value of the attribute

--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -1440,11 +1440,11 @@ bool P11GenericSecretKeyObj::init(OSObject *inobject)
 }
 
 // Set Key Type
-bool P11GenericSecretKeyObj::setKeyType(CK_KEY_TYPE keytype)
+bool P11GenericSecretKeyObj::setKeyType(CK_KEY_TYPE inKeytype)
 {
 	if (!initialized)
 	{
-		this->keytype = keytype;
+		keytype = inKeytype;
 		return true;
 	}
 	else
@@ -1454,7 +1454,7 @@ bool P11GenericSecretKeyObj::setKeyType(CK_KEY_TYPE keytype)
 // Get Key Type
 CK_KEY_TYPE P11GenericSecretKeyObj::getKeyType()
 {
-	return this->keytype;
+	return keytype;
 }
 
 // Constructor
@@ -1542,11 +1542,11 @@ bool P11DESSecretKeyObj::init(OSObject *inobject)
 }
 
 // Set Key Type
-bool P11DESSecretKeyObj::setKeyType(CK_KEY_TYPE keytype)
+bool P11DESSecretKeyObj::setKeyType(CK_KEY_TYPE inKeytype)
 {
 	if (!initialized)
 	{
-		this->keytype = keytype;
+		keytype = inKeytype;
 		return true;
 	}
 	else
@@ -1556,7 +1556,7 @@ bool P11DESSecretKeyObj::setKeyType(CK_KEY_TYPE keytype)
 // Get Key Type
 CK_KEY_TYPE P11DESSecretKeyObj::getKeyType()
 {
-	return this->keytype;
+	return keytype;
 }
 
 // Constructor

--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -61,12 +61,12 @@ P11Object::~P11Object()
 }
 
 // Add attributes
-bool P11Object::init(OSObject *osobject)
+bool P11Object::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	this->osobject = osobject;
+	osobject = inobject;
 
 	// Create attributes
 	P11Attribute* attrClass = new P11AttrClass(osobject);
@@ -307,19 +307,19 @@ P11DataObj::P11DataObj()
 }
 
 // Add attributes
-bool P11DataObj::init(OSObject *osobject)
+bool P11DataObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
 	// Set default values for attributes that will be introduced in the parent
-	if (!osobject->attributeExists(CKA_CLASS) || osobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_DATA) {
+	if (!inobject->attributeExists(CKA_CLASS) || inobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_DATA) {
 		OSAttribute setClass((unsigned long)CKO_DATA);
-		osobject->setAttribute(CKA_CLASS, setClass);
+		inobject->setAttribute(CKA_CLASS, setClass);
 	}
 
 	// Create parent
-	if (!P11Object::init(osobject)) return false;
+	if (!P11Object::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrApplication = new P11AttrApplication(osobject);
@@ -361,19 +361,19 @@ P11CertificateObj::P11CertificateObj()
 }
 
 // Add attributes
-bool P11CertificateObj::init(OSObject *osobject)
+bool P11CertificateObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
 	// Set default values for attributes that will be introduced in the parent
-	if (!osobject->attributeExists(CKA_CLASS) || osobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_CERTIFICATE) {
+	if (!inobject->attributeExists(CKA_CLASS) || inobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_CERTIFICATE) {
 		OSAttribute setClass((unsigned long)CKO_CERTIFICATE);
-		osobject->setAttribute(CKA_CLASS, setClass);
+		inobject->setAttribute(CKA_CLASS, setClass);
 	}
 
 	// Create parent
-	if (!P11Object::init(osobject)) return false;
+	if (!P11Object::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrCertificateType = new P11AttrCertificateType(osobject);
@@ -428,19 +428,19 @@ P11X509CertificateObj::P11X509CertificateObj()
 }
 
 // Add attributes
-bool P11X509CertificateObj::init(OSObject *osobject)
+bool P11X509CertificateObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
 	// Set default values for attributes that will be introduced in the parent
-	if (!osobject->attributeExists(CKA_CERTIFICATE_TYPE) || osobject->getUnsignedLongValue(CKA_CERTIFICATE_TYPE, CKC_VENDOR_DEFINED) != CKC_X_509) {
+	if (!inobject->attributeExists(CKA_CERTIFICATE_TYPE) || inobject->getUnsignedLongValue(CKA_CERTIFICATE_TYPE, CKC_VENDOR_DEFINED) != CKC_X_509) {
 		OSAttribute setCertType((unsigned long)CKC_X_509);
-		osobject->setAttribute(CKA_CERTIFICATE_TYPE, setCertType);
+		inobject->setAttribute(CKA_CERTIFICATE_TYPE, setCertType);
 	}
 
 	// Create parent
-	if (!P11CertificateObj::init(osobject)) return false;
+	if (!P11CertificateObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrSubject = new P11AttrSubject(osobject,P11Attribute::ck1);
@@ -505,19 +505,19 @@ P11OpenPGPPublicKeyObj::P11OpenPGPPublicKeyObj()
 }
 
 // Add attributes
-bool P11OpenPGPPublicKeyObj::init(OSObject *osobject)
+bool P11OpenPGPPublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
 	// Set default values for attributes that will be introduced in the parent
-	if (!osobject->attributeExists(CKA_CERTIFICATE_TYPE) || osobject->getUnsignedLongValue(CKA_CERTIFICATE_TYPE, CKC_VENDOR_DEFINED) != CKC_OPENPGP) {
+	if (!inobject->attributeExists(CKA_CERTIFICATE_TYPE) || inobject->getUnsignedLongValue(CKA_CERTIFICATE_TYPE, CKC_VENDOR_DEFINED) != CKC_OPENPGP) {
 		OSAttribute setCertType((unsigned long)CKC_OPENPGP);
-		osobject->setAttribute(CKA_CERTIFICATE_TYPE, setCertType);
+		inobject->setAttribute(CKA_CERTIFICATE_TYPE, setCertType);
 	}
 
 	// Create parent
-	if (!P11CertificateObj::init(osobject)) return false;
+	if (!P11CertificateObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrSubject = new P11AttrSubject(osobject,P11Attribute::ck1);
@@ -566,13 +566,13 @@ P11KeyObj::P11KeyObj()
 }
 
 // Add attributes
-bool P11KeyObj::init(OSObject *osobject)
+bool P11KeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
 	// Create parent
-	if (!P11Object::init(osobject)) return false;
+	if (!P11Object::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrKeyType = new P11AttrKeyType(osobject,P11Attribute::ck5);
@@ -627,18 +627,18 @@ P11PublicKeyObj::P11PublicKeyObj()
 }
 
 // Add attributes
-bool P11PublicKeyObj::init(OSObject *osobject)
+bool P11PublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_CLASS) || osobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_PUBLIC_KEY) {
+	if (!inobject->attributeExists(CKA_CLASS) || inobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_PUBLIC_KEY) {
 		OSAttribute setClass((unsigned long)CKO_PUBLIC_KEY);
-		osobject->setAttribute(CKA_CLASS, setClass);
+		inobject->setAttribute(CKA_CLASS, setClass);
 	}
 
 	// Create parent
-	if (!P11KeyObj::init(osobject)) return false;
+	if (!P11KeyObj::init(inobject)) return false;
 
 	if (initialized) return true;
 
@@ -694,18 +694,18 @@ P11RSAPublicKeyObj::P11RSAPublicKeyObj()
 }
 
 // Add attributes
-bool P11RSAPublicKeyObj::init(OSObject *osobject)
+bool P11RSAPublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_RSA) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_RSA) {
 		OSAttribute setKeyType((unsigned long)CKK_RSA);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11PublicKeyObj::init(osobject)) return false;
+	if (!P11PublicKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrModulus = new P11AttrModulus(osobject);
@@ -743,18 +743,18 @@ P11DSAPublicKeyObj::P11DSAPublicKeyObj()
 }
 
 // Add attributes
-bool P11DSAPublicKeyObj::init(OSObject *osobject)
+bool P11DSAPublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DSA) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DSA) {
 		OSAttribute setKeyType((unsigned long)CKK_DSA);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11PublicKeyObj::init(osobject)) return false;
+	if (!P11PublicKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck3);
@@ -796,18 +796,18 @@ P11ECPublicKeyObj::P11ECPublicKeyObj()
 }
 
 // Add attributes
-bool P11ECPublicKeyObj::init(OSObject *osobject)
+bool P11ECPublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_EC) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_EC) {
 		OSAttribute setKeyType((unsigned long)CKK_EC);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11PublicKeyObj::init(osobject)) return false;
+	if (!P11PublicKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrEcParams = new P11AttrEcParams(osobject,P11Attribute::ck3);
@@ -841,18 +841,18 @@ P11DHPublicKeyObj::P11DHPublicKeyObj()
 }
 
 // Add attributes
-bool P11DHPublicKeyObj::init(OSObject *osobject)
+bool P11DHPublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DH) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DH) {
 		OSAttribute setKeyType((unsigned long)CKK_DH);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11PublicKeyObj::init(osobject)) return false;
+	if (!P11PublicKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck3);
@@ -890,18 +890,18 @@ P11GOSTPublicKeyObj::P11GOSTPublicKeyObj()
 }
 
 // Add attributes
-bool P11GOSTPublicKeyObj::init(OSObject *osobject)
+bool P11GOSTPublicKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_GOSTR3410) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_GOSTR3410) {
 		OSAttribute setKeyType((unsigned long)CKK_GOSTR3410);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11PublicKeyObj::init(osobject)) return false;
+	if (!P11PublicKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4);
@@ -943,17 +943,18 @@ P11PrivateKeyObj::P11PrivateKeyObj()
 }
 
 // Add attributes
-bool P11PrivateKeyObj::init(OSObject *osobject)
+bool P11PrivateKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_CLASS) || osobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_PRIVATE_KEY) {
+	if (!inobject->attributeExists(CKA_CLASS) || inobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_PRIVATE_KEY) {
 		OSAttribute setClass((unsigned long)CKO_PRIVATE_KEY);
-		osobject->setAttribute(CKA_CLASS, setClass);
+		inobject->setAttribute(CKA_CLASS, setClass);
 	}
 
 	// Create parent
-	if (!P11KeyObj::init(osobject)) return false;
+	if (!P11KeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrSubject = new P11AttrSubject(osobject,P11Attribute::ck8);
@@ -1028,17 +1029,18 @@ P11RSAPrivateKeyObj::P11RSAPrivateKeyObj()
 }
 
 // Add attributes
-bool P11RSAPrivateKeyObj::init(OSObject *osobject)
+bool P11RSAPrivateKeyObj::init(OSObject *inobject)
 {
-	// Create parent
-	if (!P11PrivateKeyObj::init(osobject)) return false;
+	if (initialized) return true;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_RSA) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_RSA) {
 		OSAttribute setKeyType((unsigned long)CKK_RSA);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
-	if (initialized) return true;
+	// Create parent
+	if (!P11PrivateKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrModulus = new P11AttrModulus(osobject,P11Attribute::ck6);
@@ -1096,17 +1098,18 @@ P11DSAPrivateKeyObj::P11DSAPrivateKeyObj()
 }
 
 // Add attributes
-bool P11DSAPrivateKeyObj::init(OSObject *osobject)
+bool P11DSAPrivateKeyObj::init(OSObject *inobject)
 {
-	// Create parent
-	if (!P11PrivateKeyObj::init(osobject)) return false;
+	if (initialized) return true;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DSA) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DSA) {
 		OSAttribute setKeyType((unsigned long)CKK_DSA);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
-	if (initialized) return true;
+	// Create parent
+	if (!P11PrivateKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4|P11Attribute::ck6);
@@ -1148,17 +1151,18 @@ P11ECPrivateKeyObj::P11ECPrivateKeyObj()
 }
 
 // Add attributes
-bool P11ECPrivateKeyObj::init(OSObject *osobject)
+bool P11ECPrivateKeyObj::init(OSObject *inobject)
 {
-	// Create parent
-	if (!P11PrivateKeyObj::init(osobject)) return false;
+	if (initialized) return true;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_EC) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_EC) {
 		OSAttribute setKeyType((unsigned long)CKK_EC);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
-	if (initialized) return true;
+	// Create parent
+	if (!P11PrivateKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrEcParams = new P11AttrEcParams(osobject,P11Attribute::ck4|P11Attribute::ck6);
@@ -1192,17 +1196,18 @@ P11DHPrivateKeyObj::P11DHPrivateKeyObj()
 }
 
 // Add attributes
-bool P11DHPrivateKeyObj::init(OSObject *osobject)
+bool P11DHPrivateKeyObj::init(OSObject *inobject)
 {
-	// Create parent
-	if (!P11PrivateKeyObj::init(osobject)) return false;
+	if (initialized) return true;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DH) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DH) {
 		OSAttribute setKeyType((unsigned long)CKK_DH);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
-	if (initialized) return true;
+	// Create parent
+	if (!P11PrivateKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4|P11Attribute::ck6);
@@ -1244,17 +1249,18 @@ P11GOSTPrivateKeyObj::P11GOSTPrivateKeyObj()
 }
 
 // Add attributes
-bool P11GOSTPrivateKeyObj::init(OSObject *osobject)
+bool P11GOSTPrivateKeyObj::init(OSObject *inobject)
 {
-	// Create parent
-	if (!P11PrivateKeyObj::init(osobject)) return false;
+	if (initialized) return true;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_GOSTR3410) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_GOSTR3410) {
 		OSAttribute setKeyType((unsigned long)CKK_GOSTR3410);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
-	if (initialized) return true;
+	// Create parent
+	if (!P11PrivateKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
@@ -1296,18 +1302,18 @@ P11SecretKeyObj::P11SecretKeyObj()
 }
 
 // Add attributes
-bool P11SecretKeyObj::init(OSObject *osobject)
+bool P11SecretKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_CLASS) || osobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_SECRET_KEY) {
+	if (!inobject->attributeExists(CKA_CLASS) || inobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_SECRET_KEY) {
 		OSAttribute setClass((unsigned long)CKO_SECRET_KEY);
-		osobject->setAttribute(CKA_CLASS, setClass);
+		inobject->setAttribute(CKA_CLASS, setClass);
 	}
 
 	// Create parent
-	if (!P11KeyObj::init(osobject)) return false;
+	if (!P11KeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrSensitive = new P11AttrSensitive(osobject);
@@ -1395,18 +1401,18 @@ P11GenericSecretKeyObj::P11GenericSecretKeyObj()
 }
 
 // Add attributes
-bool P11GenericSecretKeyObj::init(OSObject *osobject)
+bool P11GenericSecretKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != keytype) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != keytype) {
 		OSAttribute setKeyType(keytype);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11SecretKeyObj::init(osobject)) return false;
+	if (!P11SecretKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
@@ -1458,18 +1464,18 @@ P11AESSecretKeyObj::P11AESSecretKeyObj()
 }
 
 // Add attributes
-bool P11AESSecretKeyObj::init(OSObject *osobject)
+bool P11AESSecretKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_AES) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_AES) {
 		OSAttribute setKeyType((unsigned long)CKK_AES);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11SecretKeyObj::init(osobject)) return false;
+	if (!P11SecretKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
@@ -1504,18 +1510,18 @@ P11DESSecretKeyObj::P11DESSecretKeyObj()
 }
 
 // Add attributes
-bool P11DESSecretKeyObj::init(OSObject *osobject)
+bool P11DESSecretKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != keytype) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != keytype) {
 		OSAttribute setKeyType(keytype);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11SecretKeyObj::init(osobject)) return false;
+	if (!P11SecretKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
@@ -1560,18 +1566,18 @@ P11GOSTSecretKeyObj::P11GOSTSecretKeyObj()
 }
 
 // Add attributes
-bool P11GOSTSecretKeyObj::init(OSObject *osobject)
+bool P11GOSTSecretKeyObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_GOST28147) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_GOST28147) {
 		OSAttribute setKeyType((unsigned long)CKK_GOST28147);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11SecretKeyObj::init(osobject)) return false;
+	if (!P11SecretKeyObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
@@ -1605,18 +1611,18 @@ P11DomainObj::P11DomainObj()
 }
 
 // Add attributes
-bool P11DomainObj::init(OSObject *osobject)
+bool P11DomainObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_CLASS) || osobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_DOMAIN_PARAMETERS) {
+	if (!inobject->attributeExists(CKA_CLASS) || inobject->getUnsignedLongValue(CKA_CLASS, CKO_VENDOR_DEFINED) != CKO_DOMAIN_PARAMETERS) {
 		OSAttribute setClass((unsigned long)CKO_DOMAIN_PARAMETERS);
-		osobject->setAttribute(CKA_CLASS, setClass);
+		inobject->setAttribute(CKA_CLASS, setClass);
 	}
 
 	// Create parent
-	if (!P11Object::init(osobject)) return false;
+	if (!P11Object::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrKeyType = new P11AttrKeyType(osobject);
@@ -1650,18 +1656,18 @@ P11DSADomainObj::P11DSADomainObj()
 }
 
 // Add attributes
-bool P11DSADomainObj::init(OSObject *osobject)
+bool P11DSADomainObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DSA) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DSA) {
 		OSAttribute setKeyType((unsigned long)CKK_DSA);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11DomainObj::init(osobject)) return false;
+	if (!P11DomainObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4);
@@ -1703,18 +1709,18 @@ P11DHDomainObj::P11DHDomainObj()
 }
 
 // Add attributes
-bool P11DHDomainObj::init(OSObject *osobject)
+bool P11DHDomainObj::init(OSObject *inobject)
 {
 	if (initialized) return true;
-	if (osobject == NULL) return false;
+	if (inobject == NULL) return false;
 
-	if (!osobject->attributeExists(CKA_KEY_TYPE) || osobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DH) {
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_DH) {
 		OSAttribute setKeyType((unsigned long)CKK_DH);
-		osobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
 	}
 
 	// Create parent
-	if (!P11DomainObj::init(osobject)) return false;
+	if (!P11DomainObj::init(inobject)) return false;
 
 	// Create attributes
 	P11Attribute* attrPrime = new P11AttrPrime(osobject,P11Attribute::ck4);

--- a/src/lib/P11Objects.h
+++ b/src/lib/P11Objects.h
@@ -57,7 +57,7 @@ protected:
 
 public:
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -81,7 +81,7 @@ public:
 	P11DataObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -94,7 +94,7 @@ protected:
 	P11CertificateObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 	bool initialized;
 };
 
@@ -105,7 +105,7 @@ public:
 	P11X509CertificateObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -118,7 +118,7 @@ public:
 	P11OpenPGPPublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -131,7 +131,7 @@ protected:
 	P11KeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 	bool initialized;
 };
 
@@ -142,7 +142,7 @@ protected:
 	P11PublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 	bool initialized;
 };
 
@@ -153,7 +153,7 @@ public:
 	P11RSAPublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -166,7 +166,7 @@ public:
 	P11DSAPublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -179,7 +179,7 @@ public:
 	P11ECPublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -192,7 +192,7 @@ public:
 	P11DHPublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -205,7 +205,7 @@ public:
 	P11GOSTPublicKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -218,7 +218,7 @@ protected:
 	P11PrivateKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 	bool initialized;
 };
 
@@ -229,7 +229,7 @@ public:
 	P11RSAPrivateKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -242,7 +242,7 @@ public:
 	P11DSAPrivateKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -255,7 +255,7 @@ public:
 	P11ECPrivateKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -268,7 +268,7 @@ public:
 	P11DHPrivateKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -281,7 +281,7 @@ public:
 	P11GOSTPrivateKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -294,7 +294,7 @@ protected:
 	P11SecretKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 	bool initialized;
 };
 
@@ -305,7 +305,7 @@ public:
 	P11GenericSecretKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 	// Better than multiply subclasses
 	virtual bool setKeyType(CK_KEY_TYPE keytype);
@@ -323,7 +323,7 @@ public:
 	P11AESSecretKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -336,7 +336,7 @@ public:
 	P11DESSecretKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 	// Better than multiply subclasses
 	virtual bool setKeyType(CK_KEY_TYPE keytype);
@@ -354,7 +354,7 @@ public:
 	P11GOSTSecretKeyObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 
 protected:
 	bool initialized;
@@ -367,7 +367,7 @@ protected:
 	P11DomainObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 	bool initialized;
 };
 
@@ -378,7 +378,7 @@ public:
 	P11DSADomainObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 protected:
 	bool initialized;
 };
@@ -390,7 +390,7 @@ public:
 	P11DHDomainObj();
 
 	// Add attributes
-	virtual bool init(OSObject *osobject);
+	virtual bool init(OSObject *inobject);
 protected:
 	bool initialized;
 };

--- a/src/lib/P11Objects.h
+++ b/src/lib/P11Objects.h
@@ -308,7 +308,7 @@ public:
 	virtual bool init(OSObject *inobject);
 
 	// Better than multiply subclasses
-	virtual bool setKeyType(CK_KEY_TYPE keytype);
+	virtual bool setKeyType(CK_KEY_TYPE inKeytype);
 	virtual CK_KEY_TYPE getKeyType();
 
 protected:
@@ -339,7 +339,7 @@ public:
 	virtual bool init(OSObject *inobject);
 
 	// Better than multiply subclasses
-	virtual bool setKeyType(CK_KEY_TYPE keytype);
+	virtual bool setKeyType(CK_KEY_TYPE inKeytype);
 	virtual CK_KEY_TYPE getKeyType();
 
 protected:

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -6239,9 +6239,9 @@ CK_RV SoftHSM::generateAES
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* key = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* oskey = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (key) key->destroyObject();
+			if (oskey) oskey->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -6377,9 +6377,9 @@ CK_RV SoftHSM::generateDES
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* key = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* oskey = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (key) key->destroyObject();
+			if (oskey) oskey->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -6515,9 +6515,9 @@ CK_RV SoftHSM::generateDES2
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* key = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* oskey = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (key) key->destroyObject();
+			if (oskey) oskey->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -6653,9 +6653,9 @@ CK_RV SoftHSM::generateDES3
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* key = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* oskey = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (key) key->destroyObject();
+			if (oskey) oskey->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -6932,17 +6932,17 @@ CK_RV SoftHSM::generateRSA
 	{
 		if (*phPrivateKey != CK_INVALID_HANDLE)
 		{
-			OSObject* priv = (OSObject*)handleManager->getObject(*phPrivateKey);
+			OSObject* ospriv = (OSObject*)handleManager->getObject(*phPrivateKey);
 			handleManager->destroyObject(*phPrivateKey);
-			if (priv) priv->destroyObject();
+			if (ospriv) ospriv->destroyObject();
 			*phPrivateKey = CK_INVALID_HANDLE;
 		}
 
 		if (*phPublicKey != CK_INVALID_HANDLE)
 		{
-			OSObject* pub = (OSObject*)handleManager->getObject(*phPublicKey);
+			OSObject* ospub = (OSObject*)handleManager->getObject(*phPublicKey);
 			handleManager->destroyObject(*phPublicKey);
-			if (pub) pub->destroyObject();
+			if (ospub) ospub->destroyObject();
 			*phPublicKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -7152,28 +7152,28 @@ CK_RV SoftHSM::generateDSA
 				bOK = bOK && osobject->setAttribute(CKA_NEVER_EXTRACTABLE, bNeverExtractable);
 
 				// DSA Private Key Attributes
-				ByteString prime;
-				ByteString subprime;
-				ByteString generator;
-				ByteString value;
+				ByteString bPrime;
+				ByteString bSubprime;
+				ByteString bGenerator;
+				ByteString bValue;
 				if (isPrivateKeyPrivate)
 				{
-					token->encrypt(priv->getP(), prime);
-					token->encrypt(priv->getQ(), subprime);
-					token->encrypt(priv->getG(), generator);
-					token->encrypt(priv->getX(), value);
+					token->encrypt(priv->getP(), bPrime);
+					token->encrypt(priv->getQ(), bSubprime);
+					token->encrypt(priv->getG(), bGenerator);
+					token->encrypt(priv->getX(), bValue);
 				}
 				else
 				{
-					prime = priv->getP();
-					subprime = priv->getQ();
-					generator = priv->getG();
-					value = priv->getX();
+					bPrime = priv->getP();
+					bSubprime = priv->getQ();
+					bGenerator = priv->getG();
+					bValue = priv->getX();
 				}
-				bOK = bOK && osobject->setAttribute(CKA_PRIME, prime);
-				bOK = bOK && osobject->setAttribute(CKA_SUBPRIME, subprime);
-				bOK = bOK && osobject->setAttribute(CKA_BASE, generator);
-				bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+				bOK = bOK && osobject->setAttribute(CKA_PRIME, bPrime);
+				bOK = bOK && osobject->setAttribute(CKA_SUBPRIME, bSubprime);
+				bOK = bOK && osobject->setAttribute(CKA_BASE, bGenerator);
+				bOK = bOK && osobject->setAttribute(CKA_VALUE, bValue);
 
 				if (bOK)
 					bOK = osobject->commitTransaction();
@@ -7196,17 +7196,17 @@ CK_RV SoftHSM::generateDSA
 	{
 		if (*phPrivateKey != CK_INVALID_HANDLE)
 		{
-			OSObject* priv = (OSObject*)handleManager->getObject(*phPrivateKey);
+			OSObject* ospriv = (OSObject*)handleManager->getObject(*phPrivateKey);
 			handleManager->destroyObject(*phPrivateKey);
-			if (priv) priv->destroyObject();
+			if (ospriv) ospriv->destroyObject();
 			*phPrivateKey = CK_INVALID_HANDLE;
 		}
 
 		if (*phPublicKey != CK_INVALID_HANDLE)
 		{
-			OSObject* pub = (OSObject*)handleManager->getObject(*phPublicKey);
+			OSObject* ospub = (OSObject*)handleManager->getObject(*phPublicKey);
 			handleManager->destroyObject(*phPublicKey);
-			if (pub) pub->destroyObject();
+			if (ospub) ospub->destroyObject();
 			*phPublicKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -7378,9 +7378,9 @@ CK_RV SoftHSM::generateDSAParameters
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* params = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* osparams = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (params) params->destroyObject();
+			if (osparams) osparams->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -7616,17 +7616,17 @@ CK_RV SoftHSM::generateEC
 	{
 		if (*phPrivateKey != CK_INVALID_HANDLE)
 		{
-			OSObject* priv = (OSObject*)handleManager->getObject(*phPrivateKey);
+			OSObject* ospriv = (OSObject*)handleManager->getObject(*phPrivateKey);
 			handleManager->destroyObject(*phPrivateKey);
-			if (priv) priv->destroyObject();
+			if (ospriv) ospriv->destroyObject();
 			*phPrivateKey = CK_INVALID_HANDLE;
 		}
 
 		if (*phPublicKey != CK_INVALID_HANDLE)
 		{
-			OSObject* pub = (OSObject*)handleManager->getObject(*phPublicKey);
+			OSObject* ospub = (OSObject*)handleManager->getObject(*phPublicKey);
 			handleManager->destroyObject(*phPublicKey);
-			if (pub) pub->destroyObject();
+			if (ospub) ospub->destroyObject();
 			*phPublicKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -7846,24 +7846,24 @@ CK_RV SoftHSM::generateDH
 				bOK = bOK && osobject->setAttribute(CKA_NEVER_EXTRACTABLE, bNeverExtractable);
 
 				// DH Private Key Attributes
-				ByteString prime;
-				ByteString generator;
-				ByteString value;
+				ByteString bPrime;
+				ByteString bGenerator;
+				ByteString bValue;
 				if (isPrivateKeyPrivate)
 				{
-					token->encrypt(priv->getP(), prime);
-					token->encrypt(priv->getG(), generator);
-					token->encrypt(priv->getX(), value);
+					token->encrypt(priv->getP(), bPrime);
+					token->encrypt(priv->getG(), bGenerator);
+					token->encrypt(priv->getX(), bValue);
 				}
 				else
 				{
-					prime = priv->getP();
-					generator = priv->getG();
-					value = priv->getX();
+					bPrime = priv->getP();
+					bGenerator = priv->getG();
+					bValue = priv->getX();
 				}
-				bOK = bOK && osobject->setAttribute(CKA_PRIME, prime);
-				bOK = bOK && osobject->setAttribute(CKA_BASE, generator);
-				bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+				bOK = bOK && osobject->setAttribute(CKA_PRIME, bPrime);
+				bOK = bOK && osobject->setAttribute(CKA_BASE, bGenerator);
+				bOK = bOK && osobject->setAttribute(CKA_VALUE, bValue);
 
 				if (bitLen == 0)
 				{
@@ -7891,17 +7891,17 @@ CK_RV SoftHSM::generateDH
 	{
 		if (*phPrivateKey != CK_INVALID_HANDLE)
 		{
-			OSObject* priv = (OSObject*)handleManager->getObject(*phPrivateKey);
+			OSObject* ospriv = (OSObject*)handleManager->getObject(*phPrivateKey);
 			handleManager->destroyObject(*phPrivateKey);
-			if (priv) priv->destroyObject();
+			if (ospriv) ospriv->destroyObject();
 			*phPrivateKey = CK_INVALID_HANDLE;
 		}
 
 		if (*phPublicKey != CK_INVALID_HANDLE)
 		{
-			OSObject* pub = (OSObject*)handleManager->getObject(*phPublicKey);
+			OSObject* ospub = (OSObject*)handleManager->getObject(*phPublicKey);
 			handleManager->destroyObject(*phPublicKey);
-			if (pub) pub->destroyObject();
+			if (ospub) ospub->destroyObject();
 			*phPublicKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -8053,9 +8053,9 @@ CK_RV SoftHSM::generateDHParameters
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* params = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* osparams = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (params) params->destroyObject();
+			if (osparams) osparams->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -8307,17 +8307,17 @@ CK_RV SoftHSM::generateGOST
 	{
 		if (*phPrivateKey != CK_INVALID_HANDLE)
 		{
-			OSObject* priv = (OSObject*)handleManager->getObject(*phPrivateKey);
+			OSObject* ospriv = (OSObject*)handleManager->getObject(*phPrivateKey);
 			handleManager->destroyObject(*phPrivateKey);
-			if (priv) priv->destroyObject();
+			if (ospriv) ospriv->destroyObject();
 			*phPrivateKey = CK_INVALID_HANDLE;
 		}
 
 		if (*phPublicKey != CK_INVALID_HANDLE)
 		{
-			OSObject* pub = (OSObject*)handleManager->getObject(*phPublicKey);
+			OSObject* ospub = (OSObject*)handleManager->getObject(*phPublicKey);
 			handleManager->destroyObject(*phPublicKey);
-			if (pub) pub->destroyObject();
+			if (ospub) ospub->destroyObject();
 			*phPublicKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -8526,9 +8526,9 @@ CK_RV SoftHSM::deriveDH
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* secret = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* ossecret = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (secret) secret->destroyObject();
+			if (ossecret) ossecret->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}
@@ -8761,9 +8761,9 @@ CK_RV SoftHSM::deriveECDH
 	{
 		if (*phKey != CK_INVALID_HANDLE)
 		{
-			OSObject* secret = (OSObject*)handleManager->getObject(*phKey);
+			OSObject* ossecret = (OSObject*)handleManager->getObject(*phKey);
 			handleManager->destroyObject(*phKey);
-			if (secret) secret->destroyObject();
+			if (ossecret) ossecret->destroyObject();
 			*phKey = CK_INVALID_HANDLE;
 		}
 	}

--- a/src/lib/common/Configuration.cpp
+++ b/src/lib/common/Configuration.cpp
@@ -163,9 +163,9 @@ bool Configuration::reload()
 }
 
 // Reload the configuration using the specified configuration loader
-bool Configuration::reload(ConfigLoader* configLoader)
+bool Configuration::reload(ConfigLoader* inConfigLoader)
 {
-	this->configLoader = configLoader;
+	configLoader = inConfigLoader;
 
 	return reload();
 }

--- a/src/lib/common/Configuration.h
+++ b/src/lib/common/Configuration.h
@@ -93,7 +93,7 @@ public:
 	bool reload();
 
 	// Reload the configuration using the specified configuration loader
-	bool reload(ConfigLoader* configLoader);
+	bool reload(ConfigLoader* inConfigLoader);
 
 private:
 	Configuration();

--- a/src/lib/common/MutexFactory.cpp
+++ b/src/lib/common/MutexFactory.cpp
@@ -75,17 +75,17 @@ void Mutex::unlock()
  *****************************************************************************/
 
 // Constructor
-MutexLocker::MutexLocker(Mutex* mutex)
+MutexLocker::MutexLocker(Mutex* inMutex)
 {
-	this->mutex = mutex;
+	mutex = inMutex;
 
-	if (this->mutex != NULL) this->mutex->lock();
+	if (mutex != NULL) mutex->lock();
 }
 
 // Destructor
 MutexLocker::~MutexLocker()
 {
-	if (this->mutex != NULL) this->mutex->unlock();
+	if (mutex != NULL) mutex->unlock();
 }
 
 /*****************************************************************************
@@ -139,24 +139,24 @@ void MutexFactory::recycleMutex(Mutex* mutex)
 }
 
 // Set the function pointers
-void MutexFactory::setCreateMutex(CK_CREATEMUTEX createMutex)
+void MutexFactory::setCreateMutex(CK_CREATEMUTEX inCreateMutex)
 {
-	this->createMutex = createMutex;
+	createMutex = inCreateMutex;
 }
 
-void MutexFactory::setDestroyMutex(CK_DESTROYMUTEX destroyMutex)
+void MutexFactory::setDestroyMutex(CK_DESTROYMUTEX inDestroyMutex)
 {
-	this->destroyMutex = destroyMutex;
+	destroyMutex = inDestroyMutex;
 }
 
-void MutexFactory::setLockMutex(CK_LOCKMUTEX lockMutex)
+void MutexFactory::setLockMutex(CK_LOCKMUTEX inLockMutex)
 {
-	this->lockMutex = lockMutex;
+	lockMutex = inLockMutex;
 }
 
-void MutexFactory::setUnlockMutex(CK_UNLOCKMUTEX unlockMutex)
+void MutexFactory::setUnlockMutex(CK_UNLOCKMUTEX inUnlockMutex)
 {
-	this->unlockMutex = unlockMutex;
+	unlockMutex = inUnlockMutex;
 }
 
 void MutexFactory::enable()

--- a/src/lib/common/MutexFactory.h
+++ b/src/lib/common/MutexFactory.h
@@ -65,7 +65,7 @@ class MutexLocker
 {
 public:
 	// Constructor
-	MutexLocker(Mutex* mutex);
+	MutexLocker(Mutex* inMutex);
 
 	// Destructor
 	virtual ~MutexLocker();
@@ -91,10 +91,10 @@ public:
 	void recycleMutex(Mutex* mutex);
 
 	// Set the function pointers
-	void setCreateMutex(CK_CREATEMUTEX createMutex);
-	void setDestroyMutex(CK_DESTROYMUTEX destroyMutex);
-	void setLockMutex(CK_LOCKMUTEX lockMutex);
-	void setUnlockMutex(CK_UNLOCKMUTEX unlockMutex);
+	void setCreateMutex(CK_CREATEMUTEX inCreateMutex);
+	void setDestroyMutex(CK_DESTROYMUTEX inDestroyMutex);
+	void setLockMutex(CK_LOCKMUTEX inLockMutex);
+	void setUnlockMutex(CK_UNLOCKMUTEX inUnlockMutex);
 
 	// Enable/disable mutex handling
 	void enable();

--- a/src/lib/crypto/AESKey.h
+++ b/src/lib/crypto/AESKey.h
@@ -41,7 +41,7 @@ class AESKey : public SymmetricKey
 {
 public:
 	// Base constructor
-	AESKey(size_t bitLen = 0) : SymmetricKey(bitLen) { }
+	AESKey(size_t inBitLen = 0) : SymmetricKey(inBitLen) { }
 };
 
 #endif // !SOFTHSM_V2_AESKEY_H

--- a/src/lib/crypto/BotanDHPrivateKey.cpp
+++ b/src/lib/crypto/BotanDHPrivateKey.cpp
@@ -45,12 +45,12 @@
 #if BOTAN_VERSION_MINOR == 11
 std::vector<Botan::byte> BotanDH_PrivateKey::public_value() const
 {
-	return this->impl->public_value();
+	return impl->public_value();
 }
 #else
 Botan::MemoryVector<Botan::byte> BotanDH_PrivateKey::public_value() const
 {
-	return this->impl->public_value();
+	return impl->public_value();
 }
 #endif
 
@@ -113,26 +113,26 @@ BotanDHPrivateKey::~BotanDHPrivateKey()
 /*static*/ const char* BotanDHPrivateKey::type = "Botan DH Private Key";
 
 // Set from Botan representation
-void BotanDHPrivateKey::setFromBotan(const BotanDH_PrivateKey* dh)
+void BotanDHPrivateKey::setFromBotan(const BotanDH_PrivateKey* inDH)
 {
-	ByteString p = BotanUtil::bigInt2ByteString(dh->impl->group_p());
-	setP(p);
-	ByteString g = BotanUtil::bigInt2ByteString(dh->impl->group_g());
-	setG(g);
-	ByteString x = BotanUtil::bigInt2ByteString(dh->impl->get_x());
-	setX(x);
+	ByteString inP = BotanUtil::bigInt2ByteString(inDH->impl->group_p());
+	setP(inP);
+	ByteString inG = BotanUtil::bigInt2ByteString(inDH->impl->group_g());
+	setG(inG);
+	ByteString inX = BotanUtil::bigInt2ByteString(inDH->impl->get_x());
+	setX(inX);
 }
 
 // Check if the key is of the given type
-bool BotanDHPrivateKey::isOfType(const char* type)
+bool BotanDHPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanDHPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DH private key components
-void BotanDHPrivateKey::setX(const ByteString& x)
+void BotanDHPrivateKey::setX(const ByteString& inX)
 {
-	DHPrivateKey::setX(x);
+	DHPrivateKey::setX(inX);
 
 	if (dh)
 	{
@@ -142,9 +142,9 @@ void BotanDHPrivateKey::setX(const ByteString& x)
 }
 
 // Setters for the DH public key components
-void BotanDHPrivateKey::setP(const ByteString& p)
+void BotanDHPrivateKey::setP(const ByteString& inP)
 {
-	DHPrivateKey::setP(p);
+	DHPrivateKey::setP(inP);
 
 	if (dh)
 	{
@@ -153,9 +153,9 @@ void BotanDHPrivateKey::setP(const ByteString& p)
 	}
 }
 
-void BotanDHPrivateKey::setG(const ByteString& g)
+void BotanDHPrivateKey::setG(const ByteString& inG)
 {
-	DHPrivateKey::setG(g);
+	DHPrivateKey::setG(inG);
 
 	if (dh)
 	{
@@ -262,9 +262,9 @@ BotanDH_PrivateKey* BotanDHPrivateKey::getBotanKey()
 void BotanDHPrivateKey::createBotanKey()
 {
 	// y is not needed
-	if (this->p.size() != 0 &&
-	    this->g.size() != 0 &&
-	    this->x.size() != 0)
+	if (p.size() != 0 &&
+	    g.size() != 0 &&
+	    x.size() != 0)
 	{
 		if (dh)
 		{
@@ -276,9 +276,9 @@ void BotanDHPrivateKey::createBotanKey()
 		{
 			BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
 			dh = new BotanDH_PrivateKey(*rng->getRNG(),
-				Botan::DL_Group(BotanUtil::byteString2bigInt(this->p),
-						BotanUtil::byteString2bigInt(this->g)),
-				BotanUtil::byteString2bigInt(this->x));
+				Botan::DL_Group(BotanUtil::byteString2bigInt(p),
+						BotanUtil::byteString2bigInt(g)),
+				BotanUtil::byteString2bigInt(x));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanDHPrivateKey.h
+++ b/src/lib/crypto/BotanDHPrivateKey.h
@@ -75,7 +75,7 @@ public:
 	BotanDHPrivateKey();
 
 	BotanDHPrivateKey(const BotanDH_PrivateKey* inDH);
-	
+
 	// Destructor
 	virtual ~BotanDHPrivateKey();
 
@@ -83,14 +83,14 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DH private key components
-	virtual void setX(const ByteString& x);
+	virtual void setX(const ByteString& inX);
 
 	// Setters for the DH public key components
-	virtual void setP(const ByteString& p);
-	virtual void setG(const ByteString& g);
+	virtual void setP(const ByteString& inP);
+	virtual void setG(const ByteString& inG);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -99,7 +99,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const BotanDH_PrivateKey* dh);
+	virtual void setFromBotan(const BotanDH_PrivateKey* inDH);
 
 	// Retrieve the Botan representation of the key
 	BotanDH_PrivateKey* getBotanKey();

--- a/src/lib/crypto/BotanDHPublicKey.cpp
+++ b/src/lib/crypto/BotanDHPublicKey.cpp
@@ -59,26 +59,26 @@ BotanDHPublicKey::~BotanDHPublicKey()
 /*static*/ const char* BotanDHPublicKey::type = "Botan DH Public Key";
 
 // Set from Botan representation
-void BotanDHPublicKey::setFromBotan(const Botan::DH_PublicKey* dh)
+void BotanDHPublicKey::setFromBotan(const Botan::DH_PublicKey* inDH)
 {
-	ByteString p = BotanUtil::bigInt2ByteString(dh->group_p());
-	setP(p);
-	ByteString g = BotanUtil::bigInt2ByteString(dh->group_g());
-	setG(g);
-	ByteString y = BotanUtil::bigInt2ByteString(dh->get_y());
-	setY(y);
+	ByteString inP = BotanUtil::bigInt2ByteString(inDH->group_p());
+	setP(inP);
+	ByteString inG = BotanUtil::bigInt2ByteString(inDH->group_g());
+	setG(inG);
+	ByteString inY = BotanUtil::bigInt2ByteString(inDH->get_y());
+	setY(inY);
 }
 
 // Check if the key is of the given type
-bool BotanDHPublicKey::isOfType(const char* type)
+bool BotanDHPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanDHPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DH public key components
-void BotanDHPublicKey::setP(const ByteString& p)
+void BotanDHPublicKey::setP(const ByteString& inP)
 {
-	DHPublicKey::setP(p);
+	DHPublicKey::setP(inP);
 
 	if (dh)
 	{
@@ -87,9 +87,9 @@ void BotanDHPublicKey::setP(const ByteString& p)
 	}
 }
 
-void BotanDHPublicKey::setG(const ByteString& g)
+void BotanDHPublicKey::setG(const ByteString& inG)
 {
-	DHPublicKey::setG(g);
+	DHPublicKey::setG(inG);
 
 	if (dh)
 	{
@@ -98,9 +98,9 @@ void BotanDHPublicKey::setG(const ByteString& g)
 	}
 }
 
-void BotanDHPublicKey::setY(const ByteString& y)
+void BotanDHPublicKey::setY(const ByteString& inY)
 {
-	DHPublicKey::setY(y);
+	DHPublicKey::setY(inY);
 
 	if (dh)
 	{
@@ -119,12 +119,12 @@ Botan::DH_PublicKey* BotanDHPublicKey::getBotanKey()
 
 	return dh;
 }
- 
+
 // Create the Botan representation of the key
 void BotanDHPublicKey::createBotanKey()
 {
 	// We actually do not need to check q, since it can be set zero
-	if (this->p.size() != 0 && this->y.size() != 0)
+	if (p.size() != 0 && y.size() != 0)
 	{
 		if (dh)
 		{
@@ -134,9 +134,9 @@ void BotanDHPublicKey::createBotanKey()
 
 		try
 		{
-			dh = new Botan::DH_PublicKey(Botan::DL_Group(BotanUtil::byteString2bigInt(this->p),
-							BotanUtil::byteString2bigInt(this->g)),
-							BotanUtil::byteString2bigInt(this->y));
+			dh = new Botan::DH_PublicKey(Botan::DL_Group(BotanUtil::byteString2bigInt(p),
+							BotanUtil::byteString2bigInt(g)),
+							BotanUtil::byteString2bigInt(y));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanDHPublicKey.h
+++ b/src/lib/crypto/BotanDHPublicKey.h
@@ -42,9 +42,9 @@ class BotanDHPublicKey : public DHPublicKey
 public:
 	// Constructors
 	BotanDHPublicKey();
-	
+
 	BotanDHPublicKey(const Botan::DH_PublicKey* inDH);
-	
+
 	// Destructor
 	virtual ~BotanDHPublicKey();
 
@@ -52,15 +52,15 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DH public key components
-	virtual void setP(const ByteString& p);
-	virtual void setG(const ByteString& g);
-	virtual void setY(const ByteString& y);
+	virtual void setP(const ByteString& inP);
+	virtual void setG(const ByteString& inG);
+	virtual void setY(const ByteString& inY);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::DH_PublicKey* dh);
+	virtual void setFromBotan(const Botan::DH_PublicKey* inDH);
 
 	// Retrieve the Botan representation of the key
 	Botan::DH_PublicKey* getBotanKey();

--- a/src/lib/crypto/BotanDSAPrivateKey.cpp
+++ b/src/lib/crypto/BotanDSAPrivateKey.cpp
@@ -65,28 +65,28 @@ BotanDSAPrivateKey::~BotanDSAPrivateKey()
 /*static*/ const char* BotanDSAPrivateKey::type = "Botan DSA Private Key";
 
 // Set from Botan representation
-void BotanDSAPrivateKey::setFromBotan(const Botan::DSA_PrivateKey* dsa)
+void BotanDSAPrivateKey::setFromBotan(const Botan::DSA_PrivateKey* inDSA)
 {
-	ByteString p = BotanUtil::bigInt2ByteString(dsa->group_p());
-	setP(p);
-	ByteString q = BotanUtil::bigInt2ByteString(dsa->group_q());
-	setQ(q);
-	ByteString g = BotanUtil::bigInt2ByteString(dsa->group_g());
-	setG(g);
-	ByteString x = BotanUtil::bigInt2ByteString(dsa->get_x());
-	setX(x);
+	ByteString inP = BotanUtil::bigInt2ByteString(inDSA->group_p());
+	setP(inP);
+	ByteString inQ = BotanUtil::bigInt2ByteString(inDSA->group_q());
+	setQ(inQ);
+	ByteString inG = BotanUtil::bigInt2ByteString(inDSA->group_g());
+	setG(inG);
+	ByteString inX = BotanUtil::bigInt2ByteString(inDSA->get_x());
+	setX(inX);
 }
 
 // Check if the key is of the given type
-bool BotanDSAPrivateKey::isOfType(const char* type)
+bool BotanDSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanDSAPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DSA private key components
-void BotanDSAPrivateKey::setX(const ByteString& x)
+void BotanDSAPrivateKey::setX(const ByteString& inX)
 {
-	DSAPrivateKey::setX(x);
+	DSAPrivateKey::setX(inX);
 
 	if (dsa)
 	{
@@ -97,9 +97,9 @@ void BotanDSAPrivateKey::setX(const ByteString& x)
 
 
 // Setters for the DSA domain parameters
-void BotanDSAPrivateKey::setP(const ByteString& p)
+void BotanDSAPrivateKey::setP(const ByteString& inP)
 {
-	DSAPrivateKey::setP(p);
+	DSAPrivateKey::setP(inP);
 
 	if (dsa)
 	{
@@ -108,9 +108,9 @@ void BotanDSAPrivateKey::setP(const ByteString& p)
 	}
 }
 
-void BotanDSAPrivateKey::setQ(const ByteString& q)
+void BotanDSAPrivateKey::setQ(const ByteString& inQ)
 {
-	DSAPrivateKey::setQ(q);
+	DSAPrivateKey::setQ(inQ);
 
 	if (dsa)
 	{
@@ -119,9 +119,9 @@ void BotanDSAPrivateKey::setQ(const ByteString& q)
 	}
 }
 
-void BotanDSAPrivateKey::setG(const ByteString& g)
+void BotanDSAPrivateKey::setG(const ByteString& inG)
 {
-	DSAPrivateKey::setG(g);
+	DSAPrivateKey::setG(inG);
 
 	if (dsa)
 	{
@@ -210,12 +210,12 @@ void BotanDSAPrivateKey::createBotanKey()
 {
 	// y is not needed
 	// Todo: Either q or x is needed. Both is not needed
-	if (this->p.size() != 0 &&
-	    this->q.size() != 0 &&
-	    this->g.size() != 0 &&
-	    this->x.size() != 0)
+	if (p.size() != 0 &&
+	    q.size() != 0 &&
+	    g.size() != 0 &&
+	    x.size() != 0)
 	{
-		if (dsa)   
+		if (dsa)
 		{
 			delete dsa;
 			dsa = NULL;
@@ -225,10 +225,10 @@ void BotanDSAPrivateKey::createBotanKey()
 		{
 			BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
 			dsa = new Botan::DSA_PrivateKey(*rng->getRNG(),
-							Botan::DL_Group(BotanUtil::byteString2bigInt(this->p),
-							BotanUtil::byteString2bigInt(this->q),
-							BotanUtil::byteString2bigInt(this->g)),
-							BotanUtil::byteString2bigInt(this->x));
+							Botan::DL_Group(BotanUtil::byteString2bigInt(p),
+							BotanUtil::byteString2bigInt(q),
+							BotanUtil::byteString2bigInt(g)),
+							BotanUtil::byteString2bigInt(x));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanDSAPrivateKey.h
+++ b/src/lib/crypto/BotanDSAPrivateKey.h
@@ -44,7 +44,7 @@ public:
 	BotanDSAPrivateKey();
 
 	BotanDSAPrivateKey(const Botan::DSA_PrivateKey* inDSA);
-	
+
 	// Destructor
 	virtual ~BotanDSAPrivateKey();
 
@@ -52,15 +52,15 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DSA private key components
-	virtual void setX(const ByteString& x);
+	virtual void setX(const ByteString& inX);
 
 	// Setters for the DSA domain parameters
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setG(const ByteString& g);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setG(const ByteString& inG);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -69,7 +69,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::DSA_PrivateKey* dsa);
+	virtual void setFromBotan(const Botan::DSA_PrivateKey* inDSA);
 
 	// Retrieve the Botan representation of the key
 	Botan::DSA_PrivateKey* getBotanKey();

--- a/src/lib/crypto/BotanDSAPublicKey.cpp
+++ b/src/lib/crypto/BotanDSAPublicKey.cpp
@@ -59,28 +59,28 @@ BotanDSAPublicKey::~BotanDSAPublicKey()
 /*static*/ const char* BotanDSAPublicKey::type = "Botan DSA Public Key";
 
 // Set from Botan representation
-void BotanDSAPublicKey::setFromBotan(const Botan::DSA_PublicKey* dsa)
+void BotanDSAPublicKey::setFromBotan(const Botan::DSA_PublicKey* inDSA)
 {
-	ByteString p = BotanUtil::bigInt2ByteString(dsa->group_p());
-	setP(p);
-	ByteString q = BotanUtil::bigInt2ByteString(dsa->group_q());
-	setQ(q);
-	ByteString g = BotanUtil::bigInt2ByteString(dsa->group_g());
-	setG(g);
-	ByteString y = BotanUtil::bigInt2ByteString(dsa->get_y());
-	setY(y);
+	ByteString inP = BotanUtil::bigInt2ByteString(inDSA->group_p());
+	setP(inP);
+	ByteString inQ = BotanUtil::bigInt2ByteString(inDSA->group_q());
+	setQ(inQ);
+	ByteString inG = BotanUtil::bigInt2ByteString(inDSA->group_g());
+	setG(inG);
+	ByteString inY = BotanUtil::bigInt2ByteString(inDSA->get_y());
+	setY(inY);
 }
 
 // Check if the key is of the given type
-bool BotanDSAPublicKey::isOfType(const char* type)
+bool BotanDSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanDSAPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DSA public key components
-void BotanDSAPublicKey::setP(const ByteString& p)
+void BotanDSAPublicKey::setP(const ByteString& inP)
 {
-	DSAPublicKey::setP(p);
+	DSAPublicKey::setP(inP);
 
 	if (dsa)
 	{
@@ -89,9 +89,9 @@ void BotanDSAPublicKey::setP(const ByteString& p)
 	}
 }
 
-void BotanDSAPublicKey::setQ(const ByteString& q)
+void BotanDSAPublicKey::setQ(const ByteString& inQ)
 {
-	DSAPublicKey::setQ(q);
+	DSAPublicKey::setQ(inQ);
 
 	if (dsa)
 	{
@@ -100,9 +100,9 @@ void BotanDSAPublicKey::setQ(const ByteString& q)
 	}
 }
 
-void BotanDSAPublicKey::setG(const ByteString& g)
+void BotanDSAPublicKey::setG(const ByteString& inG)
 {
-	DSAPublicKey::setG(g);
+	DSAPublicKey::setG(inG);
 
 	if (dsa)
 	{
@@ -111,9 +111,9 @@ void BotanDSAPublicKey::setG(const ByteString& g)
 	}
 }
 
-void BotanDSAPublicKey::setY(const ByteString& y)
+void BotanDSAPublicKey::setY(const ByteString& inY)
 {
-	DSAPublicKey::setY(y);
+	DSAPublicKey::setY(inY);
 
 	if (dsa)
 	{
@@ -132,14 +132,14 @@ Botan::DSA_PublicKey* BotanDSAPublicKey::getBotanKey()
 
 	return dsa;
 }
- 
+
 // Create the Botan representation of the key
 void BotanDSAPublicKey::createBotanKey()
 {
 	// We actually do not need to check q, since it can be set zero
-	if (this->p.size() != 0 &&
-	    this->g.size() != 0 &&
-	    this->y.size() != 0)
+	if (p.size() != 0 &&
+	    g.size() != 0 &&
+	    y.size() != 0)
 	{
 		if (dsa)
 		{
@@ -149,10 +149,10 @@ void BotanDSAPublicKey::createBotanKey()
 
 		try
 		{
-			dsa = new Botan::DSA_PublicKey(Botan::DL_Group(BotanUtil::byteString2bigInt(this->p),
-							BotanUtil::byteString2bigInt(this->q),
-							BotanUtil::byteString2bigInt(this->g)),
-							BotanUtil::byteString2bigInt(this->y));
+			dsa = new Botan::DSA_PublicKey(Botan::DL_Group(BotanUtil::byteString2bigInt(p),
+							BotanUtil::byteString2bigInt(q),
+							BotanUtil::byteString2bigInt(g)),
+							BotanUtil::byteString2bigInt(y));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanDSAPublicKey.h
+++ b/src/lib/crypto/BotanDSAPublicKey.h
@@ -42,9 +42,9 @@ class BotanDSAPublicKey : public DSAPublicKey
 public:
 	// Constructors
 	BotanDSAPublicKey();
-	
+
 	BotanDSAPublicKey(const Botan::DSA_PublicKey* inDSA);
-	
+
 	// Destructor
 	virtual ~BotanDSAPublicKey();
 
@@ -52,16 +52,16 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DSA public key components
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setG(const ByteString& g);
-	virtual void setY(const ByteString& y);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setG(const ByteString& inG);
+	virtual void setY(const ByteString& inY);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::DSA_PublicKey* dsa);
+	virtual void setFromBotan(const Botan::DSA_PublicKey* inDSA);
 
 	// Retrieve the Botan representation of the key
 	Botan::DSA_PublicKey* getBotanKey();

--- a/src/lib/crypto/BotanECDHPrivateKey.cpp
+++ b/src/lib/crypto/BotanECDHPrivateKey.cpp
@@ -71,7 +71,7 @@ unsigned long BotanECDHPrivateKey::getOrderLength() const
 {
 	try
 	{
-		Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+		Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 		return group.get_order().bytes();
 	}
 	catch (...)
@@ -83,24 +83,24 @@ unsigned long BotanECDHPrivateKey::getOrderLength() const
 }
 
 // Set from Botan representation
-void BotanECDHPrivateKey::setFromBotan(const Botan::ECDH_PrivateKey* eckey)
+void BotanECDHPrivateKey::setFromBotan(const Botan::ECDH_PrivateKey* inECKEY)
 {
-	ByteString ec = BotanUtil::ecGroup2ByteString(eckey->domain());
-	setEC(ec);
-	ByteString d = BotanUtil::bigInt2ByteString(eckey->private_value());
-	setD(d);
+	ByteString inEC = BotanUtil::ecGroup2ByteString(inECKEY->domain());
+	setEC(inEC);
+	ByteString inD = BotanUtil::bigInt2ByteString(inECKEY->private_value());
+	setD(inD);
 }
 
 // Check if the key is of the given type
-bool BotanECDHPrivateKey::isOfType(const char* type)
+bool BotanECDHPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanECDHPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the ECDH private key components
-void BotanECDHPrivateKey::setD(const ByteString& d)
+void BotanECDHPrivateKey::setD(const ByteString& inD)
 {
-	ECPrivateKey::setD(d);
+	ECPrivateKey::setD(inD);
 
 	if (eckey)
 	{
@@ -110,9 +110,9 @@ void BotanECDHPrivateKey::setD(const ByteString& d)
 }
 
 // Setters for the ECDH public key components
-void BotanECDHPrivateKey::setEC(const ByteString& ec)
+void BotanECDHPrivateKey::setEC(const ByteString& inEC)
 {
-	ECPrivateKey::setEC(ec);
+	ECPrivateKey::setEC(inEC);
 
 	if (eckey)
 	{
@@ -221,10 +221,10 @@ Botan::ECDH_PrivateKey* BotanECDHPrivateKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanECDHPrivateKey::createBotanKey()
 {
-	if (this->ec.size() != 0 &&
-	    this->d.size() != 0)
+	if (ec.size() != 0 &&
+	    d.size() != 0)
 	{
-		if (eckey)   
+		if (eckey)
 		{
 			delete eckey;
 			eckey = NULL;
@@ -233,10 +233,10 @@ void BotanECDHPrivateKey::createBotanKey()
 		try
 		{
 			BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
-			Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+			Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 			eckey = new Botan::ECDH_PrivateKey(*rng->getRNG(),
 							group,
-							BotanUtil::byteString2bigInt(this->d));
+							BotanUtil::byteString2bigInt(d));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanECDHPrivateKey.h
+++ b/src/lib/crypto/BotanECDHPrivateKey.h
@@ -44,7 +44,7 @@ public:
 	BotanECDHPrivateKey();
 
 	BotanECDHPrivateKey(const Botan::ECDH_PrivateKey* inECKEY);
-	
+
 	// Destructor
 	virtual ~BotanECDHPrivateKey();
 
@@ -52,16 +52,16 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the base point order length
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the ECDH private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the ECDH public key components
-	virtual void setEC(const ByteString& ec);
+	virtual void setEC(const ByteString& inEC);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -70,7 +70,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::ECDH_PrivateKey* eckey);
+	virtual void setFromBotan(const Botan::ECDH_PrivateKey* inECKEY);
 
 	// Retrieve the Botan representation of the key
 	Botan::ECDH_PrivateKey* getBotanKey();

--- a/src/lib/crypto/BotanECDHPublicKey.cpp
+++ b/src/lib/crypto/BotanECDHPublicKey.cpp
@@ -64,9 +64,8 @@ unsigned long BotanECDHPublicKey::getOrderLength() const
 {
 	try
 	{
-		Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+		Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 		return group.get_order().bytes();
-			
 	}
 	catch (...)
 	{
@@ -77,24 +76,24 @@ unsigned long BotanECDHPublicKey::getOrderLength() const
 }
 
 // Set from Botan representation
-void BotanECDHPublicKey::setFromBotan(const Botan::ECDH_PublicKey* eckey)
+void BotanECDHPublicKey::setFromBotan(const Botan::ECDH_PublicKey* inECKEY)
 {
-	ByteString ec = BotanUtil::ecGroup2ByteString(eckey->domain());
-	setEC(ec);
-	ByteString q = BotanUtil::ecPoint2ByteString(eckey->public_point());
-	setQ(q);
+	ByteString inEC = BotanUtil::ecGroup2ByteString(inECKEY->domain());
+	setEC(inEC);
+	ByteString inQ = BotanUtil::ecPoint2ByteString(inECKEY->public_point());
+	setQ(inQ);
 }
 
 // Check if the key is of the given type
-bool BotanECDHPublicKey::isOfType(const char* type)
+bool BotanECDHPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanECDHPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the ECDH public key components
-void BotanECDHPublicKey::setEC(const ByteString& ec)
+void BotanECDHPublicKey::setEC(const ByteString& inEC)
 {
-	ECPublicKey::setEC(ec);
+	ECPublicKey::setEC(inEC);
 
 	if (eckey)
 	{
@@ -103,9 +102,9 @@ void BotanECDHPublicKey::setEC(const ByteString& ec)
 	}
 }
 
-void BotanECDHPublicKey::setQ(const ByteString& q)
+void BotanECDHPublicKey::setQ(const ByteString& inQ)
 {
-	ECPublicKey::setQ(q);
+	ECPublicKey::setQ(inQ);
 
 	if (eckey)
 	{
@@ -128,8 +127,8 @@ Botan::ECDH_PublicKey* BotanECDHPublicKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanECDHPublicKey::createBotanKey()
 {
-	if (this->ec.size() != 0 &&
-	    this->q.size() != 0)
+	if (ec.size() != 0 &&
+	    q.size() != 0)
 	{
 		if (eckey)
 		{
@@ -139,8 +138,8 @@ void BotanECDHPublicKey::createBotanKey()
 
 		try
 		{
-			Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
-			Botan::PointGFp point = BotanUtil::byteString2ECPoint(this->q, group);
+			Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
+			Botan::PointGFp point = BotanUtil::byteString2ECPoint(q, group);
 			eckey = new Botan::ECDH_PublicKey(group, point);
 		}
 		catch (...)

--- a/src/lib/crypto/BotanECDHPublicKey.h
+++ b/src/lib/crypto/BotanECDHPublicKey.h
@@ -42,9 +42,9 @@ class BotanECDHPublicKey : public ECPublicKey
 public:
 	// Constructors
 	BotanECDHPublicKey();
-	
+
 	BotanECDHPublicKey(const Botan::ECDH_PublicKey* inECKEY);
-	
+
 	// Destructor
 	virtual ~BotanECDHPublicKey();
 
@@ -52,17 +52,17 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the base point order length
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the ECDH public key components
-	virtual void setEC(const ByteString& ec);
-	virtual void setQ(const ByteString& q);
+	virtual void setEC(const ByteString& inEC);
+	virtual void setQ(const ByteString& inQ);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::ECDH_PublicKey* eckey);
+	virtual void setFromBotan(const Botan::ECDH_PublicKey* inECKEY);
 
 	// Retrieve the Botan representation of the key
 	Botan::ECDH_PublicKey* getBotanKey();

--- a/src/lib/crypto/BotanECDSAPrivateKey.cpp
+++ b/src/lib/crypto/BotanECDSAPrivateKey.cpp
@@ -71,7 +71,7 @@ unsigned long BotanECDSAPrivateKey::getOrderLength() const
 {
 	try
 	{
-		Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+		Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 		return group.get_order().bytes();
 	}
 	catch (...)
@@ -83,24 +83,24 @@ unsigned long BotanECDSAPrivateKey::getOrderLength() const
 }
 
 // Set from Botan representation
-void BotanECDSAPrivateKey::setFromBotan(const Botan::ECDSA_PrivateKey* eckey)
+void BotanECDSAPrivateKey::setFromBotan(const Botan::ECDSA_PrivateKey* inECKEY)
 {
-	ByteString ec = BotanUtil::ecGroup2ByteString(eckey->domain());
-	setEC(ec);
-	ByteString d = BotanUtil::bigInt2ByteString(eckey->private_value());
-	setD(d);
+	ByteString inEC = BotanUtil::ecGroup2ByteString(inECKEY->domain());
+	setEC(inEC);
+	ByteString inD = BotanUtil::bigInt2ByteString(inECKEY->private_value());
+	setD(inD);
 }
 
 // Check if the key is of the given type
-bool BotanECDSAPrivateKey::isOfType(const char* type)
+bool BotanECDSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanECDSAPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the ECDSA private key components
-void BotanECDSAPrivateKey::setD(const ByteString& d)
+void BotanECDSAPrivateKey::setD(const ByteString& inD)
 {
-	ECPrivateKey::setD(d);
+	ECPrivateKey::setD(inD);
 
 	if (eckey)
 	{
@@ -110,9 +110,9 @@ void BotanECDSAPrivateKey::setD(const ByteString& d)
 }
 
 // Setters for the ECDSA public key components
-void BotanECDSAPrivateKey::setEC(const ByteString& ec)
+void BotanECDSAPrivateKey::setEC(const ByteString& inEC)
 {
-	ECPrivateKey::setEC(ec);
+	ECPrivateKey::setEC(inEC);
 
 	if (eckey)
 	{
@@ -217,10 +217,10 @@ Botan::ECDSA_PrivateKey* BotanECDSAPrivateKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanECDSAPrivateKey::createBotanKey()
 {
-	if (this->ec.size() != 0 &&
-	    this->d.size() != 0)
+	if (ec.size() != 0 &&
+	    d.size() != 0)
 	{
-		if (eckey)   
+		if (eckey)
 		{
 			delete eckey;
 			eckey = NULL;
@@ -229,10 +229,10 @@ void BotanECDSAPrivateKey::createBotanKey()
 		try
 		{
 			BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
-			Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+			Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 			eckey = new Botan::ECDSA_PrivateKey(*rng->getRNG(),
 							group,
-							BotanUtil::byteString2bigInt(this->d));
+							BotanUtil::byteString2bigInt(d));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanECDSAPrivateKey.h
+++ b/src/lib/crypto/BotanECDSAPrivateKey.h
@@ -44,7 +44,7 @@ public:
 	BotanECDSAPrivateKey();
 
 	BotanECDSAPrivateKey(const Botan::ECDSA_PrivateKey* inECKEY);
-	
+
 	// Destructor
 	virtual ~BotanECDSAPrivateKey();
 
@@ -52,16 +52,16 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the base point order length
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the ECDSA private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the ECDSA public key components
-	virtual void setEC(const ByteString& ec);
+	virtual void setEC(const ByteString& inEC);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -70,7 +70,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::ECDSA_PrivateKey* eckey);
+	virtual void setFromBotan(const Botan::ECDSA_PrivateKey* inECKEY);
 
 	// Retrieve the Botan representation of the key
 	Botan::ECDSA_PrivateKey* getBotanKey();

--- a/src/lib/crypto/BotanECDSAPublicKey.cpp
+++ b/src/lib/crypto/BotanECDSAPublicKey.cpp
@@ -64,9 +64,8 @@ unsigned long BotanECDSAPublicKey::getOrderLength() const
 {
 	try
 	{
-		Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+		Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 		return group.get_order().bytes();
-			
 	}
 	catch (...)
 	{
@@ -77,24 +76,24 @@ unsigned long BotanECDSAPublicKey::getOrderLength() const
 }
 
 // Set from Botan representation
-void BotanECDSAPublicKey::setFromBotan(const Botan::ECDSA_PublicKey* eckey)
+void BotanECDSAPublicKey::setFromBotan(const Botan::ECDSA_PublicKey* inECKEY)
 {
-	ByteString ec = BotanUtil::ecGroup2ByteString(eckey->domain());
-	setEC(ec);
-	ByteString q = BotanUtil::ecPoint2ByteString(eckey->public_point());
-	setQ(q);
+	ByteString inEC = BotanUtil::ecGroup2ByteString(inECKEY->domain());
+	setEC(inEC);
+	ByteString inQ = BotanUtil::ecPoint2ByteString(inECKEY->public_point());
+	setQ(inQ);
 }
 
 // Check if the key is of the given type
-bool BotanECDSAPublicKey::isOfType(const char* type)
+bool BotanECDSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanECDSAPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the ECDSA public key components
-void BotanECDSAPublicKey::setEC(const ByteString& ec)
+void BotanECDSAPublicKey::setEC(const ByteString& inEC)
 {
-	ECPublicKey::setEC(ec);
+	ECPublicKey::setEC(inEC);
 
 	if (eckey)
 	{
@@ -103,9 +102,9 @@ void BotanECDSAPublicKey::setEC(const ByteString& ec)
 	}
 }
 
-void BotanECDSAPublicKey::setQ(const ByteString& q)
+void BotanECDSAPublicKey::setQ(const ByteString& inQ)
 {
-	ECPublicKey::setQ(q);
+	ECPublicKey::setQ(inQ);
 
 	if (eckey)
 	{
@@ -128,8 +127,8 @@ Botan::ECDSA_PublicKey* BotanECDSAPublicKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanECDSAPublicKey::createBotanKey()
 {
-	if (this->ec.size() != 0 &&
-	    this->q.size() != 0)
+	if (ec.size() != 0 &&
+	    q.size() != 0)
 	{
 		if (eckey)
 		{
@@ -139,8 +138,8 @@ void BotanECDSAPublicKey::createBotanKey()
 
 		try
 		{
-			Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
-			Botan::PointGFp point = BotanUtil::byteString2ECPoint(this->q, group);
+			Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
+			Botan::PointGFp point = BotanUtil::byteString2ECPoint(q, group);
 			eckey = new Botan::ECDSA_PublicKey(group, point);
 		}
 		catch (...)

--- a/src/lib/crypto/BotanECDSAPublicKey.h
+++ b/src/lib/crypto/BotanECDSAPublicKey.h
@@ -42,9 +42,9 @@ class BotanECDSAPublicKey : public ECPublicKey
 public:
 	// Constructors
 	BotanECDSAPublicKey();
-	
+
 	BotanECDSAPublicKey(const Botan::ECDSA_PublicKey* inECKEY);
-	
+
 	// Destructor
 	virtual ~BotanECDSAPublicKey();
 
@@ -52,17 +52,17 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the base point order length
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the ECDSA public key components
-	virtual void setEC(const ByteString& ec);
-	virtual void setQ(const ByteString& q);
+	virtual void setEC(const ByteString& inEC);
+	virtual void setQ(const ByteString& inQ);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::ECDSA_PublicKey* eckey);
+	virtual void setFromBotan(const Botan::ECDSA_PublicKey* inECKEY);
 
 	// Retrieve the Botan representation of the key
 	Botan::ECDSA_PublicKey* getBotanKey();

--- a/src/lib/crypto/BotanGOSTPrivateKey.cpp
+++ b/src/lib/crypto/BotanGOSTPrivateKey.cpp
@@ -66,7 +66,7 @@ unsigned long BotanGOSTPrivateKey::getOrderLength() const
 {
 	try
 	{
-		Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+		Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 		return group.get_order().bytes();
 	}
 	catch (...)
@@ -80,28 +80,28 @@ unsigned long BotanGOSTPrivateKey::getOrderLength() const
 // Get the output length
 unsigned long BotanGOSTPrivateKey::getOutputLength() const
 {
-	return this->getOrderLength() * 2;
+	return getOrderLength() * 2;
 }
 
 // Set from Botan representation
-void BotanGOSTPrivateKey::setFromBotan(const Botan::GOST_3410_PrivateKey* eckey)
+void BotanGOSTPrivateKey::setFromBotan(const Botan::GOST_3410_PrivateKey* inECKEY)
 {
-	ByteString ec = BotanUtil::ecGroup2ByteString(eckey->domain());
-	setEC(ec);
-	ByteString d = BotanUtil::bigInt2ByteStringPrefix(eckey->private_value(), 32);
-	setD(d);
+	ByteString inEC = BotanUtil::ecGroup2ByteString(inECKEY->domain());
+	setEC(inEC);
+	ByteString inD = BotanUtil::bigInt2ByteStringPrefix(inECKEY->private_value(), 32);
+	setD(inD);
 }
 
 // Check if the key is of the given type
-bool BotanGOSTPrivateKey::isOfType(const char* type)
+bool BotanGOSTPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanGOSTPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the GOST private key components
-void BotanGOSTPrivateKey::setD(const ByteString& d)
+void BotanGOSTPrivateKey::setD(const ByteString& inD)
 {
-	GOSTPrivateKey::setD(d);
+	GOSTPrivateKey::setD(inD);
 
 	if (eckey)
 	{
@@ -112,9 +112,9 @@ void BotanGOSTPrivateKey::setD(const ByteString& d)
 
 
 // Setters for the GOST public key components
-void BotanGOSTPrivateKey::setEC(const ByteString& ec)
+void BotanGOSTPrivateKey::setEC(const ByteString& inEC)
 {
-	GOSTPrivateKey::setEC(ec);
+	GOSTPrivateKey::setEC(inEC);
 
 	if (eckey)
 	{
@@ -175,8 +175,8 @@ Botan::GOST_3410_PrivateKey* BotanGOSTPrivateKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanGOSTPrivateKey::createBotanKey()
 {
-	if (this->ec.size() != 0 &&
-	    this->d.size() != 0)
+	if (ec.size() != 0 &&
+	    d.size() != 0)
 	{
 		if (eckey)
 		{
@@ -187,10 +187,10 @@ void BotanGOSTPrivateKey::createBotanKey()
 		try
 		{
 			BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
-			Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+			Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 			eckey = new Botan::GOST_3410_PrivateKey(*rng->getRNG(),
 							group,
-							BotanUtil::byteString2bigInt(this->d));
+							BotanUtil::byteString2bigInt(d));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanGOSTPrivateKey.h
+++ b/src/lib/crypto/BotanGOSTPrivateKey.h
@@ -44,7 +44,7 @@ public:
 	BotanGOSTPrivateKey();
 
 	BotanGOSTPrivateKey(const Botan::GOST_3410_PrivateKey* inECKEY);
-	
+
 	// Destructor
 	virtual ~BotanGOSTPrivateKey();
 
@@ -52,7 +52,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the output length
 	virtual unsigned long getOutputLength() const;
@@ -61,10 +61,10 @@ public:
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the GOST private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the GOST public key components
-	virtual void setEC(const ByteString& ec);
+	virtual void setEC(const ByteString& inEC);
 
 	// Serialisation
 	virtual ByteString serialise() const;
@@ -77,7 +77,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::GOST_3410_PrivateKey* eckey);
+	virtual void setFromBotan(const Botan::GOST_3410_PrivateKey* inECKEY);
 
 	// Retrieve the Botan representation of the key
 	Botan::GOST_3410_PrivateKey* getBotanKey();

--- a/src/lib/crypto/BotanGOSTPublicKey.cpp
+++ b/src/lib/crypto/BotanGOSTPublicKey.cpp
@@ -64,7 +64,7 @@ unsigned long BotanGOSTPublicKey::getOrderLength() const
 {
 	try
 	{
-		Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+		Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 		return group.get_order().bytes();
 	}
 	catch (...)
@@ -78,38 +78,38 @@ unsigned long BotanGOSTPublicKey::getOrderLength() const
 // Get the output length
 unsigned long BotanGOSTPublicKey::getOutputLength() const
 {
-	return this->getOrderLength() * 2;
+	return getOrderLength() * 2;
 }
 
 // Set from Botan representation
-void BotanGOSTPublicKey::setFromBotan(const Botan::GOST_3410_PublicKey* eckey)
+void BotanGOSTPublicKey::setFromBotan(const Botan::GOST_3410_PublicKey* inECKEY)
 {
-	ByteString ec = BotanUtil::ecGroup2ByteString(eckey->domain());
-	setEC(ec);
+	ByteString inEC = BotanUtil::ecGroup2ByteString(inECKEY->domain());
+	setEC(inEC);
 
-	ByteString q = BotanUtil::ecPoint2ByteString(eckey->public_point()).substr(3);
+	ByteString inQ = BotanUtil::ecPoint2ByteString(inECKEY->public_point()).substr(3);
 
 	/* The points must be stored in little endian */
-	const size_t length = q.size() / 2;
+	const size_t length = inQ.size() / 2;
 	for (size_t i = 0; i < (length / 2); i++)
 	{
-		std::swap(q[i], q[length-1-i]);
-		std::swap(q[length+i], q[2*length-1-i]);
+		std::swap(inQ[i], inQ[length-1-i]);
+		std::swap(inQ[length+i], inQ[2*length-1-i]);
 	}
 
-	setQ(q);
+	setQ(inQ);
 }
 
 // Check if the key is of the given type
-bool BotanGOSTPublicKey::isOfType(const char* type)
+bool BotanGOSTPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanGOSTPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the GOST public key components
-void BotanGOSTPublicKey::setEC(const ByteString& ec)
+void BotanGOSTPublicKey::setEC(const ByteString& inEC)
 {
-	GOSTPublicKey::setEC(ec);
+	GOSTPublicKey::setEC(inEC);
 
 	if (eckey)
 	{
@@ -118,9 +118,9 @@ void BotanGOSTPublicKey::setEC(const ByteString& ec)
 	}
 }
 
-void BotanGOSTPublicKey::setQ(const ByteString& q)
+void BotanGOSTPublicKey::setQ(const ByteString& inQ)
 {
-	GOSTPublicKey::setQ(q);
+	GOSTPublicKey::setQ(inQ);
 
 	if (eckey)
 	{
@@ -167,8 +167,8 @@ Botan::GOST_3410_PublicKey* BotanGOSTPublicKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanGOSTPublicKey::createBotanKey()
 {
-	if (this->ec.size() != 0 &&
-	    this->q.size() != 0)
+	if (ec.size() != 0 &&
+	    q.size() != 0)
 	{
 		if (eckey)
 		{
@@ -179,7 +179,7 @@ void BotanGOSTPublicKey::createBotanKey()
 		try
 		{
 			/* The points are stored in little endian */
-			ByteString bPoint = this->q;
+			ByteString bPoint = q;
 			const size_t length = bPoint.size() / 2;
 			for (size_t i = 0; i < (length / 2); i++)
 			{
@@ -188,7 +188,7 @@ void BotanGOSTPublicKey::createBotanKey()
 			}
 			ByteString p = "044104" + bPoint;
 
-			Botan::EC_Group group = BotanUtil::byteString2ECGroup(this->ec);
+			Botan::EC_Group group = BotanUtil::byteString2ECGroup(ec);
 			Botan::PointGFp point = BotanUtil::byteString2ECPoint(p, group);
 			eckey = new Botan::GOST_3410_PublicKey(group, point);
 		}

--- a/src/lib/crypto/BotanGOSTPublicKey.h
+++ b/src/lib/crypto/BotanGOSTPublicKey.h
@@ -42,9 +42,9 @@ class BotanGOSTPublicKey : public GOSTPublicKey
 public:
 	// Constructors
 	BotanGOSTPublicKey();
-	
+
 	BotanGOSTPublicKey(const Botan::GOST_3410_PublicKey* inECKEY);
-	
+
 	// Destructor
 	virtual ~BotanGOSTPublicKey();
 
@@ -52,7 +52,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the output length
 	virtual unsigned long getOutputLength() const;
@@ -61,15 +61,15 @@ public:
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the GOST public key components
-	virtual void setEC(const ByteString& ec);
-	virtual void setQ(const ByteString& q);
+	virtual void setEC(const ByteString& inEC);
+	virtual void setQ(const ByteString& inQ);
 
 	// Serialisation
 	virtual ByteString serialise() const;
 	virtual bool deserialise(ByteString& serialised);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::GOST_3410_PublicKey* eckey);
+	virtual void setFromBotan(const Botan::GOST_3410_PublicKey* inECKEY);
 
 	// Retrieve the Botan representation of the key
 	Botan::GOST_3410_PublicKey* getBotanKey();

--- a/src/lib/crypto/BotanRSA.cpp
+++ b/src/lib/crypto/BotanRSA.cpp
@@ -971,8 +971,8 @@ bool BotanRSA::generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParamete
 		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
 		rsa = new Botan::RSA_PrivateKey(*rng->getRNG(),	params->getBitLength(),	e);
 	}
-	catch (std::exception& e) {
-		ERROR_MSG("RSA key generation failed: %s", e.what());
+	catch (std::exception& ex) {
+		ERROR_MSG("RSA key generation failed: %s", ex.what());
 
 		delete kp;
 

--- a/src/lib/crypto/BotanRSAPrivateKey.cpp
+++ b/src/lib/crypto/BotanRSAPrivateKey.cpp
@@ -66,36 +66,36 @@ BotanRSAPrivateKey::~BotanRSAPrivateKey()
 /*static*/ const char* BotanRSAPrivateKey::type = "Botan RSA Private Key";
 
 // Set from Botan representation
-void BotanRSAPrivateKey::setFromBotan(const Botan::RSA_PrivateKey* rsa)
+void BotanRSAPrivateKey::setFromBotan(const Botan::RSA_PrivateKey* inRSA)
 {
-	ByteString p = BotanUtil::bigInt2ByteString(rsa->get_p());
-	setP(p);
-	ByteString q = BotanUtil::bigInt2ByteString(rsa->get_q());
-	setQ(q);
-	ByteString dp1 = BotanUtil::bigInt2ByteString(rsa->get_d1());
-	setDP1(dp1);
-	ByteString dq1 = BotanUtil::bigInt2ByteString(rsa->get_d2());
-	setDQ1(dq1);
-	ByteString pq = BotanUtil::bigInt2ByteString(rsa->get_c());
-	setPQ(pq);
-	ByteString d = BotanUtil::bigInt2ByteString(rsa->get_d());
-	setD(d);
-	ByteString n = BotanUtil::bigInt2ByteString(rsa->get_n());
-	setN(n);
-	ByteString e = BotanUtil::bigInt2ByteString(rsa->get_e());
-	setE(e);
+	ByteString inP = BotanUtil::bigInt2ByteString(inRSA->get_p());
+	setP(inP);
+	ByteString inQ = BotanUtil::bigInt2ByteString(inRSA->get_q());
+	setQ(inQ);
+	ByteString inDP1 = BotanUtil::bigInt2ByteString(inRSA->get_d1());
+	setDP1(inDP1);
+	ByteString inDQ1 = BotanUtil::bigInt2ByteString(inRSA->get_d2());
+	setDQ1(inDQ1);
+	ByteString inPQ = BotanUtil::bigInt2ByteString(inRSA->get_c());
+	setPQ(inPQ);
+	ByteString inD = BotanUtil::bigInt2ByteString(inRSA->get_d());
+	setD(inD);
+	ByteString inN = BotanUtil::bigInt2ByteString(inRSA->get_n());
+	setN(inN);
+	ByteString inE = BotanUtil::bigInt2ByteString(inRSA->get_e());
+	setE(inE);
 }
 
 // Check if the key is of the given type
-bool BotanRSAPrivateKey::isOfType(const char* type)
+bool BotanRSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanRSAPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the RSA private key components
-void BotanRSAPrivateKey::setP(const ByteString& p)
+void BotanRSAPrivateKey::setP(const ByteString& inP)
 {
-	RSAPrivateKey::setP(p);
+	RSAPrivateKey::setP(inP);
 
 	if (rsa)
 	{
@@ -104,9 +104,9 @@ void BotanRSAPrivateKey::setP(const ByteString& p)
 	}
 }
 
-void BotanRSAPrivateKey::setQ(const ByteString& q)
+void BotanRSAPrivateKey::setQ(const ByteString& inQ)
 {
-	RSAPrivateKey::setQ(q);
+	RSAPrivateKey::setQ(inQ);
 
 	if (rsa)
 	{
@@ -115,9 +115,9 @@ void BotanRSAPrivateKey::setQ(const ByteString& q)
 	}
 }
 
-void BotanRSAPrivateKey::setPQ(const ByteString& pq)
+void BotanRSAPrivateKey::setPQ(const ByteString& inPQ)
 {
-	RSAPrivateKey::setPQ(pq);
+	RSAPrivateKey::setPQ(inPQ);
 
 	if (rsa)
 	{
@@ -126,9 +126,9 @@ void BotanRSAPrivateKey::setPQ(const ByteString& pq)
 	}
 }
 
-void BotanRSAPrivateKey::setDP1(const ByteString& dp1)
+void BotanRSAPrivateKey::setDP1(const ByteString& inDP1)
 {
-	RSAPrivateKey::setDP1(dp1);
+	RSAPrivateKey::setDP1(inDP1);
 
 	if (rsa)
 	{
@@ -137,9 +137,9 @@ void BotanRSAPrivateKey::setDP1(const ByteString& dp1)
 	}
 }
 
-void BotanRSAPrivateKey::setDQ1(const ByteString& dq1)
+void BotanRSAPrivateKey::setDQ1(const ByteString& inDQ1)
 {
-	RSAPrivateKey::setDQ1(dq1);
+	RSAPrivateKey::setDQ1(inDQ1);
 
 	if (rsa)
 	{
@@ -148,9 +148,9 @@ void BotanRSAPrivateKey::setDQ1(const ByteString& dq1)
 	}
 }
 
-void BotanRSAPrivateKey::setD(const ByteString& d)
+void BotanRSAPrivateKey::setD(const ByteString& inD)
 {
-	RSAPrivateKey::setD(d);
+	RSAPrivateKey::setD(inD);
 
 	if (rsa)
 	{
@@ -161,9 +161,9 @@ void BotanRSAPrivateKey::setD(const ByteString& d)
 
 
 // Setters for the RSA public key components
-void BotanRSAPrivateKey::setN(const ByteString& n)
+void BotanRSAPrivateKey::setN(const ByteString& inN)
 {
-	RSAPrivateKey::setN(n);
+	RSAPrivateKey::setN(inN);
 
 	if (rsa)
 	{
@@ -172,9 +172,9 @@ void BotanRSAPrivateKey::setN(const ByteString& n)
 	}
 }
 
-void BotanRSAPrivateKey::setE(const ByteString& e)
+void BotanRSAPrivateKey::setE(const ByteString& inE)
 {
-	RSAPrivateKey::setE(e);
+	RSAPrivateKey::setE(inE);
 
 	if (rsa)
 	{
@@ -262,9 +262,9 @@ Botan::RSA_PrivateKey* BotanRSAPrivateKey::getBotanKey()
 void BotanRSAPrivateKey::createBotanKey()
 {
 	// d and n is not needed, they can be calculated
-	if (this->p.size() != 0 &&
-	    this->q.size() != 0 &&
-	    this->e.size() != 0)
+	if (p.size() != 0 &&
+	    q.size() != 0 &&
+	    e.size() != 0)
 	{
 		if (rsa)
 		{
@@ -276,11 +276,11 @@ void BotanRSAPrivateKey::createBotanKey()
 		{
 			BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
 			rsa = new Botan::RSA_PrivateKey(*rng->getRNG(),
-						BotanUtil::byteString2bigInt(this->p), 
-						BotanUtil::byteString2bigInt(this->q), 
-						BotanUtil::byteString2bigInt(this->e), 
-						BotanUtil::byteString2bigInt(this->d), 
-						BotanUtil::byteString2bigInt(this->n));
+						BotanUtil::byteString2bigInt(p),
+						BotanUtil::byteString2bigInt(q),
+						BotanUtil::byteString2bigInt(e),
+						BotanUtil::byteString2bigInt(d),
+						BotanUtil::byteString2bigInt(n));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanRSAPrivateKey.h
+++ b/src/lib/crypto/BotanRSAPrivateKey.h
@@ -42,9 +42,9 @@ class BotanRSAPrivateKey : public RSAPrivateKey
 public:
 	// Constructors
 	BotanRSAPrivateKey();
-	
+
 	BotanRSAPrivateKey(const Botan::RSA_PrivateKey* inRSA);
-	
+
 	// Destructor
 	virtual ~BotanRSAPrivateKey();
 
@@ -52,19 +52,19 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the RSA private key components
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setPQ(const ByteString& pq);
-	virtual void setDP1(const ByteString& dp1);
-	virtual void setDQ1(const ByteString& dq1);
-	virtual void setD(const ByteString& d);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setPQ(const ByteString& inPQ);
+	virtual void setDP1(const ByteString& inDP1);
+	virtual void setDQ1(const ByteString& inDQ1);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the RSA public key components
-	virtual void setN(const ByteString& n);
-	virtual void setE(const ByteString& e);
+	virtual void setN(const ByteString& inN);
+	virtual void setE(const ByteString& inE);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -73,7 +73,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::RSA_PrivateKey* rsa);
+	virtual void setFromBotan(const Botan::RSA_PrivateKey* inRSA);
 
 	// Retrieve the Botan representation of the key
 	Botan::RSA_PrivateKey* getBotanKey();

--- a/src/lib/crypto/BotanRSAPublicKey.cpp
+++ b/src/lib/crypto/BotanRSAPublicKey.cpp
@@ -59,24 +59,24 @@ BotanRSAPublicKey::~BotanRSAPublicKey()
 /*static*/ const char* BotanRSAPublicKey::type = "Botan RSA Public Key";
 
 // Check if the key is of the given type
-bool BotanRSAPublicKey::isOfType(const char* type)
+bool BotanRSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(BotanRSAPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Set from OpenSSL representation
-void BotanRSAPublicKey::setFromBotan(const Botan::RSA_PublicKey* rsa)
+void BotanRSAPublicKey::setFromBotan(const Botan::RSA_PublicKey* inRSA)
 {
-	ByteString n = BotanUtil::bigInt2ByteString(rsa->get_n());
-	setN(n);
-	ByteString e = BotanUtil::bigInt2ByteString(rsa->get_e());
-	setE(e);
+	ByteString inN = BotanUtil::bigInt2ByteString(inRSA->get_n());
+	setN(inN);
+	ByteString inE = BotanUtil::bigInt2ByteString(inRSA->get_e());
+	setE(inE);
 }
 
 // Setters for the RSA public key components
-void BotanRSAPublicKey::setN(const ByteString& n)
+void BotanRSAPublicKey::setN(const ByteString& inN)
 {
-	RSAPublicKey::setN(n);
+	RSAPublicKey::setN(inN);
 
 	if (rsa)
 	{
@@ -85,9 +85,9 @@ void BotanRSAPublicKey::setN(const ByteString& n)
 	}
 }
 
-void BotanRSAPublicKey::setE(const ByteString& e)
+void BotanRSAPublicKey::setE(const ByteString& inE)
 {
-	RSAPublicKey::setE(e);
+	RSAPublicKey::setE(inE);
 
 	if (rsa)
 	{
@@ -110,7 +110,7 @@ Botan::RSA_PublicKey* BotanRSAPublicKey::getBotanKey()
 // Create the Botan representation of the key
 void BotanRSAPublicKey::createBotanKey()
 {
-	if (this->n.size() != 0 && this->e.size() != 0)
+	if (n.size() != 0 && e.size() != 0)
 	{
 		if (rsa)
 		{
@@ -120,8 +120,8 @@ void BotanRSAPublicKey::createBotanKey()
 
 		try
 		{
-			rsa = new Botan::RSA_PublicKey(BotanUtil::byteString2bigInt(this->n), 
-							BotanUtil::byteString2bigInt(this->e));
+			rsa = new Botan::RSA_PublicKey(BotanUtil::byteString2bigInt(n),
+							BotanUtil::byteString2bigInt(e));
 		}
 		catch (...)
 		{

--- a/src/lib/crypto/BotanRSAPublicKey.h
+++ b/src/lib/crypto/BotanRSAPublicKey.h
@@ -42,9 +42,9 @@ class BotanRSAPublicKey : public RSAPublicKey
 public:
 	// Constructors
 	BotanRSAPublicKey();
-	
+
 	BotanRSAPublicKey(const Botan::RSA_PublicKey* inRSA);
-	
+
 	// Destructor
 	virtual ~BotanRSAPublicKey();
 
@@ -52,14 +52,14 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the RSA public key components
-	virtual void setN(const ByteString& n);
-	virtual void setE(const ByteString& e);
+	virtual void setN(const ByteString& inN);
+	virtual void setE(const ByteString& inE);
 
 	// Set from Botan representation
-	virtual void setFromBotan(const Botan::RSA_PublicKey* rsa);
+	virtual void setFromBotan(const Botan::RSA_PublicKey* inRSA);
 
 	// Retrieve the Botan representation of the key
 	Botan::RSA_PublicKey* getBotanKey();

--- a/src/lib/crypto/DESKey.h
+++ b/src/lib/crypto/DESKey.h
@@ -42,8 +42,8 @@ class DESKey : public SymmetricKey
 {
 public:
 	// Base constructor
-	DESKey(size_t bitLen = 0) : SymmetricKey(bitLen) { }
-	
+	DESKey(size_t inBitLen = 0) : SymmetricKey(inBitLen) { }
+
 	// Set the key
 	virtual bool setKeyBits(const ByteString& keybits);
 };

--- a/src/lib/crypto/DHParameters.cpp
+++ b/src/lib/crypto/DHParameters.cpp
@@ -39,21 +39,21 @@
 /*static*/ const char* DHParameters::type = "Generic DH parameters";
 
 // Set the public prime p
-void DHParameters::setP(const ByteString& p)
+void DHParameters::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
 // Set the generator g
-void DHParameters::setG(const ByteString& g)
+void DHParameters::setG(const ByteString& inG)
 {
-	this->g = g;
+	g = inG;
 }
 
 // Set the optional bit length
-void DHParameters::setXBitLength(const size_t bitLen)
+void DHParameters::setXBitLength(const size_t inBitLen)
 {
-	this->bitLen = bitLen;
+	bitLen = inBitLen;
 }
 
 
@@ -76,9 +76,9 @@ size_t DHParameters::getXBitLength() const
 }
 
 // Are the parameters of the given type?
-bool DHParameters::areOfType(const char* type)
+bool DHParameters::areOfType(const char* inType)
 {
-	return (strcmp(type, DHParameters::type) == 0);
+	return (strcmp(type, inType) == 0);
 }
 
 // Serialisation

--- a/src/lib/crypto/DHParameters.h
+++ b/src/lib/crypto/DHParameters.h
@@ -47,13 +47,13 @@ public:
 	static const char* type;
 
 	// Set the public prime p
-	void setP(const ByteString& p);
+	void setP(const ByteString& inP);
 
 	// Set the generator g
-	void setG(const ByteString& g);
+	void setG(const ByteString& inG);
 
 	// Set the optional bit length
-	void setXBitLength(const size_t bitLen);
+	void setXBitLength(const size_t inBitLen);
 
 	// Get the public prime p
 	const ByteString& getP() const;
@@ -65,7 +65,7 @@ public:
 	size_t getXBitLength() const;
 
 	// Are the parameters of the given type?
-	virtual bool areOfType(const char* type);
+	virtual bool areOfType(const char* inType);
 
 	// Serialisation
 	virtual ByteString serialise() const;

--- a/src/lib/crypto/DHPrivateKey.cpp
+++ b/src/lib/crypto/DHPrivateKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* DHPrivateKey::type = "Abstract DH private key";
 
 // Check if the key is of the given type
-bool DHPrivateKey::isOfType(const char* type)
+bool DHPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -57,20 +57,20 @@ unsigned long DHPrivateKey::getOutputLength() const
 }
 
 // Setters for the DH private key components
-void DHPrivateKey::setX(const ByteString& x)
+void DHPrivateKey::setX(const ByteString& inX)
 {
-	this->x = x;
+	x = inX;
 }
 
 // Setters for the DH public key components
-void DHPrivateKey::setP(const ByteString& p)
+void DHPrivateKey::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
-void DHPrivateKey::setG(const ByteString& g)
+void DHPrivateKey::setG(const ByteString& inG)
 {
-	this->g = g;
+	g = inG;
 }
 
 // Getters for the DH private key components

--- a/src/lib/crypto/DHPrivateKey.h
+++ b/src/lib/crypto/DHPrivateKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,11 +52,11 @@ public:
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the DH private key components
-	virtual void setX(const ByteString& x);
+	virtual void setX(const ByteString& inX);
 
 	// Setters for the DH public key components
-	virtual void setP(const ByteString& p);
-	virtual void setG(const ByteString& g);
+	virtual void setP(const ByteString& inP);
+	virtual void setG(const ByteString& inG);
 
 	// Getters for the DH private key components
 	virtual const ByteString& getX() const;

--- a/src/lib/crypto/DHPublicKey.cpp
+++ b/src/lib/crypto/DHPublicKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* DHPublicKey::type = "Abstract DH public key";
 
 // Check if the key is of the given type
-bool DHPublicKey::isOfType(const char* type)
+bool DHPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -57,19 +57,19 @@ unsigned long DHPublicKey::getOutputLength() const
 }
 
 // Setters for the DH public key components
-void DHPublicKey::setP(const ByteString& p)
+void DHPublicKey::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
-void DHPublicKey::setG(const ByteString& g)
+void DHPublicKey::setG(const ByteString& inG)
 {
-	this->g = g;
+	g = inG;
 }
 
-void DHPublicKey::setY(const ByteString& y)
+void DHPublicKey::setY(const ByteString& inY)
 {
-	this->y = y;
+	y = inY;
 }
 
 // Getters for the DH public key components

--- a/src/lib/crypto/DHPublicKey.h
+++ b/src/lib/crypto/DHPublicKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,9 +52,9 @@ public:
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the DH public key components
-	virtual void setP(const ByteString& p);
-	virtual void setG(const ByteString& g);
-	virtual void setY(const ByteString& y);
+	virtual void setP(const ByteString& inP);
+	virtual void setG(const ByteString& inG);
+	virtual void setY(const ByteString& inY);
 
 	// Getters for the DH public key components
 	virtual const ByteString& getP() const;

--- a/src/lib/crypto/DSAParameters.cpp
+++ b/src/lib/crypto/DSAParameters.cpp
@@ -75,9 +75,9 @@ const ByteString& DSAParameters::getG() const
 }
 
 // Are the parameters of the given type?
-bool DSAParameters::areOfType(const char* type)
+bool DSAParameters::areOfType(const char* inType)
 {
-	return (strcmp(type, DSAParameters::type) == 0);
+	return (strcmp(type, inType) == 0);
 }
 
 // Serialisation

--- a/src/lib/crypto/DSAParameters.cpp
+++ b/src/lib/crypto/DSAParameters.cpp
@@ -39,21 +39,21 @@
 /*static*/ const char* DSAParameters::type = "Generic DSA parameters";
 
 // Set the public prime p
-void DSAParameters::setP(const ByteString& p)
+void DSAParameters::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
 // Set the public subprime q
-void DSAParameters::setQ(const ByteString& q)
+void DSAParameters::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	q = inQ;
 }
 
 // Set the generator g
-void DSAParameters::setG(const ByteString& g)
+void DSAParameters::setG(const ByteString& inG)
 {
-	this->g = g;
+	g = inG;
 }
 
 // Get the public prime p

--- a/src/lib/crypto/DSAParameters.h
+++ b/src/lib/crypto/DSAParameters.h
@@ -44,13 +44,13 @@ public:
 	static const char* type;
 
 	// Set the public prime p
-	void setP(const ByteString& p);
+	void setP(const ByteString& inP);
 
 	// Set the public subprime q
-	void setQ(const ByteString& q);
+	void setQ(const ByteString& inQ);
 
 	// Set the generator g
-	void setG(const ByteString& g);
+	void setG(const ByteString& inG);
 
 	// Get the public prime p
 	const ByteString& getP() const;
@@ -62,7 +62,7 @@ public:
 	const ByteString& getG() const;
 
 	// Are the parameters of the given type?
-	virtual bool areOfType(const char* type);
+	virtual bool areOfType(const char* inType);
 
 	// Serialisation
 	virtual ByteString serialise() const;

--- a/src/lib/crypto/DSAPrivateKey.cpp
+++ b/src/lib/crypto/DSAPrivateKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* DSAPrivateKey::type = "Abstract DSA private key";
 
 // Check if the key is of the given type
-bool DSAPrivateKey::isOfType(const char* type)
+bool DSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -57,25 +57,25 @@ unsigned long DSAPrivateKey::getOutputLength() const
 }
 
 // Setters for the DSA private key components
-void DSAPrivateKey::setX(const ByteString& x)
+void DSAPrivateKey::setX(const ByteString& inX)
 {
-	this->x = x;
+	x = inX;
 }
 
 // Setters for the DSA domain parameters
-void DSAPrivateKey::setP(const ByteString& p)
+void DSAPrivateKey::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
-void DSAPrivateKey::setQ(const ByteString& q)
+void DSAPrivateKey::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	q = inQ;
 }
 
-void DSAPrivateKey::setG(const ByteString& g)
+void DSAPrivateKey::setG(const ByteString& inG)
 {
-	this->g = g;
+	g = inG;
 }
 
 // Getters for the DSA private key components

--- a/src/lib/crypto/DSAPrivateKey.h
+++ b/src/lib/crypto/DSAPrivateKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,12 +52,12 @@ public:
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the DSA private key components
-	virtual void setX(const ByteString& x);
+	virtual void setX(const ByteString& inX);
 
 	// Setters for the DSA domain parameters
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setG(const ByteString& g);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setG(const ByteString& inG);
 
 	// Getters for the DSA private key components
 	virtual const ByteString& getX() const;

--- a/src/lib/crypto/DSAPublicKey.cpp
+++ b/src/lib/crypto/DSAPublicKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* DSAPublicKey::type = "Abstract DSA public key";
 
 // Check if the key is of the given type
-bool DSAPublicKey::isOfType(const char* type)
+bool DSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -57,24 +57,24 @@ unsigned long DSAPublicKey::getOutputLength() const
 }
 
 // Setters for the DSA public key components
-void DSAPublicKey::setP(const ByteString& p)
+void DSAPublicKey::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
-void DSAPublicKey::setQ(const ByteString& q)
+void DSAPublicKey::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	q = inQ;
 }
 
-void DSAPublicKey::setG(const ByteString& g)
+void DSAPublicKey::setG(const ByteString& inG)
 {
-	this->g = g;
+	g = inG;
 }
 
-void DSAPublicKey::setY(const ByteString& y)
+void DSAPublicKey::setY(const ByteString& inY)
 {
-	this->y = y;
+	y = inY;
 }
 
 // Getters for the DSA public key components

--- a/src/lib/crypto/DSAPublicKey.h
+++ b/src/lib/crypto/DSAPublicKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,10 +52,10 @@ public:
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the DSA public key components
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setG(const ByteString& g);
-	virtual void setY(const ByteString& y);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setG(const ByteString& inG);
+	virtual void setY(const ByteString& inY);
 
 	// Getters for the DSA public key components
 	virtual const ByteString& getP() const;

--- a/src/lib/crypto/ECParameters.cpp
+++ b/src/lib/crypto/ECParameters.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* ECParameters::type = "Generic EC parameters";
 
 // Set the curve OID ec
-void ECParameters::setEC(const ByteString& ec)
+void ECParameters::setEC(const ByteString& inEC)
 {
-	this->ec = ec;
+	ec = inEC;
 }
 
 // Get the curve OID ec
@@ -51,9 +51,9 @@ const ByteString& ECParameters::getEC() const
 }
 
 // Are the parameters of the given type?
-bool ECParameters::areOfType(const char* type)
+bool ECParameters::areOfType(const char* inType)
 {
-	return (strcmp(type, ECParameters::type) == 0);
+	return (strcmp(type, inType) == 0);
 }
 
 // Serialisation

--- a/src/lib/crypto/ECParameters.h
+++ b/src/lib/crypto/ECParameters.h
@@ -44,13 +44,13 @@ public:
 	static const char* type;
 
 	// Set the curve OID ec
-	void setEC(const ByteString& ec);
+	void setEC(const ByteString& inEC);
 
 	// Get the curve OID ec
 	const ByteString& getEC() const;
 
 	// Are the parameters of the given type?
-	virtual bool areOfType(const char* type);
+	virtual bool areOfType(const char* inType);
 
 	// Serialisation
 	virtual ByteString serialise() const;

--- a/src/lib/crypto/ECPrivateKey.cpp
+++ b/src/lib/crypto/ECPrivateKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* ECPrivateKey::type = "Abstract EC private key";
 
 // Check if the key is of the given type
-bool ECPrivateKey::isOfType(const char* type)
+bool ECPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -57,15 +57,15 @@ unsigned long ECPrivateKey::getOutputLength() const
 }
 
 // Setters for the EC private key components
-void ECPrivateKey::setD(const ByteString& d)
+void ECPrivateKey::setD(const ByteString& inD)
 {
-	this->d = d;
+	d = inD;
 }
 
 // Setters for the EC public key components
-void ECPrivateKey::setEC(const ByteString& ec)
+void ECPrivateKey::setEC(const ByteString& inEC)
 {
-	this->ec = ec;
+	ec = inEC;
 }
 
 // Getters for the EC private key components

--- a/src/lib/crypto/ECPrivateKey.cpp
+++ b/src/lib/crypto/ECPrivateKey.cpp
@@ -53,7 +53,7 @@ unsigned long ECPrivateKey::getBitLength() const
 // Get the output length
 unsigned long ECPrivateKey::getOutputLength() const
 {
-	return this->getOrderLength() * 2;
+	return getOrderLength() * 2;
 }
 
 // Setters for the EC private key components

--- a/src/lib/crypto/ECPrivateKey.h
+++ b/src/lib/crypto/ECPrivateKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -55,10 +55,10 @@ public:
 	virtual unsigned long getOrderLength() const = 0;
 
 	// Setters for the EC private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the EC public key components
-	virtual void setEC(const ByteString& ec);
+	virtual void setEC(const ByteString& inEC);
 
 	// Getters for the EC private key components
 	virtual const ByteString& getD() const;

--- a/src/lib/crypto/ECPublicKey.cpp
+++ b/src/lib/crypto/ECPublicKey.cpp
@@ -53,7 +53,7 @@ unsigned long ECPublicKey::getBitLength() const
 // Get the output length
 unsigned long ECPublicKey::getOutputLength() const
 {
-	return this->getOrderLength() * 2;
+	return getOrderLength() * 2;
 }
 
 // Setters for the EC public key components

--- a/src/lib/crypto/ECPublicKey.cpp
+++ b/src/lib/crypto/ECPublicKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* ECPublicKey::type = "Abstract EC public key";
 
 // Check if the key is of the given type
-bool ECPublicKey::isOfType(const char* type)
+bool ECPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -57,14 +57,14 @@ unsigned long ECPublicKey::getOutputLength() const
 }
 
 // Setters for the EC public key components
-void ECPublicKey::setEC(const ByteString& ec)
+void ECPublicKey::setEC(const ByteString& inEC)
 {
-	this->ec = ec;
+	ec = inEC;
 }
 
-void ECPublicKey::setQ(const ByteString& q)
+void ECPublicKey::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	q = inQ;
 }
 
 // Getters for the EC public key components

--- a/src/lib/crypto/ECPublicKey.h
+++ b/src/lib/crypto/ECPublicKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -55,8 +55,8 @@ public:
 	virtual unsigned long getOrderLength() const = 0;
 
 	// Setters for the EC public key components
-	virtual void setEC(const ByteString& ec);
-	virtual void setQ(const ByteString& q);
+	virtual void setEC(const ByteString& inEc);
+	virtual void setQ(const ByteString& inQ);
 
 	// Getters for the EC public key components
 	virtual const ByteString& getEC() const;

--- a/src/lib/crypto/GOSTPrivateKey.cpp
+++ b/src/lib/crypto/GOSTPrivateKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* GOSTPrivateKey::type = "Abstract GOST private key";
 
 // Check if the key is of the given type
-bool GOSTPrivateKey::isOfType(const char* type)
+bool GOSTPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -51,15 +51,15 @@ unsigned long GOSTPrivateKey::getBitLength() const
 }
 
 // Setters for the GOST private key components
-void GOSTPrivateKey::setD(const ByteString& d)
+void GOSTPrivateKey::setD(const ByteString& inD)
 {
-	this->d = d;
+	d = inD;
 }
 
 // Setters for the GOST public key components
-void GOSTPrivateKey::setEC(const ByteString& ec)
+void GOSTPrivateKey::setEC(const ByteString& inEC)
 {
-	this->ec = ec;
+	ec = inEC;
 }
 
 // Getters for the GOST private key components

--- a/src/lib/crypto/GOSTPrivateKey.h
+++ b/src/lib/crypto/GOSTPrivateKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,10 +52,10 @@ public:
 	virtual unsigned long getOutputLength() const = 0;
 
 	// Setters for the GOST private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the GOST public key components
-	virtual void setEC(const ByteString& ec);
+	virtual void setEC(const ByteString& inEC);
 
 	// Getters for the GOST private key components
 	virtual const ByteString& getD() const;

--- a/src/lib/crypto/GOSTPublicKey.cpp
+++ b/src/lib/crypto/GOSTPublicKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* GOSTPublicKey::type = "Abstract GOST public key";
 
 // Check if the key is of the given type
-bool GOSTPublicKey::isOfType(const char* type)
+bool GOSTPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -51,15 +51,15 @@ unsigned long GOSTPublicKey::getBitLength() const
 }
 
 // Setters for the GOST public key components
-void GOSTPublicKey::setQ(const ByteString& q)
+void GOSTPublicKey::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	q = inQ;
 }
 
 // Setters for the GOST public key components
-void GOSTPublicKey::setEC(const ByteString& ec)
+void GOSTPublicKey::setEC(const ByteString& inEC)
 {
-	this->ec = ec;
+	ec = inEC;
 }
 
 // Getters for the GOST public key components

--- a/src/lib/crypto/GOSTPublicKey.h
+++ b/src/lib/crypto/GOSTPublicKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,8 +52,8 @@ public:
 	virtual unsigned long getOutputLength() const = 0;
 
 	// Setters for the GOST public key components
-	virtual void setQ(const ByteString& q);
-	virtual void setEC(const ByteString& ec);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setEC(const ByteString& inEC);
 
 	// Getters for the GOST public key components
 	virtual const ByteString& getQ() const;

--- a/src/lib/crypto/OSSLDHPrivateKey.cpp
+++ b/src/lib/crypto/OSSLDHPrivateKey.cpp
@@ -67,59 +67,71 @@ OSSLDHPrivateKey::~OSSLDHPrivateKey()
 /*static*/ const char* OSSLDHPrivateKey::type = "OpenSSL DH Private Key";
 
 // Set from OpenSSL representation
-void OSSLDHPrivateKey::setFromOSSL(const DH* dh)
+void OSSLDHPrivateKey::setFromOSSL(const DH* inDH)
 {
-	if (dh->p) { ByteString p = OSSL::bn2ByteString(dh->p); setP(p); }
-	if (dh->g) { ByteString g = OSSL::bn2ByteString(dh->g); setG(g); }
-	if (dh->priv_key) { ByteString x = OSSL::bn2ByteString(dh->priv_key); setX(x); }
+	if (inDH->p)
+	{
+		ByteString inP = OSSL::bn2ByteString(inDH->p);
+		setP(inP);
+	}
+	if (inDH->g)
+	{
+		ByteString inG = OSSL::bn2ByteString(inDH->g);
+		setG(inG);
+	}
+	if (inDH->priv_key)
+	{
+		ByteString inX = OSSL::bn2ByteString(inDH->priv_key);
+		setX(inX);
+	}
 }
 
 // Check if the key is of the given type
-bool OSSLDHPrivateKey::isOfType(const char* type)
+bool OSSLDHPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLDHPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DH private key components
-void OSSLDHPrivateKey::setX(const ByteString& x)
+void OSSLDHPrivateKey::setX(const ByteString& inX)
 {
-	DHPrivateKey::setX(x);
+	DHPrivateKey::setX(inX);
 
-	if (dh->priv_key) 
+	if (dh->priv_key)
 	{
 		BN_clear_free(dh->priv_key);
 		dh->priv_key = NULL;
 	}
 
-	dh->priv_key = OSSL::byteString2bn(x);
+	dh->priv_key = OSSL::byteString2bn(inX);
 }
 
 
 // Setters for the DH public key components
-void OSSLDHPrivateKey::setP(const ByteString& p)
+void OSSLDHPrivateKey::setP(const ByteString& inP)
 {
-	DHPrivateKey::setP(p);
+	DHPrivateKey::setP(inP);
 
-	if (dh->p) 
+	if (dh->p)
 	{
 		BN_clear_free(dh->p);
 		dh->p = NULL;
 	}
 
-	dh->p = OSSL::byteString2bn(p);
+	dh->p = OSSL::byteString2bn(inP);
 }
 
-void OSSLDHPrivateKey::setG(const ByteString& g)
+void OSSLDHPrivateKey::setG(const ByteString& inG)
 {
-	DHPrivateKey::setG(g);
+	DHPrivateKey::setG(inG);
 
-	if (dh->g) 
+	if (dh->g)
 	{
 		BN_clear_free(dh->g);
 		dh->g = NULL;
 	}
 
-	dh->g = OSSL::byteString2bn(g);
+	dh->g = OSSL::byteString2bn(inG);
 }
 
 // Encode into PKCS#8 DER
@@ -144,8 +156,8 @@ ByteString OSSLDHPrivateKey::PKCS8Encode()
 		return der;
 	}
 	der.resize(len);
-	unsigned char* p = &der[0];
-	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &p);
+	unsigned char* priv = &der[0];
+	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &priv);
 	PKCS8_PRIV_KEY_INFO_free(p8inf);
 	if (len2 != len) der.wipe();
 	return der;
@@ -156,8 +168,8 @@ bool OSSLDHPrivateKey::PKCS8Decode(const ByteString& ber)
 {
 	int len = ber.size();
 	if (len <= 0) return false;
-	const unsigned char* p = ber.const_byte_str();
-	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &p, len);
+	const unsigned char* priv = ber.const_byte_str();
+	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &priv, len);
 	if (p8 == NULL) return false;
 	EVP_PKEY* pkey = EVP_PKCS82PKEY(p8);
 	PKCS8_PRIV_KEY_INFO_free(p8);

--- a/src/lib/crypto/OSSLDHPrivateKey.h
+++ b/src/lib/crypto/OSSLDHPrivateKey.h
@@ -42,9 +42,9 @@ class OSSLDHPrivateKey : public DHPrivateKey
 public:
 	// Constructors
 	OSSLDHPrivateKey();
-	
+
 	OSSLDHPrivateKey(const DH* inDH);
-	
+
 	// Destructor
 	virtual ~OSSLDHPrivateKey();
 
@@ -52,14 +52,14 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DH private key components
-	virtual void setX(const ByteString& x);
+	virtual void setX(const ByteString& inX);
 
 	// Setters for the DH public key components
-	virtual void setP(const ByteString& p);
-	virtual void setG(const ByteString& g);
+	virtual void setP(const ByteString& inP);
+	virtual void setG(const ByteString& inG);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -68,7 +68,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const DH* dh);
+	virtual void setFromOSSL(const DH* inDH);
 
 	// Retrieve the OpenSSL representation of the key
 	DH* getOSSLKey();

--- a/src/lib/crypto/OSSLDHPublicKey.cpp
+++ b/src/lib/crypto/OSSLDHPublicKey.cpp
@@ -66,57 +66,69 @@ OSSLDHPublicKey::~OSSLDHPublicKey()
 /*static*/ const char* OSSLDHPublicKey::type = "OpenSSL DH Public Key";
 
 // Set from OpenSSL representation
-void OSSLDHPublicKey::setFromOSSL(const DH* dh)
+void OSSLDHPublicKey::setFromOSSL(const DH* inDH)
 {
-	if (dh->p) { ByteString p = OSSL::bn2ByteString(dh->p); setP(p); }
-	if (dh->g) { ByteString g = OSSL::bn2ByteString(dh->g); setG(g); }
-	if (dh->pub_key) { ByteString y = OSSL::bn2ByteString(dh->pub_key); setY(y); }
+	if (inDH->p)
+	{
+		ByteString inP = OSSL::bn2ByteString(inDH->p);
+		setP(inP);
+	}
+	if (inDH->g)
+	{
+		ByteString inG = OSSL::bn2ByteString(inDH->g);
+		setG(inG);
+	}
+	if (inDH->pub_key)
+	{
+		ByteString inY = OSSL::bn2ByteString(inDH->pub_key);
+		setY(inY);
+	}
 }
 
 // Check if the key is of the given type
-bool OSSLDHPublicKey::isOfType(const char* type)
+bool OSSLDHPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLDHPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DH public key components
-void OSSLDHPublicKey::setP(const ByteString& p)
+void OSSLDHPublicKey::setP(const ByteString& inP)
 {
-	DHPublicKey::setP(p);
+	DHPublicKey::setP(inP);
 
-	if (dh->p) 
+	if (dh->p)
 	{
 		BN_clear_free(dh->p);
 		dh->p = NULL;
 	}
 
-	dh->p = OSSL::byteString2bn(p);
+	dh->p = OSSL::byteString2bn(inP);
 }
 
-void OSSLDHPublicKey::setG(const ByteString& g)
+void OSSLDHPublicKey::setG(const ByteString& inG)
 {
-	DHPublicKey::setG(g);
+	DHPublicKey::setG(inG);
 
-	if (dh->g) 
+	if (dh->g)
 	{
 		BN_clear_free(dh->g);
 		dh->g = NULL;
 	}
 
-	dh->g = OSSL::byteString2bn(g);
+	dh->g = OSSL::byteString2bn(inG);
 }
 
-void OSSLDHPublicKey::setY(const ByteString& y)
+void OSSLDHPublicKey::setY(const ByteString& inY)
 {
-	DHPublicKey::setY(y);
+	DHPublicKey::setY(inY);
 
-	if (dh->pub_key) 
+	if (dh->pub_key)
 	{
 		BN_clear_free(dh->pub_key);
 		dh->pub_key = NULL;
 	}
 
-	dh->pub_key = OSSL::byteString2bn(y);
+	dh->pub_key = OSSL::byteString2bn(inY);
 }
 
 // Retrieve the OpenSSL representation of the key

--- a/src/lib/crypto/OSSLDHPublicKey.h
+++ b/src/lib/crypto/OSSLDHPublicKey.h
@@ -42,9 +42,9 @@ class OSSLDHPublicKey : public DHPublicKey
 public:
 	// Constructors
 	OSSLDHPublicKey();
-	
+
 	OSSLDHPublicKey(const DH* inDH);
-	
+
 	// Destructor
 	virtual ~OSSLDHPublicKey();
 
@@ -52,15 +52,15 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DH public key components
-	virtual void setP(const ByteString& p);
-	virtual void setG(const ByteString& g);
-	virtual void setY(const ByteString& y);
+	virtual void setP(const ByteString& inP);
+	virtual void setG(const ByteString& inG);
+	virtual void setY(const ByteString& inY);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const DH* dh);
+	virtual void setFromOSSL(const DH* inDH);
 
 	// Retrieve the OpenSSL representation of the key
 	DH* getOSSLKey();

--- a/src/lib/crypto/OSSLDSAPrivateKey.cpp
+++ b/src/lib/crypto/OSSLDSAPrivateKey.cpp
@@ -67,73 +67,89 @@ OSSLDSAPrivateKey::~OSSLDSAPrivateKey()
 /*static*/ const char* OSSLDSAPrivateKey::type = "OpenSSL DSA Private Key";
 
 // Set from OpenSSL representation
-void OSSLDSAPrivateKey::setFromOSSL(const DSA* dsa)
+void OSSLDSAPrivateKey::setFromOSSL(const DSA* inDSA)
 {
-	if (dsa->p) { ByteString p = OSSL::bn2ByteString(dsa->p); setP(p); }
-	if (dsa->q) { ByteString q = OSSL::bn2ByteString(dsa->q); setQ(q); }
-	if (dsa->g) { ByteString g = OSSL::bn2ByteString(dsa->g); setG(g); }
-	if (dsa->priv_key) { ByteString x = OSSL::bn2ByteString(dsa->priv_key); setX(x); }
+	if (inDSA->p)
+	{
+		ByteString inP = OSSL::bn2ByteString(inDSA->p);
+		setP(inP);
+	}
+	if (inDSA->q)
+	{
+		ByteString inQ = OSSL::bn2ByteString(inDSA->q);
+		setQ(inQ);
+	}
+	if (inDSA->g)
+	{
+		ByteString inG = OSSL::bn2ByteString(inDSA->g);
+		setG(inG);
+	}
+	if (inDSA->priv_key)
+	{
+		ByteString inX = OSSL::bn2ByteString(inDSA->priv_key);
+		setX(inX);
+	}
 }
 
 // Check if the key is of the given type
-bool OSSLDSAPrivateKey::isOfType(const char* type)
+bool OSSLDSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLDSAPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DSA private key components
-void OSSLDSAPrivateKey::setX(const ByteString& x)
+void OSSLDSAPrivateKey::setX(const ByteString& inX)
 {
-	DSAPrivateKey::setX(x);
+	DSAPrivateKey::setX(inX);
 
-	if (dsa->priv_key) 
+	if (dsa->priv_key)
 	{
 		BN_clear_free(dsa->priv_key);
 		dsa->priv_key = NULL;
 	}
 
-	dsa->priv_key = OSSL::byteString2bn(x);
+	dsa->priv_key = OSSL::byteString2bn(inX);
 }
 
 
 // Setters for the DSA domain parameters
-void OSSLDSAPrivateKey::setP(const ByteString& p)
+void OSSLDSAPrivateKey::setP(const ByteString& inP)
 {
-	DSAPrivateKey::setP(p);
+	DSAPrivateKey::setP(inP);
 
-	if (dsa->p) 
+	if (dsa->p)
 	{
 		BN_clear_free(dsa->p);
 		dsa->p = NULL;
 	}
 
-	dsa->p = OSSL::byteString2bn(p);
+	dsa->p = OSSL::byteString2bn(inP);
 }
 
-void OSSLDSAPrivateKey::setQ(const ByteString& q)
+void OSSLDSAPrivateKey::setQ(const ByteString& inQ)
 {
-	DSAPrivateKey::setQ(q);
+	DSAPrivateKey::setQ(inQ);
 
-	if (dsa->q) 
+	if (dsa->q)
 	{
 		BN_clear_free(dsa->q);
 		dsa->q = NULL;
 	}
 
-	dsa->q = OSSL::byteString2bn(q);
+	dsa->q = OSSL::byteString2bn(inQ);
 }
 
-void OSSLDSAPrivateKey::setG(const ByteString& g)
+void OSSLDSAPrivateKey::setG(const ByteString& inG)
 {
-	DSAPrivateKey::setG(g);
+	DSAPrivateKey::setG(inG);
 
-	if (dsa->g) 
+	if (dsa->g)
 	{
 		BN_clear_free(dsa->g);
 		dsa->g = NULL;
 	}
 
-	dsa->g = OSSL::byteString2bn(g);
+	dsa->g = OSSL::byteString2bn(inG);
 }
 
 // Encode into PKCS#8 DER
@@ -158,8 +174,8 @@ ByteString OSSLDSAPrivateKey::PKCS8Encode()
 		return der;
 	}
 	der.resize(len);
-	unsigned char* p = &der[0];
-	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &p);
+	unsigned char* priv = &der[0];
+	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &priv);
 	PKCS8_PRIV_KEY_INFO_free(p8inf);
 	if (len2 != len) der.wipe();
 	return der;
@@ -170,8 +186,8 @@ bool OSSLDSAPrivateKey::PKCS8Decode(const ByteString& ber)
 {
 	int len = ber.size();
 	if (len <= 0) return false;
-	const unsigned char* p = ber.const_byte_str();
-	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &p, len);
+	const unsigned char* priv = ber.const_byte_str();
+	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &priv, len);
 	if (p8 == NULL) return false;
 	EVP_PKEY* pkey = EVP_PKCS82PKEY(p8);
 	PKCS8_PRIV_KEY_INFO_free(p8);

--- a/src/lib/crypto/OSSLDSAPrivateKey.h
+++ b/src/lib/crypto/OSSLDSAPrivateKey.h
@@ -42,9 +42,9 @@ class OSSLDSAPrivateKey : public DSAPrivateKey
 public:
 	// Constructors
 	OSSLDSAPrivateKey();
-	
+
 	OSSLDSAPrivateKey(const DSA* inDSA);
-	
+
 	// Destructor
 	virtual ~OSSLDSAPrivateKey();
 
@@ -52,15 +52,15 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DSA private key components
-	virtual void setX(const ByteString& x);
+	virtual void setX(const ByteString& inX);
 
 	// Setters for the DSA domain parameters
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setG(const ByteString& g);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setG(const ByteString& inG);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -69,7 +69,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const DSA* dsa);
+	virtual void setFromOSSL(const DSA* inDSA);
 
 	// Retrieve the OpenSSL representation of the key
 	DSA* getOSSLKey();

--- a/src/lib/crypto/OSSLDSAPublicKey.cpp
+++ b/src/lib/crypto/OSSLDSAPublicKey.cpp
@@ -66,71 +66,87 @@ OSSLDSAPublicKey::~OSSLDSAPublicKey()
 /*static*/ const char* OSSLDSAPublicKey::type = "OpenSSL DSA Public Key";
 
 // Set from OpenSSL representation
-void OSSLDSAPublicKey::setFromOSSL(const DSA* dsa)
+void OSSLDSAPublicKey::setFromOSSL(const DSA* inDSA)
 {
-	if (dsa->p) { ByteString p = OSSL::bn2ByteString(dsa->p); setP(p); }
-	if (dsa->q) { ByteString q = OSSL::bn2ByteString(dsa->q); setQ(q); }
-	if (dsa->g) { ByteString g = OSSL::bn2ByteString(dsa->g); setG(g); }
-	if (dsa->pub_key) { ByteString y = OSSL::bn2ByteString(dsa->pub_key); setY(y); }
+	if (inDSA->p)
+	{
+		ByteString inP = OSSL::bn2ByteString(inDSA->p);
+		setP(inP);
+	}
+	if (inDSA->q)
+	{
+		ByteString inQ = OSSL::bn2ByteString(inDSA->q);
+		setQ(inQ);
+	}
+	if (inDSA->g)
+	{
+		ByteString inG = OSSL::bn2ByteString(inDSA->g);
+		setG(inG);
+	}
+	if (inDSA->pub_key)
+	{
+		ByteString inY = OSSL::bn2ByteString(inDSA->pub_key);
+		setY(inY);
+	}
 }
 
 // Check if the key is of the given type
-bool OSSLDSAPublicKey::isOfType(const char* type)
+bool OSSLDSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLDSAPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the DSA public key components
-void OSSLDSAPublicKey::setP(const ByteString& p)
+void OSSLDSAPublicKey::setP(const ByteString& inP)
 {
-	DSAPublicKey::setP(p);
+	DSAPublicKey::setP(inP);
 
-	if (dsa->p) 
+	if (dsa->p)
 	{
 		BN_clear_free(dsa->p);
 		dsa->p = NULL;
 	}
 
-	dsa->p = OSSL::byteString2bn(p);
+	dsa->p = OSSL::byteString2bn(inP);
 }
 
-void OSSLDSAPublicKey::setQ(const ByteString& q)
+void OSSLDSAPublicKey::setQ(const ByteString& inQ)
 {
-	DSAPublicKey::setQ(q);
+	DSAPublicKey::setQ(inQ);
 
-	if (dsa->q) 
+	if (dsa->q)
 	{
 		BN_clear_free(dsa->q);
 		dsa->q = NULL;
 	}
 
-	dsa->q = OSSL::byteString2bn(q);
+	dsa->q = OSSL::byteString2bn(inQ);
 }
 
-void OSSLDSAPublicKey::setG(const ByteString& g)
+void OSSLDSAPublicKey::setG(const ByteString& inG)
 {
-	DSAPublicKey::setG(g);
+	DSAPublicKey::setG(inG);
 
-	if (dsa->g) 
+	if (dsa->g)
 	{
 		BN_clear_free(dsa->g);
 		dsa->g = NULL;
 	}
 
-	dsa->g = OSSL::byteString2bn(g);
+	dsa->g = OSSL::byteString2bn(inG);
 }
 
-void OSSLDSAPublicKey::setY(const ByteString& y)
+void OSSLDSAPublicKey::setY(const ByteString& inY)
 {
-	DSAPublicKey::setY(y);
+	DSAPublicKey::setY(inY);
 
-	if (dsa->pub_key) 
+	if (dsa->pub_key)
 	{
 		BN_clear_free(dsa->pub_key);
 		dsa->pub_key = NULL;
 	}
 
-	dsa->pub_key = OSSL::byteString2bn(y);
+	dsa->pub_key = OSSL::byteString2bn(inY);
 }
 
 // Retrieve the OpenSSL representation of the key

--- a/src/lib/crypto/OSSLDSAPublicKey.h
+++ b/src/lib/crypto/OSSLDSAPublicKey.h
@@ -42,9 +42,9 @@ class OSSLDSAPublicKey : public DSAPublicKey
 public:
 	// Constructors
 	OSSLDSAPublicKey();
-	
+
 	OSSLDSAPublicKey(const DSA* inDSA);
-	
+
 	// Destructor
 	virtual ~OSSLDSAPublicKey();
 
@@ -52,16 +52,16 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the DSA public key components
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setG(const ByteString& g);
-	virtual void setY(const ByteString& y);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setG(const ByteString& inG);
+	virtual void setY(const ByteString& inY);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const DSA* dsa);
+	virtual void setFromOSSL(const DSA* inDSA);
 
 	// Retrieve the OpenSSL representation of the key
 	DSA* getOSSLKey();

--- a/src/lib/crypto/OSSLECPrivateKey.cpp
+++ b/src/lib/crypto/OSSLECPrivateKey.cpp
@@ -88,45 +88,45 @@ unsigned long OSSLECPrivateKey::getOrderLength() const
 }
 
 // Set from OpenSSL representation
-void OSSLECPrivateKey::setFromOSSL(const EC_KEY* eckey)
+void OSSLECPrivateKey::setFromOSSL(const EC_KEY* inECKEY)
 {
-	const EC_GROUP* grp = EC_KEY_get0_group(eckey);
+	const EC_GROUP* grp = EC_KEY_get0_group(inECKEY);
 	if (grp != NULL)
 	{
-		ByteString ec = OSSL::grp2ByteString(grp);
-		setEC(ec);
+		ByteString inEC = OSSL::grp2ByteString(grp);
+		setEC(inEC);
 	}
-	const BIGNUM* pk = EC_KEY_get0_private_key(eckey);
+	const BIGNUM* pk = EC_KEY_get0_private_key(inECKEY);
 	if (pk != NULL)
 	{
-		ByteString d = OSSL::bn2ByteString(pk);
-		setD(d);
+		ByteString inD = OSSL::bn2ByteString(pk);
+		setD(inD);
 	}
 }
 
 // Check if the key is of the given type
-bool OSSLECPrivateKey::isOfType(const char* type)
+bool OSSLECPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLECPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the EC private key components
-void OSSLECPrivateKey::setD(const ByteString& d)
+void OSSLECPrivateKey::setD(const ByteString& inD)
 {
-	ECPrivateKey::setD(d);
+	ECPrivateKey::setD(inD);
 
-	BIGNUM* pk = OSSL::byteString2bn(d);
+	BIGNUM* pk = OSSL::byteString2bn(inD);
 	EC_KEY_set_private_key(eckey, pk);
 	BN_clear_free(pk);
 }
 
 
 // Setters for the EC public key components
-void OSSLECPrivateKey::setEC(const ByteString& ec)
+void OSSLECPrivateKey::setEC(const ByteString& inEC)
 {
-	ECPrivateKey::setEC(ec);
+	ECPrivateKey::setEC(inEC);
 
-	EC_GROUP* grp = OSSL::byteString2grp(ec);
+	EC_GROUP* grp = OSSL::byteString2grp(inEC);
 	EC_KEY_set_group(eckey, grp);
 	EC_GROUP_free(grp);
 }
@@ -153,8 +153,8 @@ ByteString OSSLECPrivateKey::PKCS8Encode()
 		return der;
 	}
 	der.resize(len);
-	unsigned char* p = &der[0];
-	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &p);
+	unsigned char* priv = &der[0];
+	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &priv);
 	PKCS8_PRIV_KEY_INFO_free(p8inf);
 	if (len2 != len) der.wipe();
 	return der;
@@ -165,8 +165,8 @@ bool OSSLECPrivateKey::PKCS8Decode(const ByteString& ber)
 {
 	int len = ber.size();
 	if (len <= 0) return false;
-	const unsigned char* p = ber.const_byte_str();
-	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &p, len);
+	const unsigned char* priv = ber.const_byte_str();
+	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &priv, len);
 	if (p8 == NULL) return false;
 	EVP_PKEY* pkey = EVP_PKCS82PKEY(p8);
 	PKCS8_PRIV_KEY_INFO_free(p8);

--- a/src/lib/crypto/OSSLECPrivateKey.h
+++ b/src/lib/crypto/OSSLECPrivateKey.h
@@ -43,9 +43,9 @@ class OSSLECPrivateKey : public ECPrivateKey
 public:
 	// Constructors
 	OSSLECPrivateKey();
-	
+
 	OSSLECPrivateKey(const EC_KEY* inECKEY);
-	
+
 	// Destructor
 	virtual ~OSSLECPrivateKey();
 
@@ -53,16 +53,16 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the base point order length
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the EC private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the EC public key components
-	virtual void setEC(const ByteString& ec);
+	virtual void setEC(const ByteString& inEC);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -71,7 +71,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const EC_KEY* eckey);
+	virtual void setFromOSSL(const EC_KEY* inECKEY);
 
 	// Retrieve the OpenSSL representation of the key
 	EC_KEY* getOSSLKey();

--- a/src/lib/crypto/OSSLECPublicKey.cpp
+++ b/src/lib/crypto/OSSLECPublicKey.cpp
@@ -82,43 +82,43 @@ unsigned long OSSLECPublicKey::getOrderLength() const
 }
 
 // Set from OpenSSL representation
-void OSSLECPublicKey::setFromOSSL(const EC_KEY* eckey)
+void OSSLECPublicKey::setFromOSSL(const EC_KEY* inECKEY)
 {
-	const EC_GROUP* grp = EC_KEY_get0_group(eckey);
+	const EC_GROUP* grp = EC_KEY_get0_group(inECKEY);
 	if (grp != NULL)
 	{
-		ByteString ec = OSSL::grp2ByteString(grp);
-		setEC(ec);
+		ByteString inEC = OSSL::grp2ByteString(grp);
+		setEC(inEC);
 	}
-	const EC_POINT* pub = EC_KEY_get0_public_key(eckey);
+	const EC_POINT* pub = EC_KEY_get0_public_key(inECKEY);
 	if (pub != NULL && grp != NULL)
 	{
-		ByteString q = OSSL::pt2ByteString(pub, grp);
-		setQ(q);
+		ByteString inQ = OSSL::pt2ByteString(pub, grp);
+		setQ(inQ);
 	}
 }
 
 // Check if the key is of the given type
-bool OSSLECPublicKey::isOfType(const char* type)
+bool OSSLECPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLECPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the EC public key components
-void OSSLECPublicKey::setEC(const ByteString& ec)
+void OSSLECPublicKey::setEC(const ByteString& inEC)
 {
-	ECPublicKey::setEC(ec);
+	ECPublicKey::setEC(inEC);
 
-	EC_GROUP* grp = OSSL::byteString2grp(ec);
+	EC_GROUP* grp = OSSL::byteString2grp(inEC);
 	EC_KEY_set_group(eckey, grp);
 	EC_GROUP_free(grp);
 }
 
-void OSSLECPublicKey::setQ(const ByteString& q)
+void OSSLECPublicKey::setQ(const ByteString& inQ)
 {
-	ECPublicKey::setQ(q);
+	ECPublicKey::setQ(inQ);
 
-	EC_POINT* pub = OSSL::byteString2pt(q, EC_KEY_get0_group(eckey));
+	EC_POINT* pub = OSSL::byteString2pt(inQ, EC_KEY_get0_group(eckey));
 	EC_KEY_set_public_key(eckey, pub);
 	EC_POINT_free(pub);
 }

--- a/src/lib/crypto/OSSLECPublicKey.h
+++ b/src/lib/crypto/OSSLECPublicKey.h
@@ -42,9 +42,9 @@ class OSSLECPublicKey : public ECPublicKey
 public:
 	// Constructors
 	OSSLECPublicKey();
-	
+
 	OSSLECPublicKey(const EC_KEY* inECKEY);
-	
+
 	// Destructor
 	virtual ~OSSLECPublicKey();
 
@@ -52,17 +52,17 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the base point order length
 	virtual unsigned long getOrderLength() const;
 
 	// Setters for the EC public key components
-	virtual void setEC(const ByteString& ec);
-	virtual void setQ(const ByteString& q);
+	virtual void setEC(const ByteString& inEC);
+	virtual void setQ(const ByteString& inQ);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const EC_KEY* eckey);
+	virtual void setFromOSSL(const EC_KEY* inECKEY);
 
 	// Retrieve the OpenSSL representation of the key
 	EC_KEY* getOSSLKey();

--- a/src/lib/crypto/OSSLGOSTPrivateKey.cpp
+++ b/src/lib/crypto/OSSLGOSTPrivateKey.cpp
@@ -95,15 +95,15 @@ void OSSLGOSTPrivateKey::setFromOSSL(const EVP_PKEY* pkey)
 }
 
 // Check if the key is of the given type
-bool OSSLGOSTPrivateKey::isOfType(const char* type)
+bool OSSLGOSTPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLGOSTPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the GOST private key components
-void OSSLGOSTPrivateKey::setD(const ByteString& d)
+void OSSLGOSTPrivateKey::setD(const ByteString& inD)
 {
-	GOSTPrivateKey::setD(d);
+	GOSTPrivateKey::setD(inD);
 
 	EC_KEY* ec = (EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
 	if (ec == NULL)
@@ -118,7 +118,7 @@ void OSSLGOSTPrivateKey::setD(const ByteString& d)
 		ec = (EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
 	}
 
-	const BIGNUM* priv = OSSL::byteString2bn(d);
+	const BIGNUM* priv = OSSL::byteString2bn(inD);
 	if (EC_KEY_set_private_key(ec, priv) <= 0)
 	{
 		ERROR_MSG("EC_KEY_set_private_key failed");
@@ -129,13 +129,13 @@ void OSSLGOSTPrivateKey::setD(const ByteString& d)
 #ifdef notyet
 	if (gost2001_compute_public(ec) <= 0)
 		ERROR_MSG("gost2001_compute_public failed");
-#endif		
+#endif
 }
 
 // Setters for the GOST public key components
-void OSSLGOSTPrivateKey::setEC(const ByteString& ec)
+void OSSLGOSTPrivateKey::setEC(const ByteString& inEC)
 {
-        GOSTPrivateKey::setEC(ec);
+        GOSTPrivateKey::setEC(inEC);
 }
 
 // Retrieve the OpenSSL representation of the key

--- a/src/lib/crypto/OSSLGOSTPrivateKey.cpp
+++ b/src/lib/crypto/OSSLGOSTPrivateKey.cpp
@@ -86,12 +86,12 @@ void OSSLGOSTPrivateKey::setFromOSSL(const EVP_PKEY* pkey)
 	const BIGNUM* priv = EC_KEY_get0_private_key(eckey);
 	setD(OSSL::bn2ByteString(priv));
 
-	ByteString ec;
+	ByteString inEC;
 	int nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(eckey));
 	ec.resize(i2d_ASN1_OBJECT(OBJ_nid2obj(nid), NULL));
-	unsigned char *p = &ec[0];
+	unsigned char *p = &inEC[0];
 	i2d_ASN1_OBJECT(OBJ_nid2obj(nid), &p);
-	setEC(ec);
+	setEC(inEC);
 }
 
 // Check if the key is of the given type
@@ -105,8 +105,8 @@ void OSSLGOSTPrivateKey::setD(const ByteString& inD)
 {
 	GOSTPrivateKey::setD(inD);
 
-	EC_KEY* ec = (EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
-	if (ec == NULL)
+	EC_KEY* inEC = (EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
+	if (inEC == NULL)
 	{
 		const unsigned char* p = dummyKey;
 		if (d2i_PrivateKey(NID_id_GostR3410_2001, &pkey, &p, (long) sizeof(dummyKey)) == NULL)
@@ -115,11 +115,11 @@ void OSSLGOSTPrivateKey::setD(const ByteString& inD)
 
 			return;
 		}
-		ec = (EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
+		inEC = (EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
 	}
 
 	const BIGNUM* priv = OSSL::byteString2bn(inD);
-	if (EC_KEY_set_private_key(ec, priv) <= 0)
+	if (EC_KEY_set_private_key(inEC, priv) <= 0)
 	{
 		ERROR_MSG("EC_KEY_set_private_key failed");
 		return;
@@ -127,7 +127,7 @@ void OSSLGOSTPrivateKey::setD(const ByteString& inD)
 	BN_clear_free((BIGNUM*)priv);
 
 #ifdef notyet
-	if (gost2001_compute_public(ec) <= 0)
+	if (gost2001_compute_public(inEC) <= 0)
 		ERROR_MSG("gost2001_compute_public failed");
 #endif
 }

--- a/src/lib/crypto/OSSLGOSTPrivateKey.h
+++ b/src/lib/crypto/OSSLGOSTPrivateKey.h
@@ -42,9 +42,9 @@ class OSSLGOSTPrivateKey : public GOSTPrivateKey
 public:
 	// Constructors
 	OSSLGOSTPrivateKey();
-	
+
 	OSSLGOSTPrivateKey(const EVP_PKEY* inPKEY);
-	
+
 	// Destructor
 	virtual ~OSSLGOSTPrivateKey();
 
@@ -52,16 +52,16 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the output length
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the GOST private key components
-	virtual void setD(const ByteString& d);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the GOST public key components
-	virtual void setEC(const ByteString& d);
+	virtual void setEC(const ByteString& inEC);
 
 	// Serialisation
 	virtual ByteString serialise() const;

--- a/src/lib/crypto/OSSLGOSTPublicKey.cpp
+++ b/src/lib/crypto/OSSLGOSTPublicKey.cpp
@@ -100,22 +100,22 @@ void OSSLGOSTPublicKey::setFromOSSL(const EVP_PKEY* pkey)
 }
 
 // Check if the key is of the given type
-bool OSSLGOSTPublicKey::isOfType(const char* type)
+bool OSSLGOSTPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLGOSTPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the GOST public key components
-void OSSLGOSTPublicKey::setEC(const ByteString& ec)
+void OSSLGOSTPublicKey::setEC(const ByteString& inEC)
 {
-        GOSTPublicKey::setEC(ec);
+        GOSTPublicKey::setEC(inEC);
 }
 
-void OSSLGOSTPublicKey::setQ(const ByteString& q)
+void OSSLGOSTPublicKey::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	GOSTPublicKey::setQ(inQ);
 
-	if (q.size() != 64)
+	if (inQ.size() != 64)
 	{
 		ERROR_MSG("bad GOST public key size %zu", q.size());
 		return;
@@ -124,7 +124,7 @@ void OSSLGOSTPublicKey::setQ(const ByteString& q)
 	ByteString der;
 	der.resize(37 + 64);
 	memcpy(&der[0], gost_prefix, 37);
-	memcpy(&der[37], q.const_byte_str(), 64);
+	memcpy(&der[37], inQ.const_byte_str(), 64);
 	const unsigned char *p = &der[0];
 	if (d2i_PUBKEY(&pkey, &p, (long) der.size()) == NULL)
 		ERROR_MSG("d2i_PUBKEY failed");

--- a/src/lib/crypto/OSSLGOSTPublicKey.cpp
+++ b/src/lib/crypto/OSSLGOSTPublicKey.cpp
@@ -90,13 +90,13 @@ void OSSLGOSTPublicKey::setFromOSSL(const EVP_PKEY* pkey)
 	// can check: der is prefix + 64 bytes
 	setQ(der.substr(37));
 
-	ByteString ec;
+	ByteString inEC;
 	const EC_KEY* eckey = (const EC_KEY*) EVP_PKEY_get0((EVP_PKEY*) pkey);
 	int nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(eckey));
-	ec.resize(i2d_ASN1_OBJECT(OBJ_nid2obj(nid), NULL));
-	p = &ec[0];
+	inEC.resize(i2d_ASN1_OBJECT(OBJ_nid2obj(nid), NULL));
+	p = &inEC[0];
 	i2d_ASN1_OBJECT(OBJ_nid2obj(nid), &p);
-	setEC(ec);
+	setEC(inEC);
 }
 
 // Check if the key is of the given type

--- a/src/lib/crypto/OSSLGOSTPublicKey.h
+++ b/src/lib/crypto/OSSLGOSTPublicKey.h
@@ -42,9 +42,9 @@ class OSSLGOSTPublicKey : public GOSTPublicKey
 public:
 	// Constructors
 	OSSLGOSTPublicKey();
-	
+
 	OSSLGOSTPublicKey(const EVP_PKEY* inPKEY);
-	
+
 	// Destructor
 	virtual ~OSSLGOSTPublicKey();
 
@@ -52,14 +52,14 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the output length
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the GOST public key components
-	virtual void setEC(const ByteString& ec);
-	virtual void setQ(const ByteString& q);
+	virtual void setEC(const ByteString& inEC);
+	virtual void setQ(const ByteString& inQ);
 
 	// Serialisation
 	virtual ByteString serialise() const;

--- a/src/lib/crypto/OSSLRSAPrivateKey.cpp
+++ b/src/lib/crypto/OSSLRSAPrivateKey.cpp
@@ -67,129 +67,161 @@ OSSLRSAPrivateKey::~OSSLRSAPrivateKey()
 /*static*/ const char* OSSLRSAPrivateKey::type = "OpenSSL RSA Private Key";
 
 // Set from OpenSSL representation
-void OSSLRSAPrivateKey::setFromOSSL(const RSA* rsa)
+void OSSLRSAPrivateKey::setFromOSSL(const RSA* inRSA)
 {
-	if (rsa->p) { ByteString p = OSSL::bn2ByteString(rsa->p); setP(p); }
-	if (rsa->q) { ByteString q = OSSL::bn2ByteString(rsa->q); setQ(q); }
-	if (rsa->dmp1) { ByteString dp1 = OSSL::bn2ByteString(rsa->dmp1); setDP1(dp1); }
-	if (rsa->dmq1) { ByteString dq1 = OSSL::bn2ByteString(rsa->dmq1); setDQ1(dq1); }
-	if (rsa->iqmp) { ByteString pq = OSSL::bn2ByteString(rsa->iqmp); setPQ(pq); }
-	if (rsa->d) { ByteString d = OSSL::bn2ByteString(rsa->d); setD(d); }
-	if (rsa->n) { ByteString n = OSSL::bn2ByteString(rsa->n); setN(n); }
-	if (rsa->e) { ByteString e = OSSL::bn2ByteString(rsa->e); setE(e); }
+	if (inRSA->p)
+	{
+		ByteString inP = OSSL::bn2ByteString(inRSA->p);
+		setP(inP);
+	}
+	if (inRSA->q)
+	{
+		ByteString inQ = OSSL::bn2ByteString(inRSA->q);
+		setQ(inQ);
+	}
+	if (inRSA->dmp1)
+	{
+		ByteString inDP1 = OSSL::bn2ByteString(inRSA->dmp1);
+		setDP1(inDP1);
+	}
+	if (inRSA->dmq1)
+	{
+		ByteString inDQ1 = OSSL::bn2ByteString(inRSA->dmq1);
+		setDQ1(inDQ1);
+	}
+	if (inRSA->iqmp)
+	{
+		ByteString inPQ = OSSL::bn2ByteString(inRSA->iqmp);
+		setPQ(inPQ);
+	}
+	if (inRSA->d)
+	{
+		ByteString inD = OSSL::bn2ByteString(inRSA->d);
+		setD(inD);
+	}
+	if (inRSA->n)
+	{
+		ByteString inN = OSSL::bn2ByteString(inRSA->n);
+		setN(inN);
+	}
+	if (inRSA->e)
+	{
+		ByteString inE = OSSL::bn2ByteString(inRSA->e);
+		setE(inE);
+	}
 }
 
 // Check if the key is of the given type
-bool OSSLRSAPrivateKey::isOfType(const char* type)
+bool OSSLRSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLRSAPrivateKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Setters for the RSA private key components
-void OSSLRSAPrivateKey::setP(const ByteString& p)
+void OSSLRSAPrivateKey::setP(const ByteString& inP)
 {
-	RSAPrivateKey::setP(p);
+	RSAPrivateKey::setP(inP);
 
-	if (rsa->p) 
+	if (rsa->p)
 	{
 		BN_clear_free(rsa->p);
 		rsa->p = NULL;
 	}
 
-	rsa->p = OSSL::byteString2bn(p);
+	rsa->p = OSSL::byteString2bn(inP);
 }
 
-void OSSLRSAPrivateKey::setQ(const ByteString& q)
+void OSSLRSAPrivateKey::setQ(const ByteString& inQ)
 {
-	RSAPrivateKey::setQ(q);
+	RSAPrivateKey::setQ(inQ);
 
-	if (rsa->q) 
+	if (rsa->q)
 	{
 		BN_clear_free(rsa->q);
 		rsa->q = NULL;
 	}
 
-	rsa->q = OSSL::byteString2bn(q);
+	rsa->q = OSSL::byteString2bn(inQ);
 }
 
-void OSSLRSAPrivateKey::setPQ(const ByteString& pq)
+void OSSLRSAPrivateKey::setPQ(const ByteString& inPQ)
 {
-	RSAPrivateKey::setPQ(pq);
+	RSAPrivateKey::setPQ(inPQ);
 
-	if (rsa->iqmp) 
+	if (rsa->iqmp)
 	{
 		BN_clear_free(rsa->iqmp);
 		rsa->iqmp = NULL;
 	}
 
-	rsa->iqmp = OSSL::byteString2bn(pq);
+	rsa->iqmp = OSSL::byteString2bn(inPQ);
 }
 
-void OSSLRSAPrivateKey::setDP1(const ByteString& dp1)
+void OSSLRSAPrivateKey::setDP1(const ByteString& inDP1)
 {
-	RSAPrivateKey::setDP1(dp1);
+	RSAPrivateKey::setDP1(inDP1);
 
-	if (rsa->dmp1) 
+	if (rsa->dmp1)
 	{
 		BN_clear_free(rsa->dmp1);
 		rsa->dmp1 = NULL;
 	}
 
-	rsa->dmp1 = OSSL::byteString2bn(dp1);
+	rsa->dmp1 = OSSL::byteString2bn(inDP1);
 }
 
-void OSSLRSAPrivateKey::setDQ1(const ByteString& dq1)
+void OSSLRSAPrivateKey::setDQ1(const ByteString& inDQ1)
 {
-	RSAPrivateKey::setDQ1(dq1);
+	RSAPrivateKey::setDQ1(inDQ1);
 
-	if (rsa->dmq1) 
+	if (rsa->dmq1)
 	{
 		BN_clear_free(rsa->dmq1);
 		rsa->dmq1 = NULL;
 	}
 
-	rsa->dmq1 = OSSL::byteString2bn(dq1);
+	rsa->dmq1 = OSSL::byteString2bn(inDQ1);
 }
 
-void OSSLRSAPrivateKey::setD(const ByteString& d)
+void OSSLRSAPrivateKey::setD(const ByteString& inD)
 {
-	RSAPrivateKey::setD(d);
+	RSAPrivateKey::setD(inD);
 
-	if (rsa->d) 
+	if (rsa->d)
 	{
 		BN_clear_free(rsa->d);
 		rsa->d = NULL;
 	}
 
-	rsa->d = OSSL::byteString2bn(d);
+	rsa->d = OSSL::byteString2bn(inD);
 }
 
 
 // Setters for the RSA public key components
-void OSSLRSAPrivateKey::setN(const ByteString& n)
+void OSSLRSAPrivateKey::setN(const ByteString& inN)
 {
-	RSAPrivateKey::setN(n);
+	RSAPrivateKey::setN(inN);
 
-	if (rsa->n) 
+	if (rsa->n)
 	{
 		BN_clear_free(rsa->n);
 		rsa->n = NULL;
 	}
 
-	rsa->n = OSSL::byteString2bn(n);
+	rsa->n = OSSL::byteString2bn(inN);
 }
 
-void OSSLRSAPrivateKey::setE(const ByteString& e)
+void OSSLRSAPrivateKey::setE(const ByteString& inE)
 {
-	RSAPrivateKey::setE(e);
+	RSAPrivateKey::setE(inE);
 
-	if (rsa->e) 
+	if (rsa->e)
 	{
 		BN_clear_free(rsa->e);
 		rsa->e = NULL;
 	}
 
-	rsa->e = OSSL::byteString2bn(e);
+	rsa->e = OSSL::byteString2bn(inE);
 }
 
 // Encode into PKCS#8 DER
@@ -214,8 +246,8 @@ ByteString OSSLRSAPrivateKey::PKCS8Encode()
 		return der;
 	}
 	der.resize(len);
-	unsigned char* p = &der[0];
-	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &p);
+	unsigned char* priv = &der[0];
+	int len2 = i2d_PKCS8_PRIV_KEY_INFO(p8inf, &priv);
 	PKCS8_PRIV_KEY_INFO_free(p8inf);
 	if (len2 != len) der.wipe();
 	return der;
@@ -226,8 +258,8 @@ bool OSSLRSAPrivateKey::PKCS8Decode(const ByteString& ber)
 {
 	int len = ber.size();
 	if (len <= 0) return false;
-	const unsigned char* p = ber.const_byte_str();
-	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &p, len);
+	const unsigned char* priv = ber.const_byte_str();
+	PKCS8_PRIV_KEY_INFO* p8 = d2i_PKCS8_PRIV_KEY_INFO(NULL, &priv, len);
 	if (p8 == NULL) return false;
 	EVP_PKEY* pkey = EVP_PKCS82PKEY(p8);
 	PKCS8_PRIV_KEY_INFO_free(p8);

--- a/src/lib/crypto/OSSLRSAPrivateKey.h
+++ b/src/lib/crypto/OSSLRSAPrivateKey.h
@@ -42,9 +42,9 @@ class OSSLRSAPrivateKey : public RSAPrivateKey
 public:
 	// Constructors
 	OSSLRSAPrivateKey();
-	
+
 	OSSLRSAPrivateKey(const RSA* inRSA);
-	
+
 	// Destructor
 	virtual ~OSSLRSAPrivateKey();
 
@@ -52,19 +52,19 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the RSA private key components
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setPQ(const ByteString& pq);
-	virtual void setDP1(const ByteString& dp1);
-	virtual void setDQ1(const ByteString& dq1);
-	virtual void setD(const ByteString& d);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setPQ(const ByteString& inPQ);
+	virtual void setDP1(const ByteString& inDP1);
+	virtual void setDQ1(const ByteString& inDQ1);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the RSA public key components
-	virtual void setN(const ByteString& n);
-	virtual void setE(const ByteString& e);
+	virtual void setN(const ByteString& inN);
+	virtual void setE(const ByteString& inE);
 
 	// Encode into PKCS#8 DER
 	virtual ByteString PKCS8Encode();
@@ -73,7 +73,7 @@ public:
 	virtual bool PKCS8Decode(const ByteString& ber);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const RSA* rsa);
+	virtual void setFromOSSL(const RSA* inRSA);
 
 	// Retrieve the OpenSSL representation of the key
 	RSA* getOSSLKey();

--- a/src/lib/crypto/OSSLRSAPublicKey.cpp
+++ b/src/lib/crypto/OSSLRSAPublicKey.cpp
@@ -66,43 +66,51 @@ OSSLRSAPublicKey::~OSSLRSAPublicKey()
 /*static*/ const char* OSSLRSAPublicKey::type = "OpenSSL RSA Public Key";
 
 // Check if the key is of the given type
-bool OSSLRSAPublicKey::isOfType(const char* type)
+bool OSSLRSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(OSSLRSAPublicKey::type, type);
+	return !strcmp(type, inType);
 }
 
 // Set from OpenSSL representation
-void OSSLRSAPublicKey::setFromOSSL(const RSA* rsa)
+void OSSLRSAPublicKey::setFromOSSL(const RSA* inRSA)
 {
-	if (rsa->n) { ByteString n = OSSL::bn2ByteString(rsa->n); setN(n); }
-	if (rsa->e) { ByteString e = OSSL::bn2ByteString(rsa->e); setE(e); }
+	if (inRSA->n)
+	{
+		ByteString inN = OSSL::bn2ByteString(inRSA->n);
+		setN(inN);
+	}
+	if (inRSA->e)
+	{
+		ByteString inE = OSSL::bn2ByteString(inRSA->e);
+		setE(inE);
+	}
 }
 
 // Setters for the RSA public key components
-void OSSLRSAPublicKey::setN(const ByteString& n)
+void OSSLRSAPublicKey::setN(const ByteString& inN)
 {
-	RSAPublicKey::setN(n);
+	RSAPublicKey::setN(inN);
 
-	if (rsa->n) 
+	if (rsa->n)
 	{
 		BN_clear_free(rsa->n);
 		rsa->n = NULL;
 	}
 
-	rsa->n = OSSL::byteString2bn(n);
+	rsa->n = OSSL::byteString2bn(inN);
 }
 
-void OSSLRSAPublicKey::setE(const ByteString& e)
+void OSSLRSAPublicKey::setE(const ByteString& inE)
 {
-	RSAPublicKey::setE(e);
+	RSAPublicKey::setE(inE);
 
-	if (rsa->e) 
+	if (rsa->e)
 	{
 		BN_clear_free(rsa->e);
 		rsa->e = NULL;
 	}
 
-	rsa->e = OSSL::byteString2bn(e);
+	rsa->e = OSSL::byteString2bn(inE);
 }
 
 // Retrieve the OpenSSL representation of the key

--- a/src/lib/crypto/OSSLRSAPublicKey.h
+++ b/src/lib/crypto/OSSLRSAPublicKey.h
@@ -42,9 +42,9 @@ class OSSLRSAPublicKey : public RSAPublicKey
 public:
 	// Constructors
 	OSSLRSAPublicKey();
-	
+
 	OSSLRSAPublicKey(const RSA* inRSA);
-	
+
 	// Destructor
 	virtual ~OSSLRSAPublicKey();
 
@@ -52,14 +52,14 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Setters for the RSA public key components
-	virtual void setN(const ByteString& n);
-	virtual void setE(const ByteString& e);
+	virtual void setN(const ByteString& inN);
+	virtual void setE(const ByteString& inE);
 
 	// Set from OpenSSL representation
-	virtual void setFromOSSL(const RSA* rsa);
+	virtual void setFromOSSL(const RSA* inRSA);
 
 	// Retrieve the OpenSSL representation of the key
 	RSA* getOSSLKey();

--- a/src/lib/crypto/PrivateKey.h
+++ b/src/lib/crypto/PrivateKey.h
@@ -50,7 +50,7 @@ public:
 	virtual ~PrivateKey() { }
 
 	// Check if the private key is of the given type
-	virtual bool isOfType(const char* type) = 0;
+	virtual bool isOfType(const char* inType) = 0;
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const = 0;

--- a/src/lib/crypto/PublicKey.h
+++ b/src/lib/crypto/PublicKey.h
@@ -49,7 +49,7 @@ public:
 	virtual ~PublicKey() { }
 
 	// Check if it is of the given type
-	virtual bool isOfType(const char* type) = 0;
+	virtual bool isOfType(const char* inType) = 0;
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const = 0;

--- a/src/lib/crypto/RSAParameters.cpp
+++ b/src/lib/crypto/RSAParameters.cpp
@@ -39,15 +39,15 @@
 /*static*/ const char* RSAParameters::type = "Generic RSA parameters";
 
 // Set the public exponent
-void RSAParameters::setE(const ByteString& e)
+void RSAParameters::setE(const ByteString& inE)
 {
-	this->e = e;
+	e = inE;
 }
 
 // Set the bit length
-void RSAParameters::setBitLength(const size_t bitLen)
+void RSAParameters::setBitLength(const size_t inBitLen)
 {
-	this->bitLen = bitLen;
+	bitLen = inBitLen;
 }
 
 // Get the public exponent
@@ -63,9 +63,9 @@ size_t RSAParameters::getBitLength() const
 }
 
 // Are the parameters of the given type?
-bool RSAParameters::areOfType(const char* type)
+bool RSAParameters::areOfType(const char* inType)
 {
-	return (strcmp(type, RSAParameters::type) == 0);
+	return (strcmp(type, inType) == 0);
 }
 
 // Serialisation

--- a/src/lib/crypto/RSAParameters.h
+++ b/src/lib/crypto/RSAParameters.h
@@ -47,10 +47,10 @@ public:
 	static const char* type;
 
 	// Set the public exponent
-	void setE(const ByteString& e);
+	void setE(const ByteString& inE);
 
 	// Set the bit length
-	void setBitLength(const size_t bitLen);
+	void setBitLength(const size_t inBitLen);
 
 	// Get the public exponent
 	const ByteString& getE() const;
@@ -59,7 +59,7 @@ public:
 	size_t getBitLength() const;
 
 	// Are the parameters of the given type?
-	virtual bool areOfType(const char* type);
+	virtual bool areOfType(const char* inType);
 
 	// Serialisation
 	virtual ByteString serialise() const;

--- a/src/lib/crypto/RSAPrivateKey.cpp
+++ b/src/lib/crypto/RSAPrivateKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* RSAPrivateKey::type = "Abstract RSA private key";
 
 // Check if the key is of the given type
-bool RSAPrivateKey::isOfType(const char* type)
+bool RSAPrivateKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -58,45 +58,45 @@ unsigned long RSAPrivateKey::getOutputLength() const
 }
 
 // Setters for the RSA private key components
-void RSAPrivateKey::setP(const ByteString& p)
+void RSAPrivateKey::setP(const ByteString& inP)
 {
-	this->p = p;
+	p = inP;
 }
 
-void RSAPrivateKey::setQ(const ByteString& q)
+void RSAPrivateKey::setQ(const ByteString& inQ)
 {
-	this->q = q;
+	q = inQ;
 }
 
-void RSAPrivateKey::setPQ(const ByteString& pq)
+void RSAPrivateKey::setPQ(const ByteString& inPQ)
 {
-	this->pq = pq;
+	pq = inPQ;
 }
 
-void RSAPrivateKey::setDP1(const ByteString& dp1)
+void RSAPrivateKey::setDP1(const ByteString& inDP1)
 {
-	this->dp1 = dp1;
+	dp1 = inDP1;
 }
 
-void RSAPrivateKey::setDQ1(const ByteString& dq1)
+void RSAPrivateKey::setDQ1(const ByteString& inDQ1)
 {
-	this->dq1 = dq1;
+	dq1 = inDQ1;
 }
 
-void RSAPrivateKey::setD(const ByteString& d)
+void RSAPrivateKey::setD(const ByteString& inD)
 {
-	this->d = d;
+	d = inD;
 }
 
 // Setters for the RSA public key components
-void RSAPrivateKey::setN(const ByteString& n)
+void RSAPrivateKey::setN(const ByteString& inN)
 {
-	this->n = n;
+	n = inN;
 }
 
-void RSAPrivateKey::setE(const ByteString& e)
+void RSAPrivateKey::setE(const ByteString& inE)
 {
-	this->e = e;
+	e = inE;
 }
 
 // Getters for the RSA private key components

--- a/src/lib/crypto/RSAPrivateKey.h
+++ b/src/lib/crypto/RSAPrivateKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,16 +52,16 @@ public:
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the RSA private key components
-	virtual void setP(const ByteString& p);
-	virtual void setQ(const ByteString& q);
-	virtual void setPQ(const ByteString& pq);
-	virtual void setDP1(const ByteString& dp1);
-	virtual void setDQ1(const ByteString& dq1);
-	virtual void setD(const ByteString& d);
+	virtual void setP(const ByteString& inP);
+	virtual void setQ(const ByteString& inQ);
+	virtual void setPQ(const ByteString& inPQ);
+	virtual void setDP1(const ByteString& inDP1);
+	virtual void setDQ1(const ByteString& inDQ1);
+	virtual void setD(const ByteString& inD);
 
 	// Setters for the RSA public key components
-	virtual void setN(const ByteString& n);
-	virtual void setE(const ByteString& e);
+	virtual void setN(const ByteString& inN);
+	virtual void setE(const ByteString& inE);
 
 	// Getters for the RSA private key components
 	virtual const ByteString& getP() const;

--- a/src/lib/crypto/RSAPublicKey.cpp
+++ b/src/lib/crypto/RSAPublicKey.cpp
@@ -39,9 +39,9 @@
 /*static*/ const char* RSAPublicKey::type = "Abstract RSA public key";
 
 // Check if the key is of the given type
-bool RSAPublicKey::isOfType(const char* type)
+bool RSAPublicKey::isOfType(const char* inType)
 {
-	return !strcmp(this->type, type);
+	return !strcmp(type, inType);
 }
 
 // Get the bit length
@@ -58,14 +58,14 @@ unsigned long RSAPublicKey::getOutputLength() const
 }
 
 // Setters for the RSA public key components
-void RSAPublicKey::setN(const ByteString& n)
+void RSAPublicKey::setN(const ByteString& inN)
 {
-	this->n = n;
+	n = inN;
 }
 
-void RSAPublicKey::setE(const ByteString& e)
+void RSAPublicKey::setE(const ByteString& inE)
 {
-	this->e = e;
+	e = inE;
 }
 
 // Getters for the RSA public key components

--- a/src/lib/crypto/RSAPublicKey.h
+++ b/src/lib/crypto/RSAPublicKey.h
@@ -43,7 +43,7 @@ public:
 	static const char* type;
 
 	// Check if the key is of the given type
-	virtual bool isOfType(const char* type);
+	virtual bool isOfType(const char* inType);
 
 	// Get the bit length
 	virtual unsigned long getBitLength() const;
@@ -52,8 +52,8 @@ public:
 	virtual unsigned long getOutputLength() const;
 
 	// Setters for the RSA public key components
-	virtual void setN(const ByteString& n);
-	virtual void setE(const ByteString& e);
+	virtual void setN(const ByteString& inN);
+	virtual void setE(const ByteString& inE);
 
 	// Getters for the RSA public key components
 	virtual const ByteString& getN() const;

--- a/src/lib/crypto/SymmetricKey.cpp
+++ b/src/lib/crypto/SymmetricKey.cpp
@@ -36,9 +36,9 @@
 #include "SymmetricKey.h"
 
 // Base constructors
-SymmetricKey::SymmetricKey(size_t bitLen /* = 0 */)
+SymmetricKey::SymmetricKey(size_t inBitLen /* = 0 */)
 {
-	this->bitLen = bitLen;
+	bitLen = inBitLen;
 }
 
 SymmetricKey::SymmetricKey(const SymmetricKey& in)
@@ -73,9 +73,9 @@ ByteString SymmetricKey::serialise() const
 }
 
 // Set the bit length
-void SymmetricKey::setBitLen(const size_t bitLen)
+void SymmetricKey::setBitLen(const size_t inBitLen)
 {
-	this->bitLen = bitLen;
+	bitLen = inBitLen;
 }
 
 // Retrieve the bit length

--- a/src/lib/crypto/SymmetricKey.h
+++ b/src/lib/crypto/SymmetricKey.h
@@ -41,7 +41,7 @@ class SymmetricKey : public Serialisable
 {
 public:
 	// Base constructors
-	SymmetricKey(size_t bitLen = 0);
+	SymmetricKey(size_t inBitLen = 0);
 
 	SymmetricKey(const SymmetricKey& in);
 
@@ -58,7 +58,7 @@ public:
 	virtual ByteString serialise() const;
 
 	// Set the bit length
-	virtual void setBitLen(const size_t bitLen);
+	virtual void setBitLen(const size_t inBitLen);
 
 	// Retrieve the bit length
 	virtual size_t getBitLen() const;

--- a/src/lib/object_store/Directory.cpp
+++ b/src/lib/object_store/Directory.cpp
@@ -49,9 +49,9 @@
 #include <sys/stat.h>
 
 // Constructor
-Directory::Directory(std::string path)
+Directory::Directory(std::string inPath)
 {
-	this->path = path;
+	path = inPath;
 	dirMutex = MutexFactory::i()->getMutex();
 
 	valid = (dirMutex != NULL) && refresh();

--- a/src/lib/object_store/Directory.h
+++ b/src/lib/object_store/Directory.h
@@ -42,7 +42,7 @@ class Directory
 {
 public:
 	// Constructor
-	Directory(std::string path);
+	Directory(std::string inPath);
 
 	// Destructor
 	virtual ~Directory();

--- a/src/lib/object_store/File.cpp
+++ b/src/lib/object_store/File.cpp
@@ -63,7 +63,7 @@ enum AttributeKind {
 //
 // N.B.: the create flag only has a function when a file is opened read/write
 // N.B.: the truncate flag only has a function when the create one is true
-File::File(std::string path, bool forRead /* = true */, bool forWrite /* = false */, bool create /* = false */, bool truncate /* = true */)
+File::File(std::string inPath, bool forRead /* = true */, bool forWrite /* = false */, bool create /* = false */, bool truncate /* = true */)
 {
 	stream = NULL;
 
@@ -71,7 +71,7 @@ File::File(std::string path, bool forRead /* = true */, bool forWrite /* = false
 	isWritable = forWrite;
 	locked = false;
 
-	this->path = path;
+	path = inPath;
 	valid = false;
 
 	if (forRead || forWrite)

--- a/src/lib/object_store/File.h
+++ b/src/lib/object_store/File.h
@@ -42,7 +42,7 @@ class File
 {
 public:
 	// Constructor
-	File(std::string path, bool forRead = true, bool forWrite = false, bool create = false, bool truncate = true);
+	File(std::string inPath, bool forRead = true, bool forWrite = false, bool create = false, bool truncate = true);
 
 	// Destructor
 	virtual ~File();

--- a/src/lib/object_store/Generation.cpp
+++ b/src/lib/object_store/Generation.cpp
@@ -231,10 +231,10 @@ void Generation::rollback()
 }
 
 // Constructor
-Generation::Generation(const std::string path, bool isToken)
+Generation::Generation(const std::string inPath, bool inIsToken)
 {
-	this->path = path;
-	this->isToken = isToken;
+	path = inPath;
+	isToken = inIsToken;
 	pendingUpdate = false;
 	currentValue = 0;
 	genMutex = NULL;

--- a/src/lib/object_store/Generation.h
+++ b/src/lib/object_store/Generation.h
@@ -42,7 +42,7 @@ class Generation
 {
 public:
 	// Factory
-	static Generation* create(const std::string path, bool isToken = false);
+	static Generation* create(const std::string inPath, bool inIsToken = false);
 
 	// Destructor
 	virtual ~Generation();

--- a/src/lib/object_store/OSAttribute.cpp
+++ b/src/lib/object_store/OSAttribute.cpp
@@ -36,11 +36,11 @@
 // Copy constructor
 OSAttribute::OSAttribute(const OSAttribute& in)
 {
-	this->attributeType = in.attributeType;
-	this->boolValue = in.boolValue;
-	this->ulongValue = in.ulongValue;
-	this->byteStrValue = in.byteStrValue;
-	this->arrayValue = in.arrayValue;
+	attributeType = in.attributeType;
+	boolValue = in.boolValue;
+	ulongValue = in.ulongValue;
+	byteStrValue = in.byteStrValue;
+	arrayValue = in.arrayValue;
 }
 
 // Constructor for a boolean type attribute

--- a/src/lib/object_store/OSToken.cpp
+++ b/src/lib/object_store/OSToken.cpp
@@ -51,13 +51,14 @@
 #include <stdio.h>
 
 // Constructor
-OSToken::OSToken(const std::string tokenPath)
+OSToken::OSToken(const std::string inTokenPath)
 {
+	tokenPath = inTokenPath;
+
 	tokenDir = new Directory(tokenPath);
 	gen = Generation::create(tokenPath + OS_PATHSEP + "generation", true);
 	tokenObject = new ObjectFile(this, tokenPath + OS_PATHSEP + "token.object", tokenPath + OS_PATHSEP + "token.lock");
 	tokenMutex = MutexFactory::i()->getMutex();
-	this->tokenPath = tokenPath;
 	valid = (gen != NULL) && (tokenMutex != NULL) && tokenDir->isValid() && tokenObject->valid;
 
 	DEBUG_MSG("Opened token %s", tokenPath.c_str());
@@ -319,7 +320,7 @@ std::set<OSObject*> OSToken::getObjects()
     return objects;
 }
 
-void OSToken::getObjects(std::set<OSObject*> &objects)
+void OSToken::getObjects(std::set<OSObject*> &inObjects)
 {
     index();
 
@@ -327,7 +328,7 @@ void OSToken::getObjects(std::set<OSObject*> &objects)
     // the object list when we return it
     MutexLocker lock(tokenMutex);
 
-    objects.insert(this->objects.begin(),this->objects.end());
+    inObjects.insert(objects.begin(),objects.end());
 }
 
 // Create a new object

--- a/src/lib/object_store/OSToken.h
+++ b/src/lib/object_store/OSToken.h
@@ -53,14 +53,14 @@ class OSToken : public ObjectStoreToken
 {
 public:
 	// Constructor
-	OSToken(const std::string tokenPath);
+	OSToken(const std::string inTokenPath);
 
 	// Create a new token
 	static OSToken* createToken(const std::string basePath, const std::string tokenDir, const ByteString& label, const ByteString& serial);
 
 	// Access an existing token
 	static OSToken* accessToken(const std::string &basePath, const std::string &tokenDir);
-	
+
 	// Constructor for new tokens
 	OSToken(const std::string tokenPath, const ByteString& label, const ByteString& serialNumber);
 
@@ -92,7 +92,7 @@ public:
 	virtual std::set<OSObject*> getObjects();
 
 	// Insert objects into the given set
-	virtual void getObjects(std::set<OSObject*> &objects);
+	virtual void getObjects(std::set<OSObject*> &inObjects);
 
 	// Create a new object
 	virtual OSObject* createObject();

--- a/src/lib/object_store/ObjectFile.cpp
+++ b/src/lib/object_store/ObjectFile.cpp
@@ -47,16 +47,16 @@
 #define ARRAY_ATTR			0x4
 
 // Constructor
-ObjectFile::ObjectFile(OSToken* parent, std::string path, std::string lockpath, bool isNew /* = false */)
+ObjectFile::ObjectFile(OSToken* parent, std::string inPath, std::string inLockpath, bool isNew /* = false */)
 {
-	this->path = path;
+	path = inPath;
 	gen = Generation::create(path);
 	objectMutex = MutexFactory::i()->getMutex();
 	valid = (gen != NULL) && (objectMutex != NULL);
 	token = parent;
 	inTransaction = false;
 	transactionLockFile = NULL;
-	this->lockpath = lockpath;
+	lockpath = inLockpath;
 
 	if (!valid) return;
 

--- a/src/lib/object_store/ObjectFile.h
+++ b/src/lib/object_store/ObjectFile.h
@@ -52,7 +52,7 @@ class ObjectFile : public OSObject
 {
 public:
 	// Constructor
-	ObjectFile(OSToken* parent, const std::string path, const std::string lockpath, bool isNew = false);
+	ObjectFile(OSToken* parent, const std::string inPath, const std::string inLockpath, bool isNew = false);
 
 	// Destructor
 	virtual ~ObjectFile();

--- a/src/lib/object_store/ObjectStore.cpp
+++ b/src/lib/object_store/ObjectStore.cpp
@@ -43,9 +43,9 @@
 #include <stdio.h>
 
 // Constructor
-ObjectStore::ObjectStore(std::string storePath)
+ObjectStore::ObjectStore(std::string inStorePath)
 {
-	this->storePath = storePath;
+	storePath = inStorePath;
 	valid = false;
 	storeMutex = MutexFactory::i()->getMutex();
 

--- a/src/lib/object_store/ObjectStore.h
+++ b/src/lib/object_store/ObjectStore.h
@@ -47,7 +47,7 @@ class ObjectStore
 {
 public:
 	// Constructor
-	ObjectStore(std::string storePath);
+	ObjectStore(std::string inStorePath);
 
 	// Destructor
 	virtual ~ObjectStore();

--- a/src/lib/object_store/ObjectStoreToken.cpp
+++ b/src/lib/object_store/ObjectStoreToken.cpp
@@ -37,7 +37,7 @@
 // OSToken is a concrete implementation of ObjectStoreToken base class.
 #include "OSToken.h"
 
-#if HAVE_OBJECTSTORE_BACKEND_DB
+#ifdef HAVE_OBJECTSTORE_BACKEND_DB
 // DBToken is a concrete implementation of ObjectSToreToken that stores the objects and attributes in an SQLite3 database.
 #include "DBToken.h"
 #endif
@@ -56,7 +56,7 @@ static AccessToken static_accessToken = reinterpret_cast<AccessToken>(OSToken::a
 		static_createToken = reinterpret_cast<CreateToken>(OSToken::createToken);
 		static_accessToken = reinterpret_cast<AccessToken>(OSToken::accessToken);
 	}
-#if HAVE_OBJECTSTORE_BACKEND_DB
+#ifdef HAVE_OBJECTSTORE_BACKEND_DB
 	else if (backend == "db")
 	{
 		static_createToken = reinterpret_cast<CreateToken>(DBToken::createToken);

--- a/src/lib/object_store/SessionObject.cpp
+++ b/src/lib/object_store/SessionObject.cpp
@@ -35,14 +35,14 @@
 #include "SessionObjectStore.h"
 
 // Constructor
-SessionObject::SessionObject(SessionObjectStore* parent, CK_SLOT_ID slotID, CK_SESSION_HANDLE hSession, bool isPrivate)
+SessionObject::SessionObject(SessionObjectStore* inParent, CK_SLOT_ID inSlotID, CK_SESSION_HANDLE inHSession, bool inIsPrivate)
 {
-	this->hSession = hSession;
-	this->slotID = slotID;
-	this->isPrivate = isPrivate;
+	hSession = inHSession;
+	slotID = inSlotID;
+	isPrivate = inIsPrivate;
 	objectMutex = MutexFactory::i()->getMutex();
 	valid = (objectMutex != NULL);
-	this->parent = parent;
+	parent = inParent;
 }
 
 // Destructor
@@ -197,17 +197,17 @@ bool SessionObject::isValid()
     return valid;
 }
 
-bool SessionObject::hasSlotID(CK_SLOT_ID slotID)
+bool SessionObject::hasSlotID(CK_SLOT_ID inSlotID)
 {
-    return this->slotID == slotID;
+    return slotID == inSlotID;
 }
 
 // Called by the session object store when a session is closed. If it's the
 // session this object was associated with, the function returns true and the
 // object is invalidated
-bool SessionObject::removeOnSessionClose(CK_SESSION_HANDLE hSession)
+bool SessionObject::removeOnSessionClose(CK_SESSION_HANDLE inHSession)
 {
-	if (this->hSession == hSession)
+	if (hSession == inHSession)
 	{
 		// Save space
 		discardAttributes();
@@ -222,9 +222,9 @@ bool SessionObject::removeOnSessionClose(CK_SESSION_HANDLE hSession)
 
 // Called by the session object store when a token is logged out.
 // Remove when this session object is a private object for this token.
-bool SessionObject::removeOnAllSessionsClose(CK_SLOT_ID slotID)
+bool SessionObject::removeOnAllSessionsClose(CK_SLOT_ID inSlotID)
 {
-    if (this->slotID == slotID)
+    if (slotID == inSlotID)
     {
         discardAttributes();
 
@@ -238,9 +238,9 @@ bool SessionObject::removeOnAllSessionsClose(CK_SLOT_ID slotID)
 
 // Called by the session object store when a token is logged out.
 // Remove when this session object is a private object for this token.
-bool SessionObject::removeOnTokenLogout(CK_SLOT_ID slotID)
+bool SessionObject::removeOnTokenLogout(CK_SLOT_ID inSlotID)
 {
-    if (this->slotID == slotID && this->isPrivate)
+    if (slotID == inSlotID && isPrivate)
     {
         discardAttributes();
 

--- a/src/lib/object_store/SessionObject.h
+++ b/src/lib/object_store/SessionObject.h
@@ -49,7 +49,7 @@ class SessionObject : public OSObject
 {
 public:
 	// Constructor
-	SessionObject(SessionObjectStore* parent, CK_SLOT_ID slotID, CK_SESSION_HANDLE hSession, bool isPrivate = false);
+	SessionObject(SessionObjectStore* inParent, CK_SLOT_ID inSlotID, CK_SESSION_HANDLE inHSession, bool inIsPrivate = false);
 
 	// Destructor
 	virtual ~SessionObject();
@@ -72,20 +72,20 @@ public:
 	// The validity state of the object
 	virtual bool isValid();
 
-	bool hasSlotID(CK_SLOT_ID slotID);
+	bool hasSlotID(CK_SLOT_ID inSlotID);
 
 	// Called by the session object store when a session is closed. If it's the
 	// session this object was associated with, the function returns true and the
 	// object is invalidated
-	bool removeOnSessionClose(CK_SESSION_HANDLE hSession);
+	bool removeOnSessionClose(CK_SESSION_HANDLE inHSession);
 
 	// Called by the session object store when all the sessions for a token
 	// have been closed.
-	bool removeOnAllSessionsClose(CK_SLOT_ID slotID);
+	bool removeOnAllSessionsClose(CK_SLOT_ID inSlotID);
 
 	// Called by the session object store when a token is logged out.
 	// Remove when this session object is a private object for this token.
-	bool removeOnTokenLogout(CK_SLOT_ID slotID);
+	bool removeOnTokenLogout(CK_SLOT_ID inSlotID);
 
 	// These functions are just stubs for session objects
 	virtual bool startTransaction(Access access);

--- a/src/lib/object_store/SessionObjectStore.cpp
+++ b/src/lib/object_store/SessionObjectStore.cpp
@@ -80,16 +80,16 @@ std::set<SessionObject*> SessionObjectStore::getObjects()
 	return objects;
 }
 
-void SessionObjectStore::getObjects(CK_SLOT_ID slotID, std::set<OSObject*> &objects)
+void SessionObjectStore::getObjects(CK_SLOT_ID slotID, std::set<OSObject*> &inObjects)
 {
 	// Make sure that no other thread is in the process of changing
 	// the object list when we return it
 	MutexLocker lock(storeMutex);
 
 	std::set<SessionObject*>::iterator it;
-	for (it=this->objects.begin(); it!=this->objects.end(); ++it) {
+	for (it=objects.begin(); it!=objects.end(); ++it) {
 		if ((*it)->hasSlotID(slotID))
-			objects.insert(*it);
+			inObjects.insert(*it);
 	}
 }
 

--- a/src/lib/object_store/SessionObjectStore.h
+++ b/src/lib/object_store/SessionObjectStore.h
@@ -56,7 +56,7 @@ public:
 	std::set<SessionObject*> getObjects();
 
 	// Insert the session objects for the given slotID into the given OSObject set
-	void getObjects(CK_SLOT_ID slotID, std::set<OSObject*> &objects);
+	void getObjects(CK_SLOT_ID slotID, std::set<OSObject*> &inObjects);
 
 	// Create a new object
 	SessionObject* createObject(CK_SLOT_ID slotID, CK_SESSION_HANDLE hSession, bool isPrivate = false);

--- a/src/lib/session_mgr/Session.cpp
+++ b/src/lib/session_mgr/Session.cpp
@@ -34,14 +34,14 @@
 #include "Session.h"
 
 // Constructor
-Session::Session(Slot* slot, bool isReadWrite, CK_VOID_PTR pApplication, CK_NOTIFY notify)
+Session::Session(Slot* inSlot, bool inIsReadWrite, CK_VOID_PTR inPApplication, CK_NOTIFY inNotify)
 {
-	this->slot = slot;
-	this->token = slot->getToken();
-	this->isReadWrite = isReadWrite;
+	slot = inSlot;
+	token = slot->getToken();
+	isReadWrite = inIsReadWrite;
 	hSession = CK_INVALID_HANDLE;
-	this->pApplication = pApplication;
-	this->notify = notify;
+	pApplication = inPApplication;
+	notify = inNotify;
 	operation = SESSION_OP_NONE;
 	findOp = NULL;
 	digestOp = NULL;
@@ -143,9 +143,9 @@ CK_STATE Session::getState()
 	}
 }
 
-void Session::setHandle(CK_SESSION_HANDLE hSession)
+void Session::setHandle(CK_SESSION_HANDLE inHSession)
 {
-	this->hSession = hSession;
+	hSession = inHSession;
 }
 
 CK_SESSION_HANDLE Session::getHandle()
@@ -166,9 +166,9 @@ Token* Session::getToken()
 }
 
 // Set the operation type
-void Session::setOpType(int operation)
+void Session::setOpType(int inOperation)
 {
-	this->operation = operation;
+	operation = inOperation;
 }
 
 // Get the operation type
@@ -236,12 +236,12 @@ void Session::resetOp()
 	operation = SESSION_OP_NONE;
 }
 
-void Session::setFindOp(FindOperation *findOp)
+void Session::setFindOp(FindOperation *inFindOp)
 {
-	if (this->findOp != NULL) {
-		delete this->findOp;
+	if (findOp != NULL) {
+		delete findOp;
 	}
-	this->findOp = findOp;
+	findOp = inFindOp;
 }
 
 FindOperation *Session::getFindOp()
@@ -250,14 +250,14 @@ FindOperation *Session::getFindOp()
 }
 
 // Set the digesting operator
-void Session::setDigestOp(HashAlgorithm* digestOp)
+void Session::setDigestOp(HashAlgorithm* inDigestOp)
 {
-	if (this->digestOp != NULL)
+	if (digestOp != NULL)
 	{
-		CryptoFactory::i()->recycleHashAlgorithm(this->digestOp);
+		CryptoFactory::i()->recycleHashAlgorithm(digestOp);
 	}
 
-	this->digestOp = digestOp;
+	digestOp = inDigestOp;
 }
 
 // Get the digesting operator
@@ -267,15 +267,15 @@ HashAlgorithm* Session::getDigestOp()
 }
 
 // Set the MACing operator
-void Session::setMacOp(MacAlgorithm *macOp)
+void Session::setMacOp(MacAlgorithm *inMacOp)
 {
-	if (this->macOp != NULL)
+	if (macOp != NULL)
 	{
 		setSymmetricKey(NULL);
-		CryptoFactory::i()->recycleMacAlgorithm(this->macOp);
+		CryptoFactory::i()->recycleMacAlgorithm(macOp);
 	}
 
-	this->macOp = macOp;
+	macOp = inMacOp;
 }
 
 // Get the MACing operator
@@ -284,16 +284,16 @@ MacAlgorithm *Session::getMacOp()
 	return macOp;
 }
 
-void Session::setAsymmetricCryptoOp(AsymmetricAlgorithm *asymmetricCryptoOp)
+void Session::setAsymmetricCryptoOp(AsymmetricAlgorithm *inAsymmetricCryptoOp)
 {
-	if (this->asymmetricCryptoOp != NULL)
+	if (asymmetricCryptoOp != NULL)
 	{
 		setPublicKey(NULL);
 		setPrivateKey(NULL);
-		CryptoFactory::i()->recycleAsymmetricAlgorithm(this->asymmetricCryptoOp);
+		CryptoFactory::i()->recycleAsymmetricAlgorithm(asymmetricCryptoOp);
 	}
 
-	this->asymmetricCryptoOp = asymmetricCryptoOp;
+	asymmetricCryptoOp = inAsymmetricCryptoOp;
 }
 
 AsymmetricAlgorithm *Session::getAsymmetricCryptoOp()
@@ -301,15 +301,15 @@ AsymmetricAlgorithm *Session::getAsymmetricCryptoOp()
 	return asymmetricCryptoOp;
 }
 
-void Session::setSymmetricCryptoOp(SymmetricAlgorithm *symmetricCryptoOp)
+void Session::setSymmetricCryptoOp(SymmetricAlgorithm *inSymmetricCryptoOp)
 {
-	if (this->symmetricCryptoOp != NULL)
+	if (symmetricCryptoOp != NULL)
 	{
 		setSymmetricKey(NULL);
-		CryptoFactory::i()->recycleSymmetricAlgorithm(this->symmetricCryptoOp);
+		CryptoFactory::i()->recycleSymmetricAlgorithm(symmetricCryptoOp);
 	}
 
-	this->symmetricCryptoOp = symmetricCryptoOp;
+	symmetricCryptoOp = inSymmetricCryptoOp;
 }
 
 SymmetricAlgorithm *Session::getSymmetricCryptoOp()
@@ -317,9 +317,9 @@ SymmetricAlgorithm *Session::getSymmetricCryptoOp()
 	return symmetricCryptoOp;
 }
 
-void Session::setMechanism(AsymMech::Type mechanism)
+void Session::setMechanism(AsymMech::Type inMechanism)
 {
-	this->mechanism = mechanism;
+	mechanism = inMechanism;
 }
 
 AsymMech::Type Session::getMechanism()
@@ -327,33 +327,33 @@ AsymMech::Type Session::getMechanism()
 	return mechanism;
 }
 
-void Session::setParameters(void* param, size_t paramLen)
+void Session::setParameters(void* inParam, size_t inParamLen)
 {
-	if (param == NULL || paramLen == 0) return;
+	if (inParam == NULL || inParamLen == 0) return;
 
-	if (this->param != NULL)
+	if (param != NULL)
 	{
-		free(this->param);
-		this->paramLen = 0;
+		free(param);
+		paramLen = 0;
 	}
 
-	this->param = malloc(paramLen);
-	if (this->param != NULL)
+	param = malloc(inParamLen);
+	if (param != NULL)
 	{
-		memcpy(this->param, param, paramLen);
-		this->paramLen = paramLen;
+		memcpy(param, inParam, inParamLen);
+		paramLen = inParamLen;
 	}
 }
 
-void* Session::getParameters(size_t& paramLen)
+void* Session::getParameters(size_t& inParamLen)
 {
-	paramLen = this->paramLen;
-	return this->param;
+	inParamLen = paramLen;
+	return param;
 }
 
-void Session::setAllowMultiPartOp(bool allowMultiPartOp)
+void Session::setAllowMultiPartOp(bool inAllowMultiPartOp)
 {
-	this->allowMultiPartOp = allowMultiPartOp;
+	allowMultiPartOp = inAllowMultiPartOp;
 }
 
 bool Session::getAllowMultiPartOp()
@@ -361,9 +361,9 @@ bool Session::getAllowMultiPartOp()
 	return allowMultiPartOp;
 }
 
-void Session::setAllowSinglePartOp(bool allowSinglePartOp)
+void Session::setAllowSinglePartOp(bool inAllowSinglePartOp)
 {
-	this->allowSinglePartOp = allowSinglePartOp;
+	allowSinglePartOp = inAllowSinglePartOp;
 }
 
 bool Session::getAllowSinglePartOp()
@@ -371,17 +371,17 @@ bool Session::getAllowSinglePartOp()
 	return allowSinglePartOp;
 }
 
-void Session::setPublicKey(PublicKey* publicKey)
+void Session::setPublicKey(PublicKey* inPublicKey)
 {
 	if (asymmetricCryptoOp == NULL)
 		return;
 
-	if (this->publicKey != NULL)
+	if (publicKey != NULL)
 	{
-		asymmetricCryptoOp->recyclePublicKey(this->publicKey);
+		asymmetricCryptoOp->recyclePublicKey(publicKey);
 	}
 
-	this->publicKey = publicKey;
+	publicKey = inPublicKey;
 }
 
 PublicKey* Session::getPublicKey()
@@ -389,17 +389,17 @@ PublicKey* Session::getPublicKey()
 	return publicKey;
 }
 
-void Session::setPrivateKey(PrivateKey* privateKey)
+void Session::setPrivateKey(PrivateKey* inPrivateKey)
 {
 	if (asymmetricCryptoOp == NULL)
 		return;
 
-	if (this->privateKey != NULL)
+	if (privateKey != NULL)
 	{
-		asymmetricCryptoOp->recyclePrivateKey(this->privateKey);
+		asymmetricCryptoOp->recyclePrivateKey(privateKey);
 	}
 
-	this->privateKey = privateKey;
+	privateKey = inPrivateKey;
 }
 
 PrivateKey* Session::getPrivateKey()
@@ -407,20 +407,20 @@ PrivateKey* Session::getPrivateKey()
 	return privateKey;
 }
 
-void Session::setSymmetricKey(SymmetricKey* symmetricKey)
+void Session::setSymmetricKey(SymmetricKey* inSymmetricKey)
 {
-	if (this->symmetricKey != NULL)
+	if (symmetricKey != NULL)
 	{
 		if (macOp) {
-			macOp->recycleKey(this->symmetricKey);
+			macOp->recycleKey(symmetricKey);
 		} else if (symmetricCryptoOp) {
-			symmetricCryptoOp->recycleKey(this->symmetricKey);
+			symmetricCryptoOp->recycleKey(symmetricKey);
 		} else {
 			return;
 		}
 	}
 
-	this->symmetricKey = symmetricKey;
+	symmetricKey = inSymmetricKey;
 }
 
 SymmetricKey* Session::getSymmetricKey()

--- a/src/lib/session_mgr/Session.h
+++ b/src/lib/session_mgr/Session.h
@@ -57,7 +57,7 @@
 class Session
 {
 public:
-	Session(Slot* slot, bool isReadWrite, CK_VOID_PTR pApplication, CK_NOTIFY notify);
+	Session(Slot* inSlot, bool inIsReadWrite, CK_VOID_PTR inPApplication, CK_NOTIFY inNotify);
 
 	// Destructor
 	virtual ~Session();
@@ -70,53 +70,53 @@ public:
 	CK_RV getInfo(CK_SESSION_INFO_PTR pInfo);
 	bool isRW();
 	CK_STATE getState();
-	void setHandle(CK_SESSION_HANDLE hSession);
+	void setHandle(CK_SESSION_HANDLE inHSession);
 	CK_SESSION_HANDLE getHandle();
 
 	// Operations
 	int getOpType();
-	void setOpType(int operation);
+	void setOpType(int inOperation);
 	void resetOp();
 
 	// Find
-	void setFindOp(FindOperation *findOp);
+	void setFindOp(FindOperation *inFindOp);
 	FindOperation *getFindOp();
 
 	// Digest
-	void setDigestOp(HashAlgorithm* digestOp);
+	void setDigestOp(HashAlgorithm* inDigestOp);
 	HashAlgorithm* getDigestOp();
 
 	// Mac
-	void setMacOp(MacAlgorithm* macOp);
+	void setMacOp(MacAlgorithm* inMacOp);
 	MacAlgorithm* getMacOp();
 
 	// Asymmetric Crypto
-	void setAsymmetricCryptoOp(AsymmetricAlgorithm* asymmetricCryptoOp);
+	void setAsymmetricCryptoOp(AsymmetricAlgorithm* inAsymmetricCryptoOp);
 	AsymmetricAlgorithm* getAsymmetricCryptoOp();
 
 	// Symmetric Crypto
-	void setSymmetricCryptoOp(SymmetricAlgorithm* symmetricCryptoOp);
+	void setSymmetricCryptoOp(SymmetricAlgorithm* inSymmetricCryptoOp);
 	SymmetricAlgorithm* getSymmetricCryptoOp();
 
-	void setMechanism(AsymMech::Type mechanism);
+	void setMechanism(AsymMech::Type inMechanism);
 	AsymMech::Type getMechanism();
 
-	void setParameters(void* param, size_t paramLen);
-	void* getParameters(size_t& paramLen);
+	void setParameters(void* inParam, size_t inParamLen);
+	void* getParameters(size_t& inParamLen);
 
-	void setAllowMultiPartOp(bool allowMultiPartOp);
+	void setAllowMultiPartOp(bool inAllowMultiPartOp);
 	bool getAllowMultiPartOp();
 
-	void setAllowSinglePartOp(bool allowSinglePartOp);
+	void setAllowSinglePartOp(bool inAllowSinglePartOp);
 	bool getAllowSinglePartOp();
 
-	void setPublicKey(PublicKey* publicKey);
+	void setPublicKey(PublicKey* inPublicKey);
 	PublicKey* getPublicKey();
 
-	void setPrivateKey(PrivateKey* privateKey);
+	void setPrivateKey(PrivateKey* inPrivateKey);
 	PrivateKey* getPrivateKey();
 
-	void setSymmetricKey(SymmetricKey* symmetricKey);
+	void setSymmetricKey(SymmetricKey* inSymmetricKey);
 	SymmetricKey* getSymmetricKey();
 
 private:

--- a/src/lib/slot_mgr/Slot.cpp
+++ b/src/lib/slot_mgr/Slot.cpp
@@ -39,18 +39,18 @@
 #include <string.h>
 
 // Constructor
-Slot::Slot(ObjectStore* objectStore, size_t slotID, ObjectStoreToken* token /* = NULL */)
+Slot::Slot(ObjectStore* inObjectStore, size_t inSlotID, ObjectStoreToken* inToken /* = NULL */)
 {
-	this->objectStore = objectStore;
-	this->slotID = slotID;
+	objectStore = inObjectStore;
+	slotID = inSlotID;
 
-	if (token != NULL)
+	if (inToken != NULL)
 	{
-		this->token = new Token(token);
+		token = new Token(inToken);
 	}
 	else
 	{
-		this->token = new Token();
+		token = new Token();
 	}
 }
 

--- a/src/lib/slot_mgr/Slot.h
+++ b/src/lib/slot_mgr/Slot.h
@@ -46,7 +46,7 @@ class Slot
 {
 public:
 	// Constructor
-	Slot(ObjectStore* objectStore, size_t slotID, ObjectStoreToken *token = NULL);
+	Slot(ObjectStore* inObjectStore, size_t inSlotID, ObjectStoreToken *inToken = NULL);
 
 	// Destructor
 	virtual ~Slot();

--- a/src/lib/slot_mgr/Token.cpp
+++ b/src/lib/slot_mgr/Token.cpp
@@ -50,11 +50,11 @@ Token::Token()
 }
 
 // Constructor
-Token::Token(ObjectStoreToken* token)
+Token::Token(ObjectStoreToken* inToken)
 {
 	tokenMutex = MutexFactory::i()->getMutex();
 
-	this->token = token;
+	token = inToken;
 
 	ByteString soPINBlob, userPINBlob;
 

--- a/src/lib/slot_mgr/Token.h
+++ b/src/lib/slot_mgr/Token.h
@@ -47,7 +47,7 @@ class Token
 public:
 	// Constructor
 	Token();
-	Token(ObjectStoreToken *token);
+	Token(ObjectStoreToken *inToken);
 
 	// Destructor
 	virtual ~Token();


### PR DESCRIPTION
Jakob, please check and merge this.

Mostly renames of variables to mitigate warnings about shadowed variables.