### PR TITLE
Fix errors reported by Visual Studio 2015

### DIFF
--- a/src/bin/common/library.cpp
+++ b/src/bin/common/library.cpp
@@ -64,8 +64,8 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle,
 	{
 		// Failed to load the PKCS #11 library
 		dw = GetLastError();
-		snprintf(errMsg, sizeof(errMsg), "LoadLibraryA failed: 0x%x", dw);
-		pErrMsg = &errMsg;
+		snprintf((char*)errMsg, sizeof(errMsg), "LoadLibraryA failed: 0x%x", dw);
+		pErrMsg = (char**)&errMsg;
 		return NULL;
 	}
 	else
@@ -78,8 +78,8 @@ CK_C_GetFunctionList loadLibrary(char* module, void** moduleHandle,
 	if (pGetFunctionList == NULL)
 	{
 		dw = GetLastError();
-		snprintf(errMsg, sizeof(errMsg), "getProcAddress failed: 0x%x", dw);
-		pErrMsg = &errMsg;
+		snprintf((char*)errMsg, sizeof(errMsg), "getProcAddress failed: 0x%x", dw);
+		pErrMsg = (char**)&errMsg;
 	}
 
 	// Store the handle so we can FreeLibrary it later

--- a/src/lib/data_mgr/SecureAllocator.h
+++ b/src/lib/data_mgr/SecureAllocator.h
@@ -195,8 +195,8 @@ public:
 	}
 
 	// Comparison operators
-	inline bool operator==(SecureAllocator const&) { return true; }
-	inline bool operator!=(SecureAllocator const&) { return false; }
+	inline bool operator==(SecureAllocator const&) const { return true; }
+	inline bool operator!=(SecureAllocator const&) const { return false; }
 };
 
 #endif // !_SOFTHSM_V2_SECUREALLOCATOR_H


### PR DESCRIPTION
I've been able to build both 32-bit and 64-bit release of SoftHSMv2 in Visual Studio 2015 Community with these simple changes.