### PR TITLE
softhsm2-migrate: add empty attributes for RSA values missing in SoftHSMv1

### DIFF
--- a/src/bin/migrate/softhsm2-migrate.cpp
+++ b/src/bin/migrate/softhsm2-migrate.cpp
@@ -679,11 +679,11 @@ int dbRSAPriv2session(sqlite3* /*db*/, CK_OBJECT_HANDLE objectID, CK_SESSION_HAN
 		{ CKA_PUBLIC_EXPONENT,		NULL,	0 },
 		{ CKA_PRIVATE_EXPONENT,		NULL,	0 },
 		{ CKA_PRIME_1,			NULL,	0 },
-		{ CKA_PRIME_2,			NULL,	0 }
-// SoftHSM v1 did not store these values
-//		{ CKA_EXPONENT_1,		NULL,	0 },
-//		{ CKA_EXPONENT_2,		NULL,	0 },
-//		{ CKA_COEFFICIENT,		NULL,	0 }
+		{ CKA_PRIME_2,			NULL,	0 },
+		// SoftHSM v1 did not store the values below
+		{ CKA_EXPONENT_1,		NULL,	0 },
+		{ CKA_EXPONENT_2,		NULL,	0 },
+		{ CKA_COEFFICIENT,		NULL,	0 }
 	};
 
 	for (i = 0; i < 23; i++)
@@ -696,7 +696,7 @@ int dbRSAPriv2session(sqlite3* /*db*/, CK_OBJECT_HANDLE objectID, CK_SESSION_HAN
 		}
 	}
 
-	rv = p11->C_CreateObject(hSession, privTemplate, 23, &hKey);
+	rv = p11->C_CreateObject(hSession, privTemplate, 26, &hKey);
 	if (rv != CKR_OK)
 	{
 		fprintf(stderr, "ERROR %X: Could not save the private key in the token. "
@@ -708,7 +708,7 @@ int dbRSAPriv2session(sqlite3* /*db*/, CK_OBJECT_HANDLE objectID, CK_SESSION_HAN
 		printf("Object %lu has been migrated\n", objectID);
 	}
 
-	freeTemplate(privTemplate, 23);
+	freeTemplate(privTemplate, 26);
 
 	return result;
 }


### PR DESCRIPTION
While both OpenSSL and Botan are happy with an RSA private key being created without *exponent1*, *exponent2* and *coefficient*, SoftHSMv2 [isn't](https://github.com/opendnssec/SoftHSMv2/blob/3b087c730920040301478a2e8d58ad6e9eb7f2a0/src/lib/SoftHSM.cpp#L9639). Here is an excerpt from OpenDNSSEC 1.4.8.2 logs when trying to sign a zone using a PKCS#11 slot migrated from SoftHSMv1 to SoftHSMv2 using current `softhsm2-migrate`:

    SecureDataManager.cpp(359): Invalid IV in encrypted data
    [hsm] sign init: CKR_GENERAL_ERROR
    [hsm] error signing rrset with libhsm
    [rrset] unable to sign RRset[6]: lhsm_sign() failed
    [worker[1]] sign zone example.com failed: 1 RRsets failed
    [worker[1]] CRITICAL: failed to sign zone example.com: General error
    [worker[1]] backoff task [sign] for zone example.com with 60 seconds

This is expected, as the `CKA_EXPONENT_1`, `CKA_EXPONENT_2` and `CKA_COEFFICIENT` attributes are [not created](https://github.com/opendnssec/SoftHSMv2/blob/a7b85cd6eaa00fbbddcd8503836303ade81f88cc/src/bin/migrate/softhsm2-migrate.cpp#L683) in the destination object by `softhsm2-migrate`. This in turn causes `SoftHSM::getRSAPrivateKey()` to return `CKR_GENERAL_ERROR` when trying to fetch an RSA private key migrated in this manner.

If `dbRSAPriv2session()` is modified to create the missing attributes with empty values, SoftHSMv2 seems to be happy again. Am I missing something here? Because frankly speaking, I don't see how `softhsm2-migrate` is supposed to work without this change. That being said, everything written above is coming from someone whose knowledge about crypto is pretty vague. I also haven't tested this change with any PKCS#11 provider other than `libsofthsm2.so`.

It looks like @letoams also came across this issue [a while ago](http://lists.opendnssec.org/pipermail/opendnssec-user/2014-August/003072.html).
