### PR TITLE
Do not attempt decryption of empty byte strings

### DIFF
--- a/src/lib/data_mgr/SecureDataManager.cpp
+++ b/src/lib/data_mgr/SecureDataManager.cpp
@@ -338,6 +338,13 @@ bool SecureDataManager::decrypt(const ByteString& encrypted, ByteString& plainte
 		return false;
 	}
 
+	// Do not attempt decryption of empty byte strings
+	if (encrypted.size() == 0)
+	{
+		plaintext = ByteString("");
+		return true;
+	}
+
 	AESKey theKey(256);
 	ByteString unmaskedKey;
 


### PR DESCRIPTION
When a PKCS#11 object is created, a default value is assigned to each of its attributes. Some of these attributes are then [updated](https://github.com/opendnssec/SoftHSMv2/blob/dd6337892b856432aa1dcf0abe00aa8fc1678e49/src/lib/P11Objects.cpp#L220) using values taken from a supplied template. If the object in question is private, the attribute update process involves [encrypting](https://github.com/opendnssec/SoftHSMv2/blob/99d128a13d7da0d21c6d0f16aaa348f73a15df08/src/lib/P11Attributes.cpp#L56-L60) its value. However, the default (empty) values of some non-mandatory attributes (namely [`CKA_EXPONENT_1`](https://github.com/opendnssec/SoftHSMv2/blob/99d128a13d7da0d21c6d0f16aaa348f73a15df08/src/lib/P11Attributes.cpp#L1831-L1840), [`CKA_EXPONENT_2`](https://github.com/opendnssec/SoftHSMv2/blob/99d128a13d7da0d21c6d0f16aaa348f73a15df08/src/lib/P11Attributes.cpp#L1842-L1851) and [`CKA_COEFFICIENT`](https://github.com/opendnssec/SoftHSMv2/blob/99d128a13d7da0d21c6d0f16aaa348f73a15df08/src/lib/P11Attributes.cpp#L1853-L1862) in the case of RSA private keys) are **not** encrypted when the PKCS#11 object is saved in the token. This in turn causes `SecureDataManager::decrypt()` to [return an error](https://github.com/opendnssec/SoftHSMv2/blob/48bc38bfe4b1e1bccbc7891a0a2c95289f609789/src/lib/data_mgr/SecureDataManager.cpp#L354-L362) when such an object is subsequently [retrieved](https://github.com/opendnssec/SoftHSMv2/blob/3b087c730920040301478a2e8d58ad6e9eb7f2a0/src/lib/SoftHSM.cpp#L9639-L9641).

This pull request fixes the issue by causing `SecureDataManager::decrypt()` to return an empty `ByteString` as the decrypted plaintext if the input data supplied to it is empty.

This is a spin-off of #161.
