### PR TITLE
Issue #177: CKA_NEVER_EXTRACTABLE set to CK_FALSE on objects created …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@ Bugfixes:
 * Issue #169: One-byte buffer overflow in call to EVP_DecryptUpdate.
 * Issue #173: Adjust return values for the template parsing.
 * Issue #174: C_DeriveKey() error with leading zero bytes.
+* Issue #177: CKA_NEVER_EXTRACTABLE set to CK_FALSE on objects
+  created with C_CreateObject.
 * SOFTHSM-123: Fix library cleanup on BSD.
 
 

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -9602,6 +9602,27 @@ CK_RV SoftHSM::CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTempla
 	if (rv != CKR_OK)
 		return rv;
 
+	if (op == OBJECT_OP_CREATE)
+	{
+		if (objClass == CKO_PUBLIC_KEY &&
+		    (!object->startTransaction() ||
+		    !object->setAttribute(CKA_LOCAL, false) ||
+		    !object->commitTransaction()))
+		{
+			return CKR_GENERAL_ERROR;
+		}
+
+		if ((objClass == CKO_SECRET_KEY || objClass == CKO_PRIVATE_KEY) &&
+		    (!object->startTransaction() ||
+		    !object->setAttribute(CKA_LOCAL, false) ||
+		    !object->setAttribute(CKA_ALWAYS_SENSITIVE, false) ||
+		    !object->setAttribute(CKA_NEVER_EXTRACTABLE, false) ||
+		    !object->commitTransaction()))
+		{
+			return CKR_GENERAL_ERROR;
+		}
+	}
+
 	if (isOnToken)
 	{
 		*phObject = handleManager->addTokenObject(slot->getSlotID(), isPrivate != CK_FALSE, object);


### PR DESCRIPTION
…with C_CreateObject.