### PR TITLE
Stop discarding the global OpenSSL libcrypto state

### DIFF
--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -204,19 +204,10 @@ OSSLCryptoFactory::~OSSLCryptoFactory()
 		ENGINE_free(eg);
 		eg = NULL;
 	}
-
-	ENGINE_cleanup();
 #endif
 
 	// Destroy the one-and-only RNG
 	delete rng;
-
-	// Clean up OpenSSL
-	ERR_remove_state(0);
-	RAND_cleanup();
-	EVP_cleanup();
-	CRYPTO_cleanup_all_ex_data();
-	ERR_free_strings();
 
 	// Recycle locks
 	CRYPTO_set_locking_callback(NULL);


### PR DESCRIPTION
A single instance of the OpenSSL libcrypto library can be shared by the main application and its libraries, including `libsofthsm2.so`.  To enable it, the libcrypto API checks if each individual subsystem is already initialized, and prevents double initialization.  Initializing the same subsystem by multiple components (the main application or its libraries) is thus safe.

On the other hand, discarding (cleaning up) the state of a libcrypto subsystem breaks all other components using it.  Consequently, only the main application may safely perform cleanup of the OpenSSL libcrypto library.

See https://wiki.openssl.org/index.php/Library_Initialization#libcrypto_Initialization for details.

For example, the existing code causes applications to crash on `ENGINE_cleanup()`, since `libsofthsm2.so` has already executed this function.  See OpenSC/libp11#51 for details.  The code is also likely to cause other, less obvious defects.

This PR fixes opendnssec/SoftHSMv2#181.