### PR TITLE
The slot ID of a token should always be the same

### DIFF
--- a/src/lib/session_mgr/SessionManager.cpp
+++ b/src/lib/session_mgr/SessionManager.cpp
@@ -129,7 +129,7 @@ CK_RV SessionManager::closeSession(CK_SESSION_HANDLE hSession)
 
 	// Check if this is the last session on the token
 	bool lastSession = true;
-	CK_ULONG slotID = sessions[sessionID]->getSlot()->getSlotID();
+	const CK_SLOT_ID slotID( sessions[sessionID]->getSlot()->getSlotID() );
 	for (size_t i = 0; i < sessions.size(); i++)
 	{
 		if (sessions[i] == NULL) continue;
@@ -167,7 +167,7 @@ CK_RV SessionManager::closeAllSessions(Slot* slot)
 	if (token == NULL) return CKR_TOKEN_NOT_PRESENT;
 
 	// Close all sessions on this slot
-	CK_ULONG slotID = slot->getSlotID();
+	const CK_SLOT_ID slotID( slot->getSlotID() );
 	for (std::vector<Session*>::iterator i = sessions.begin(); i != sessions.end(); i++)
 	{
 		if (*i == NULL) continue;
@@ -210,7 +210,7 @@ Session* SessionManager::getSession(CK_SESSION_HANDLE hSession)
 	return sessions[hSession - 1];
 }
 
-bool SessionManager::haveSession(size_t slotID)
+bool SessionManager::haveSession(CK_SLOT_ID slotID)
 {
 	// Lock access to the vector
 	MutexLocker lock(sessionsMutex);
@@ -228,7 +228,7 @@ bool SessionManager::haveSession(size_t slotID)
 	return false;
 }
 
-bool SessionManager::haveROSession(size_t slotID)
+bool SessionManager::haveROSession(CK_SLOT_ID slotID)
 {
 	// Lock access to the vector
 	MutexLocker lock(sessionsMutex);

--- a/src/lib/session_mgr/SessionManager.h
+++ b/src/lib/session_mgr/SessionManager.h
@@ -53,8 +53,8 @@ public:
     CK_RV closeAllSessions(Slot* slot);
 	CK_RV getSessionInfo(CK_SESSION_HANDLE hSession, CK_SESSION_INFO_PTR pInfo);
 	Session* getSession(CK_SESSION_HANDLE hSession);
-	bool haveSession(size_t slotID);
-	bool haveROSession(size_t slotID);
+	bool haveSession(CK_SLOT_ID slotID);
+	bool haveROSession(CK_SLOT_ID slotID);
 
 private:
 	// The sessions

--- a/src/lib/slot_mgr/Slot.cpp
+++ b/src/lib/slot_mgr/Slot.cpp
@@ -37,9 +37,10 @@
 #include "Token.h"
 #include <stdio.h>
 #include <string.h>
+#include <sstream>
 
 // Constructor
-Slot::Slot(ObjectStore* inObjectStore, size_t inSlotID, ObjectStoreToken* inToken /* = NULL */)
+Slot::Slot(ObjectStore* inObjectStore, CK_SLOT_ID inSlotID, ObjectStoreToken* inToken /* = NULL */)
 {
 	objectStore = inObjectStore;
 	slotID = inSlotID;
@@ -80,15 +81,16 @@ CK_RV Slot::getSlotInfo(CK_SLOT_INFO_PTR info)
 		return CKR_ARGUMENTS_BAD;
 	}
 
-	char description[65];
-	char mfgID[33];
+	std::ostringstream osDescription;
+	osDescription << "SoftHSM slot ID 0x" << std::hex << slotID;
+	const std::string sDescription(osDescription.str());
 
-	snprintf(description, 65, "SoftHSM slot %d", (int) slotID);
+	char mfgID[33];
 	snprintf(mfgID, 33, "SoftHSM project");
 
 	memset(info->slotDescription, ' ', 64);
 	memset(info->manufacturerID, ' ', 32);
-	memcpy(info->slotDescription, description, strlen(description));
+	memcpy(info->slotDescription, sDescription.data(), sDescription.size());
 	memcpy(info->manufacturerID, mfgID, strlen(mfgID));
 
 	info->flags = CKF_TOKEN_PRESENT;
@@ -102,7 +104,7 @@ CK_RV Slot::getSlotInfo(CK_SLOT_INFO_PTR info)
 }
 
 // Get the slot ID
-size_t Slot::getSlotID()
+CK_SLOT_ID Slot::getSlotID()
 {
 	return slotID;
 }

--- a/src/lib/slot_mgr/Slot.h
+++ b/src/lib/slot_mgr/Slot.h
@@ -46,7 +46,7 @@ class Slot
 {
 public:
 	// Constructor
-	Slot(ObjectStore* inObjectStore, size_t inSlotID, ObjectStoreToken *inToken = NULL);
+	Slot(ObjectStore* inObjectStore, CK_SLOT_ID inSlotID, ObjectStoreToken *inToken = NULL);
 
 	// Destructor
 	virtual ~Slot();
@@ -61,7 +61,7 @@ public:
 	CK_RV getSlotInfo(CK_SLOT_INFO_PTR info);
 
 	// Get the slot ID
-	size_t getSlotID();
+	CK_SLOT_ID getSlotID();
 
 	// Is a token present?
 	bool isTokenPresent();
@@ -74,7 +74,7 @@ private:
 	Token* token;
 
 	// The slot ID
-	size_t slotID;
+	CK_SLOT_ID slotID;
 };
 
 #endif // !_SOFTHSM_V2_SLOT_H

--- a/src/lib/slot_mgr/SlotManager.cpp
+++ b/src/lib/slot_mgr/SlotManager.cpp
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <sstream>
 #include <cassert>
+#include <stdexcept>
 typedef std::pair<CK_SLOT_ID, Slot*> SlotMapElement;
 typedef std::pair<SlotMap::iterator, bool> InsertResult;
 

--- a/src/lib/slot_mgr/SlotManager.cpp
+++ b/src/lib/slot_mgr/SlotManager.cpp
@@ -38,9 +38,12 @@
 #include "SlotManager.h"
 #include <iostream>
 #include <sstream>
+#include <cassert>
+typedef std::pair<CK_SLOT_ID, Slot*> SlotMapElement;
+typedef std::pair<SlotMap::iterator, bool> InsertResult;
 
 // Constructor
-SlotManager::SlotManager(ObjectStore* objectStore)
+SlotManager::SlotManager(ObjectStore*const objectStore)
 {
 	// Add a slot for each token that already exists
 	for (size_t i = 0; i < objectStore->getTokenCount(); i++)
@@ -57,23 +60,29 @@ SlotManager::SlotManager(ObjectStore* objectStore)
 		// this since sunpkcs11 java wrapper is parsing the slot ID to a java int that needs to be positive.
 		// java int is 32 bit and the the sign bit is removed.
 		const CK_SLOT_ID mask( ((CK_SLOT_ID)1<<31)-1 );
-		Slot*const newSlot( new Slot(objectStore, mask&l, pToken) );
-		slots.push_back(newSlot);
+		const CK_SLOT_ID slotID(mask&l);
+		insertToken(objectStore, slotID, pToken);
 	}
 
 	// Add an empty slot
-	slots.push_back(new Slot(objectStore, objectStore->getTokenCount()));
+	insertToken(objectStore, objectStore->getTokenCount(), NULL);
+}
+
+void SlotManager::insertToken(ObjectStore*const objectStore, const CK_SLOT_ID slotID, ObjectStoreToken*const pToken) {
+	Slot*const newSlot( new Slot(objectStore, slotID, pToken) );
+	const InsertResult result( slots.insert(SlotMapElement(slotID, newSlot)) );
+	assert(result.second);// fails if there is already a token on this slot
 }
 
 // Destructor
 SlotManager::~SlotManager()
 {
-	std::vector<Slot*> toDelete = slots;
+	SlotMap toDelete = slots;
 	slots.clear();
 
-	for (std::vector<Slot*>::iterator i = toDelete.begin(); i != toDelete.end(); i++)
+	for (SlotMap::iterator i = toDelete.begin(); i != toDelete.end(); i++)
 	{
-		delete *i;
+		delete i->second;
 	}
 }
 
@@ -86,14 +95,14 @@ CK_RV SlotManager::getSlotList(ObjectStore* objectStore, CK_BBOOL tokenPresent, 
 
 	// Calculate the size of the list
 	bool uninitialized = false;
-	for (std::vector<Slot*>::iterator i = slots.begin(); i != slots.end(); i++)
+	for (SlotMap::iterator i = slots.begin(); i != slots.end(); i++)
 	{
-		if ((tokenPresent == CK_FALSE) || (*i)->isTokenPresent())
+		if ((tokenPresent == CK_FALSE) || i->second->isTokenPresent())
 		{
 			size++;
 		}
 
-		if ((*i)->getToken() != NULL && (*i)->getToken()->isInitialized() == false)
+		if (i->second->getToken() != NULL && i->second->getToken()->isInitialized() == false)
 		{
 			uninitialized = true;
 		}
@@ -105,7 +114,7 @@ CK_RV SlotManager::getSlotList(ObjectStore* objectStore, CK_BBOOL tokenPresent, 
 		// Always have an uninitialized token
 		if (uninitialized == false)
 		{
-			slots.push_back(new Slot(objectStore, objectStore->getTokenCount()));
+			insertToken(objectStore, objectStore->getTokenCount(), NULL);
 			size++;
 		}
 
@@ -124,11 +133,11 @@ CK_RV SlotManager::getSlotList(ObjectStore* objectStore, CK_BBOOL tokenPresent, 
 
 	size = 0;
 
-	for (std::vector<Slot*>::iterator i = slots.begin(); i != slots.end(); i++)
+	for (SlotMap::iterator i = slots.begin(); i != slots.end(); i++)
 	{
-		if ((tokenPresent == CK_FALSE) || (*i)->isTokenPresent())
+		if ((tokenPresent == CK_FALSE) || i->second->isTokenPresent())
 		{
-			pSlotList[size++] = (*i)->getSlotID();
+			pSlotList[size++] = i->second->getSlotID();
 		}
 	}
 
@@ -138,7 +147,7 @@ CK_RV SlotManager::getSlotList(ObjectStore* objectStore, CK_BBOOL tokenPresent, 
 }
 
 // Get the slots
-std::vector<Slot*> SlotManager::getSlots()
+SlotMap SlotManager::getSlots()
 {
 	return slots;
 }
@@ -146,13 +155,9 @@ std::vector<Slot*> SlotManager::getSlots()
 // Get one slot
 Slot* SlotManager::getSlot(CK_SLOT_ID slotID)
 {
-	for (std::vector<Slot*>::iterator i = slots.begin(); i != slots.end(); i++)
-	{
-		if ((*i)->getSlotID() == slotID)
-		{
-			return *i;
-		}
+	try {
+		return slots.at(slotID);
+	} catch( const std::out_of_range &oor) {
+		return NULL_PTR;
 	}
-
-	return NULL;
 }

--- a/src/lib/slot_mgr/SlotManager.h
+++ b/src/lib/slot_mgr/SlotManager.h
@@ -41,7 +41,8 @@
 #include "ObjectStore.h"
 #include "Slot.h"
 #include <string>
-#include <vector>
+#include <map>
+typedef std::map<const CK_SLOT_ID, Slot*const> SlotMap;
 
 class SlotManager
 {
@@ -53,7 +54,7 @@ public:
 	virtual ~SlotManager();
 
 	// Get the slots
-	std::vector<Slot*> getSlots();
+	SlotMap getSlots();
 
 	// Get the slot list
 	CK_RV getSlotList(ObjectStore* objectStore, CK_BBOOL tokenPresent, CK_SLOT_ID_PTR pSlotList, CK_ULONG_PTR pulCount);
@@ -61,8 +62,9 @@ public:
 	// Get one slot
 	Slot* getSlot(CK_SLOT_ID slotID);
 private:
+	void insertToken(ObjectStore* objectStore, CK_SLOT_ID slotID, ObjectStoreToken* pToken);
 	// The slots
-	std::vector<Slot*> slots;
+	SlotMap slots;
 };
 
 #endif // !_SOFTHSM_V2_SLOTMANAGER_H

--- a/src/lib/slot_mgr/test/SlotManagerTests.cpp
+++ b/src/lib/slot_mgr/test/SlotManagerTests.cpp
@@ -86,20 +86,20 @@ void SlotManagerTests::testNoExistingTokens()
 
 	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
 	CPPUNIT_ASSERT(ulCount == 1);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotID() == testList[0]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotID() == testList[0]);
 
 	// Retrieve slot information about the first slot
 	CK_SLOT_INFO slotInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the first slot
 	CK_TOKEN_INFO tokenInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 }
@@ -136,48 +136,48 @@ void SlotManagerTests::testExistingTokens()
 
 	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
 	CPPUNIT_ASSERT(ulCount == 3);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotID() == testList[0]);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotID() == testList[1]);
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getSlotID() == testList[2]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotID() == testList[0]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotID() == testList[1]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getSlotID() == testList[2]);
 
 	// Retrieve slot information about the first slot
 	CK_SLOT_INFO slotInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the first slot
 	CK_TOKEN_INFO tokenInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 	CPPUNIT_ASSERT(!memcmp(tokenInfo.label, &label1[0], label1.size()) || 
 	               !memcmp(tokenInfo.label, &label2[0], label2.size()));
 
 	// Retrieve slot information about the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 	CPPUNIT_ASSERT(!memcmp(tokenInfo.label, &label1[0], label1.size()) || 
 	               !memcmp(tokenInfo.label, &label2[0], label2.size()));
 
 	// Retrieve slot information about the third slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the third slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 }
@@ -208,20 +208,20 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 
 		CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
 		CPPUNIT_ASSERT(ulCount == 1);
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotID() == testList[0]);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotID() == testList[0]);
 
 		// Retrieve slot information about the first slot
 		CK_SLOT_INFO slotInfo;
 
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotInfo(&slotInfo) == CKR_OK);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 		CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 		// Retrieve token information about the token in the first slot
 		CK_TOKEN_INFO tokenInfo;
 
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 		CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 
@@ -229,16 +229,16 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 		ByteString soPIN((unsigned char*)"1234", 4);
 		CK_UTF8CHAR label[33] = "My test token                   ";
 
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->initToken(soPIN, label) == CKR_OK);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->initToken(soPIN, label) == CKR_OK);
 
 		// Retrieve slot information about the first slot
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotInfo(&slotInfo) == CKR_OK);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 		CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 		// Retrieve token information about the token in the first slot
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-		CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+		CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 		CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 		CPPUNIT_ASSERT(!memcmp(tokenInfo.label, label, 32));
@@ -265,21 +265,21 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 
 	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
 	CPPUNIT_ASSERT(ulCount == 2);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotID() == testList[0]);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotID() == testList[1]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotID() == testList[0]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotID() == testList[1]);
 
 	// Retrieve slot information about the first slot
 	CK_SLOT_INFO slotInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the first slot
 	CK_TOKEN_INFO tokenInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 
@@ -287,13 +287,13 @@ void SlotManagerTests::testInitialiseTokenInLastSlot()
 	CPPUNIT_ASSERT(!memcmp(tokenInfo.label, label, 32));
 
 	// Retrieve slot information about the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 }
@@ -330,48 +330,48 @@ void SlotManagerTests::testReinitialiseExistingToken()
 
 	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
 	CPPUNIT_ASSERT(ulCount == 3);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotID() == testList[0]);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotID() == testList[1]);
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getSlotID() == testList[2]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotID() == testList[0]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotID() == testList[1]);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getSlotID() == testList[2]);
 
 	// Retrieve slot information about the first slot
 	CK_SLOT_INFO slotInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the first slot
 	CK_TOKEN_INFO tokenInfo;
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 	CPPUNIT_ASSERT(!memcmp(tokenInfo.label, &label1[0], label1.size()) || 
 	               !memcmp(tokenInfo.label, &label2[0], label2.size()));
 
 	// Retrieve slot information about the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 	CPPUNIT_ASSERT(!memcmp(tokenInfo.label, &label1[0], label1.size()) || 
 	               !memcmp(tokenInfo.label, &label2[0], label2.size()));
 
 	// Retrieve slot information about the third slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the third slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 
@@ -379,16 +379,16 @@ void SlotManagerTests::testReinitialiseExistingToken()
 	ByteString soPIN((unsigned char*)"1234", 4);
 	CK_UTF8CHAR label[33] = "My test token                   ";
 
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->initToken(soPIN, label) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->initToken(soPIN, label) == CKR_OK);
 
 	// Retrieve slot information about the first slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getSlotInfo(&slotInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getSlotInfo(&slotInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT) == CKF_TOKEN_PRESENT);
 
 	// Retrieve token information about the token in the first slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 	CPPUNIT_ASSERT(!memcmp(tokenInfo.label, label, 32));
@@ -421,7 +421,7 @@ void SlotManagerTests::testUninitialisedToken()
 	// Initialise the token in the first slot
 	ByteString soPIN((unsigned char*)"1234", 4);
 	CK_UTF8CHAR label[33] = "My test token                   ";
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->initToken(soPIN, label) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->initToken(soPIN, label) == CKR_OK);
 
 	// Check if a new slot is added
 	ulCount = 10;
@@ -435,19 +435,23 @@ void SlotManagerTests::testUninitialisedToken()
 	CPPUNIT_ASSERT(ulCount == 2);
 	ulCount = 10;
 	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, NULL_PTR, &ulCount) == CKR_OK);
+	CPPUNIT_ASSERT(ulCount == 2);
+
+	// get new list
+	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
 	CPPUNIT_ASSERT(ulCount == 2);
 
 	// Retrieve token information about the tokens
 	CK_TOKEN_INFO tokenInfo;
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 
 	// Initialise the token in the second slot
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->initToken(soPIN, label) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->initToken(soPIN, label) == CKR_OK);
 
 	// Check if a new slot is added
 	ulCount = 10;
@@ -463,15 +467,19 @@ void SlotManagerTests::testUninitialisedToken()
 	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, NULL_PTR, &ulCount) == CKR_OK);
 	CPPUNIT_ASSERT(ulCount == 3);
 
+	// get new list
+	CPPUNIT_ASSERT(slotManager.getSlotList(&store, CK_TRUE, testList, &ulCount) == CKR_OK);
+	CPPUNIT_ASSERT(ulCount == 3);
+
 	// Retrieve token information about the tokens
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[0]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[0]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[1]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[1]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getToken() != NULL);
-	CPPUNIT_ASSERT(slotManager.getSlots()[2]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getToken() != NULL);
+	CPPUNIT_ASSERT(slotManager.getSlots()[testList[2]]->getToken()->getTokenInfo(&tokenInfo) == CKR_OK);
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) != CKF_TOKEN_INITIALIZED);
 }
 

--- a/src/lib/test/AsymEncryptDecryptTests.cpp
+++ b/src/lib/test/AsymEncryptDecryptTests.cpp
@@ -34,9 +34,7 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "AsymEncryptDecryptTests.h"
-#include "testconfig.h"
 
 // CKA_TOKEN
 const CK_BBOOL ON_TOKEN = CK_TRUE;
@@ -48,51 +46,6 @@ const CK_BBOOL IS_PUBLIC = CK_FALSE;
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(AsymEncryptDecryptTests);
-
-void AsymEncryptDecryptTests::setUp()
-{
-//    printf("\nObjectTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
-	CK_SESSION_HANDLE hSession;
-
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, sopin,sopinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Open session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Login SO
-	rv = C_Login(hSession,CKU_SO, sopin, sopinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Initialize the user pin
-	rv = C_InitPIN(hSession, pin, pinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-}
-
-void AsymEncryptDecryptTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 CK_RV AsymEncryptDecryptTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk)
 {
@@ -213,8 +166,6 @@ void AsymEncryptDecryptTests::rsaOAEPParams(CK_SESSION_HANDLE hSession, CK_OBJEC
 void AsymEncryptDecryptTests::testRsaEncryptDecrypt()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
 
@@ -222,7 +173,7 @@ void AsymEncryptDecryptTests::testRsaEncryptDecrypt()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -230,15 +181,15 @@ void AsymEncryptDecryptTests::testRsaEncryptDecrypt()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPublicKey = CK_INVALID_HANDLE;

--- a/src/lib/test/AsymEncryptDecryptTests.h
+++ b/src/lib/test/AsymEncryptDecryptTests.h
@@ -34,10 +34,10 @@
 #ifndef _SOFTHSM_V2_ASYMENCRYPTDECRYPTTESTS_H
 #define _SOFTHSM_V2_ASYMENCRYPTDECRYPTTESTS_H
 
+#include "TestsBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class AsymEncryptDecryptTests : public CppUnit::TestFixture
+class AsymEncryptDecryptTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(AsymEncryptDecryptTests);
 	CPPUNIT_TEST(testRsaEncryptDecrypt);
@@ -45,9 +45,6 @@ class AsymEncryptDecryptTests : public CppUnit::TestFixture
 
 public:
 	void testRsaEncryptDecrypt();
-
-	void setUp();
-	void tearDown();
 
 protected:
 	CK_RV generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk);

--- a/src/lib/test/AsymWrapUnwrapTests.cpp
+++ b/src/lib/test/AsymWrapUnwrapTests.cpp
@@ -34,9 +34,7 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "AsymWrapUnwrapTests.h"
-#include "testconfig.h"
 
 // CKA_TOKEN
 const CK_BBOOL ON_TOKEN = CK_TRUE;
@@ -48,51 +46,6 @@ const CK_BBOOL IS_PUBLIC = CK_FALSE;
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(AsymWrapUnwrapTests);
-
-void AsymWrapUnwrapTests::setUp()
-{
-//    printf("\nObjectTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
-	CK_SESSION_HANDLE hSession;
-
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, sopin,sopinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Open session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Login SO
-	rv = C_Login(hSession,CKU_SO, sopin, sopinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Initialize the user pin
-	rv = C_InitPIN(hSession, pin, pinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-}
-
-void AsymWrapUnwrapTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 // Generate throw-away (session) symmetric key
 CK_RV AsymWrapUnwrapTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE &hKey)
@@ -200,7 +153,7 @@ void AsymWrapUnwrapTests::rsaWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_SESS
 	ulSymValueLen = valueTemplate[0].ulValueLen;
 
 	// CKM_RSA_PKCS Wrap/Unwrap support
-	rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, CKM_RSA_PKCS, &mechInfo);
+	rv = C_GetMechanismInfo(m_initializedTokenSlotID, CKM_RSA_PKCS, &mechInfo);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(mechInfo.flags&CKF_WRAP);
 	CPPUNIT_ASSERT(mechInfo.flags&CKF_UNWRAP);
@@ -237,8 +190,6 @@ void AsymWrapUnwrapTests::rsaWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_SESS
 void AsymWrapUnwrapTests::testRsaWrapUnwrap()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
 
@@ -246,7 +197,7 @@ void AsymWrapUnwrapTests::testRsaWrapUnwrap()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -254,15 +205,15 @@ void AsymWrapUnwrapTests::testRsaWrapUnwrap()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPublicKey = CK_INVALID_HANDLE;

--- a/src/lib/test/AsymWrapUnwrapTests.h
+++ b/src/lib/test/AsymWrapUnwrapTests.h
@@ -34,10 +34,10 @@
 #ifndef _SOFTHSM_V2_ASYMWRAPUNWRAPTESTS_H
 #define _SOFTHSM_V2_ASYMWRAPUNWRAPTESTS_H
 
+#include "TestsBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class AsymWrapUnwrapTests : public CppUnit::TestFixture
+class AsymWrapUnwrapTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(AsymWrapUnwrapTests);
 	CPPUNIT_TEST(testRsaWrapUnwrap);
@@ -45,9 +45,6 @@ class AsymWrapUnwrapTests : public CppUnit::TestFixture
 
 public:
 	void testRsaWrapUnwrap();
-
-	void setUp();
-	void tearDown();
 
 protected:
 	CK_RV generateAesKey(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE &hKey);

--- a/src/lib/test/DeriveTests.cpp
+++ b/src/lib/test/DeriveTests.cpp
@@ -35,9 +35,7 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "DeriveTests.h"
-#include "testconfig.h"
 
 // CKA_TOKEN
 const CK_BBOOL ON_TOKEN = CK_TRUE;
@@ -49,51 +47,6 @@ const CK_BBOOL IS_PUBLIC = CK_FALSE;
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(DeriveTests);
-
-void DeriveTests::setUp()
-{
-//    printf("\nDeriveTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
-	CK_SESSION_HANDLE hSession;
-
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, sopin,sopinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Open session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Login SO
-	rv = C_Login(hSession,CKU_SO, sopin, sopinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Initialize the user pin
-	rv = C_InitPIN(hSession, pin, pinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-}
-
-void DeriveTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 CK_RV DeriveTests::generateDhKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk)
 {
@@ -281,8 +234,6 @@ bool DeriveTests::compareSecret(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKe
 void DeriveTests::testDhDerive()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
 
@@ -290,7 +241,7 @@ void DeriveTests::testDhDerive()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -298,15 +249,15 @@ void DeriveTests::testDhDerive()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Public Session keys
@@ -487,8 +438,6 @@ void DeriveTests::symDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey, C
 void DeriveTests::testSymDerive()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
 
@@ -496,7 +445,7 @@ void DeriveTests::testSymDerive()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -504,15 +453,15 @@ void DeriveTests::testSymDerive()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Generate base key

--- a/src/lib/test/DeriveTests.h
+++ b/src/lib/test/DeriveTests.h
@@ -33,10 +33,10 @@
 #ifndef _SOFTHSM_V2_DERIVETESTS_H
 #define _SOFTHSM_V2_DERIVETESTS_H
 
+#include "TestsBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class DeriveTests : public CppUnit::TestFixture
+class DeriveTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(DeriveTests);
 	CPPUNIT_TEST(testDhDerive);
@@ -46,9 +46,6 @@ class DeriveTests : public CppUnit::TestFixture
 public:
 	void testDhDerive();
 	void testSymDerive();
-
-	void setUp();
-	void tearDown();
 
 protected:
 	CK_RV generateDhKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk);

--- a/src/lib/test/DigestTests.cpp
+++ b/src/lib/test/DigestTests.cpp
@@ -33,40 +33,9 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "DigestTests.h"
-#include "testconfig.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(DigestTests);
-
-void DigestTests::setUp()
-{
-//    printf("\nDigestTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	CK_RV rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
-}
-
-void DigestTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 void DigestTests::testDigestInit()
 {
@@ -85,7 +54,7 @@ void DigestTests::testDigestInit()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_DigestInit(hSession, NULL_PTR);
@@ -125,7 +94,7 @@ void DigestTests::testDigest()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_Digest(CK_INVALID_HANDLE, data, sizeof(data)-1, NULL_PTR, &digestLen);
@@ -178,7 +147,7 @@ void DigestTests::testDigestUpdate()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_DigestUpdate(CK_INVALID_HANDLE, data, sizeof(data)-1);
@@ -215,7 +184,7 @@ void DigestTests::testDigestKey()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create the generic secret key to digest
@@ -275,7 +244,7 @@ void DigestTests::testDigestFinal()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_DigestFinal(CK_INVALID_HANDLE, NULL_PTR, &digestLen);
@@ -337,7 +306,7 @@ void DigestTests::testDigestAll()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	for (unsigned int i = 0; i < sizeof(mechanisms)/sizeof(CK_MECHANISM); i++)

--- a/src/lib/test/DigestTests.h
+++ b/src/lib/test/DigestTests.h
@@ -33,10 +33,10 @@
 #ifndef _SOFTHSM_V2_DIGESTTESTS_H
 #define _SOFTHSM_V2_DIGESTTESTS_H
 
+#include "TestsNoPINInitBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class DigestTests : public CppUnit::TestFixture
+class DigestTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(DigestTests);
 	CPPUNIT_TEST(testDigestInit);
@@ -54,9 +54,6 @@ public:
 	void testDigestKey();
 	void testDigestFinal();
 	void testDigestAll();
-
-	void setUp();
-	void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_DIGESTTESTS_H

--- a/src/lib/test/InfoTests.cpp
+++ b/src/lib/test/InfoTests.cpp
@@ -34,41 +34,9 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "InfoTests.h"
-#include "testconfig.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(InfoTests);
-
-void InfoTests::setUp()
-{
-//    printf("\nInfoTests\n");
-
-#ifndef _WIN32
-    setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-    setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	CK_RV rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
-}
-
-void InfoTests::tearDown()
-{
-	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
-}
 
 void InfoTests::testGetInfo()
 {
@@ -164,19 +132,19 @@ void InfoTests::testGetSlotInfo()
 	// Just make sure that we finalize any previous failed tests
 	C_Finalize(NULL_PTR);
 
-	rv = C_GetSlotInfo(SLOT_NO_INIT_TOKEN, &slotInfo);
+	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetSlotInfo(SLOT_NO_INIT_TOKEN, NULL_PTR);
+	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetSlotInfo(SLOT_INVALID, &slotInfo);
+	rv = C_GetSlotInfo(m_invalidSlotID, &slotInfo);
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetSlotInfo(SLOT_NO_INIT_TOKEN, &slotInfo);
+	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT ) == CKF_TOKEN_PRESENT);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_REMOVABLE_DEVICE ) == 0);
@@ -198,8 +166,6 @@ void InfoTests::testGetSlotInfoAlt()
     setenv("SOFTHSM2_CONF", ".\\softhsm2-alt.conf", 1);
 #endif
 
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_UTF8CHAR label[32];
 	memset(label, ' ', 32);
 	memcpy(label, "token1", strlen("token1"));
@@ -207,28 +173,33 @@ void InfoTests::testGetSlotInfoAlt()
 	// (Re)initialize the token
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
+	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	C_Finalize(NULL_PTR);
 
-	rv = C_GetSlotInfo(SLOT_NO_INIT_TOKEN, &slotInfo);
+	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetSlotInfo(SLOT_NO_INIT_TOKEN, NULL_PTR);
+	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetSlotInfo(SLOT_INVALID, &slotInfo);
+	rv = C_GetSlotInfo(m_invalidSlotID, &slotInfo);
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetSlotInfo(SLOT_NO_INIT_TOKEN, &slotInfo);
+	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT ) == CKF_TOKEN_PRESENT);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_REMOVABLE_DEVICE ) == CKF_REMOVABLE_DEVICE);
 
 	C_Finalize(NULL_PTR);
+#ifndef _WIN32
+	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 }
 
 
@@ -240,24 +211,24 @@ void InfoTests::testGetTokenInfo()
 	// Just make sure that we finalize any previous failed tests
 	C_Finalize(NULL_PTR);
 
-	rv = C_GetTokenInfo(SLOT_NO_INIT_TOKEN, &tokenInfo);
+	rv = C_GetTokenInfo(m_notInitializedTokenSlotID, &tokenInfo);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetTokenInfo(SLOT_NO_INIT_TOKEN, NULL_PTR);
+	rv = C_GetTokenInfo(m_notInitializedTokenSlotID, NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetTokenInfo(SLOT_INVALID, &tokenInfo);
+	rv = C_GetTokenInfo(m_invalidSlotID, &tokenInfo);
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetTokenInfo(SLOT_NO_INIT_TOKEN, &tokenInfo);
+	rv = C_GetTokenInfo(m_notInitializedTokenSlotID, &tokenInfo);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == 0);
 
-	rv = C_GetTokenInfo(SLOT_INIT_TOKEN, &tokenInfo);
+	rv = C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
@@ -274,30 +245,30 @@ void InfoTests::testGetMechanismList()
 	// Just make sure that we finalize any previous failed tests
 	C_Finalize(NULL_PTR);
 
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, NULL_PTR, &ulMechCount);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, NULL_PTR, NULL_PTR);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetMechanismList(SLOT_INVALID, NULL_PTR, &ulMechCount);
+	rv = C_GetMechanismList(m_invalidSlotID, NULL_PTR, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
 	// Get the size of the buffer
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, NULL_PTR, &ulMechCount);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	pMechanismList = (CK_MECHANISM_TYPE_PTR)malloc(ulMechCount * sizeof(CK_MECHANISM_TYPE_PTR));
 
 	// Check if we have a too small buffer
 	ulMechCount = 0;
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, pMechanismList, &ulMechCount);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
 	// Get the mechanism list
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, pMechanismList, &ulMechCount);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	free(pMechanismList);
 
@@ -314,32 +285,32 @@ void InfoTests::testGetMechanismInfo()
 	// Just make sure that we finalize any previous failed tests
 	C_Finalize(NULL_PTR);
 
-	rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, CKM_RSA_PKCS, &info);
+	rv = C_GetMechanismInfo(m_initializedTokenSlotID, CKM_RSA_PKCS, &info);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Get the mechanism list
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, NULL_PTR, &ulMechCount);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(ulMechCount != 0);
 	pMechanismList = (CK_MECHANISM_TYPE_PTR)malloc(ulMechCount * sizeof(CK_MECHANISM_TYPE_PTR));
-	rv = C_GetMechanismList(SLOT_INIT_TOKEN, pMechanismList, &ulMechCount);
+	rv = C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, pMechanismList[0], NULL_PTR);
+	rv = C_GetMechanismInfo(m_initializedTokenSlotID, pMechanismList[0], NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetMechanismInfo(SLOT_INVALID, pMechanismList[0], &info);
+	rv = C_GetMechanismInfo(m_invalidSlotID, pMechanismList[0], &info);
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, CKM_VENDOR_DEFINED, &info);
+	rv = C_GetMechanismInfo(m_initializedTokenSlotID, CKM_VENDOR_DEFINED, &info);
 	CPPUNIT_ASSERT(rv == CKR_MECHANISM_INVALID);
 
 	for (unsigned int i = 0; i < ulMechCount; i++)
 	{
-		rv = C_GetMechanismInfo(SLOT_INIT_TOKEN, pMechanismList[i], &info);
+		rv = C_GetMechanismInfo(m_initializedTokenSlotID, pMechanismList[i], &info);
 		CPPUNIT_ASSERT(rv == CKR_OK);
 	}
 

--- a/src/lib/test/InfoTests.h
+++ b/src/lib/test/InfoTests.h
@@ -34,10 +34,10 @@
 #ifndef _SOFTHSM_V2_INFOTESTS_H
 #define _SOFTHSM_V2_INFOTESTS_H
 
+#include "TestsNoPINInitBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class InfoTests : public CppUnit::TestFixture
+class InfoTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(InfoTests);
 	CPPUNIT_TEST(testGetInfo);
@@ -59,9 +59,6 @@ public:
 	void testGetMechanismList();
 	void testGetMechanismInfo();
 	void testGetSlotInfoAlt();
-
-	void setUp();
-	void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_INFOTESTS_H

--- a/src/lib/test/Makefile.am
+++ b/src/lib/test/Makefile.am
@@ -23,6 +23,8 @@ p11test_SOURCES =		p11test.cpp \
 				SignVerifyTests.cpp \
 				AsymEncryptDecryptTests.cpp \
 				AsymWrapUnwrapTests.cpp \
+				TestsBase.cpp \
+				TestsNoPINInitBase.cpp \
 				../common/osmutex.cpp
 
 p11test_LDADD =			../libsofthsm2.la 

--- a/src/lib/test/ObjectTests.h
+++ b/src/lib/test/ObjectTests.h
@@ -35,10 +35,10 @@
 #ifndef _SOFTHSM_V2_OBJECTTESTS_H
 #define _SOFTHSM_V2_OBJECTTESTS_H
 
+#include "TestsBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class ObjectTests : public CppUnit::TestFixture
+class ObjectTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(ObjectTests);
 	CPPUNIT_TEST(testCreateObject);
@@ -80,9 +80,6 @@ public:
 	void testGetInvalidAttribute();
 	void testArrayAttribute();
 	void testCreateSecretKey();
-
-	void setUp();
-	void tearDown();
 
 protected:
 	void checkCommonObjectAttributes

--- a/src/lib/test/RandomTests.cpp
+++ b/src/lib/test/RandomTests.cpp
@@ -33,40 +33,9 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "RandomTests.h"
-#include "testconfig.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RandomTests);
-
-void RandomTests::setUp()
-{
-//    printf("\nRandomTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	CK_RV rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
-}
-
-void RandomTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 void RandomTests::testSeedRandom()
 {
@@ -83,7 +52,7 @@ void RandomTests::testSeedRandom()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_SeedRandom(hSession, NULL_PTR, sizeof(seed));
@@ -111,7 +80,7 @@ void RandomTests::testGenerateRandom()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_GenerateRandom(hSession, NULL_PTR, 40);

--- a/src/lib/test/RandomTests.h
+++ b/src/lib/test/RandomTests.h
@@ -33,10 +33,10 @@
 #ifndef _SOFTHSM_V2_RANDOMTESTS_H
 #define _SOFTHSM_V2_RANDOMTESTS_H
 
+#include "TestsNoPINInitBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class RandomTests : public CppUnit::TestFixture
+class RandomTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(RandomTests);
 	CPPUNIT_TEST(testSeedRandom);
@@ -46,9 +46,6 @@ class RandomTests : public CppUnit::TestFixture
 public:
 	void testSeedRandom();
 	void testGenerateRandom();
-
-	void setUp();
-	void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_RANDOMTESTS_H

--- a/src/lib/test/SessionTests.h
+++ b/src/lib/test/SessionTests.h
@@ -34,10 +34,10 @@
 #ifndef _SOFTHSM_V2_SESSIONTESTS_H
 #define _SOFTHSM_V2_SESSIONTESTS_H
 
+#include "TestsNoPINInitBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class SessionTests : public CppUnit::TestFixture
+class SessionTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(SessionTests);
 	CPPUNIT_TEST(testOpenSession);
@@ -51,9 +51,6 @@ public:
 	void testCloseSession();
 	void testCloseAllSessions();
 	void testGetSessionInfo();
-
-	void setUp();
-	void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_SESSIONTESTS_H

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -42,9 +42,7 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "SignVerifyTests.h"
-#include "testconfig.h"
 
 // CKA_TOKEN
 const CK_BBOOL ON_TOKEN = CK_TRUE;
@@ -56,51 +54,6 @@ const CK_BBOOL IS_PUBLIC = CK_FALSE;
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SignVerifyTests);
-
-void SignVerifyTests::setUp()
-{
-//    printf("\nSignVerifyTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
-	CK_SESSION_HANDLE hSession;
-
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, sopin,sopinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Open session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Login SO
-	rv = C_Login(hSession,CKU_SO, sopin, sopinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Initialize the user pin
-	rv = C_InitPIN(hSession, pin, pinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-}
-
-void SignVerifyTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 CK_RV SignVerifyTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk)
 {
@@ -204,8 +157,6 @@ void SignVerifyTests::digestRsaPkcsSignVerify(CK_MECHANISM_TYPE mechanismType, C
 void SignVerifyTests::testRsaSignVerify()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
 	CK_RSA_PKCS_PSS_PARAMS params[] = {
@@ -220,7 +171,7 @@ void SignVerifyTests::testRsaSignVerify()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -228,15 +179,15 @@ void SignVerifyTests::testRsaSignVerify()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPuk = CK_INVALID_HANDLE;
@@ -404,8 +355,6 @@ void SignVerifyTests::hmacSignVerify(CK_MECHANISM_TYPE mechanismType, CK_SESSION
 void SignVerifyTests::testHmacSignVerify()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
 
@@ -413,7 +362,7 @@ void SignVerifyTests::testHmacSignVerify()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -421,15 +370,15 @@ void SignVerifyTests::testHmacSignVerify()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Public Session keys

--- a/src/lib/test/SignVerifyTests.h
+++ b/src/lib/test/SignVerifyTests.h
@@ -34,10 +34,10 @@
 #ifndef _SOFTHSM_V2_SIGNVERIFYTESTS_H
 #define _SOFTHSM_V2_SIGNVERIFYTESTS_H
 
+#include "TestsBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class SignVerifyTests : public CppUnit::TestFixture
+class SignVerifyTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(SignVerifyTests);
 	CPPUNIT_TEST(testRsaSignVerify);
@@ -47,9 +47,6 @@ class SignVerifyTests : public CppUnit::TestFixture
 public:
 	void testRsaSignVerify();
 	void testHmacSignVerify();
-
-	void setUp();
-	void tearDown();
 
 protected:
 	CK_RV generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk);

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -33,9 +33,7 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "SymmetricAlgorithmTests.h"
-#include "testconfig.h"
 
 // CKA_TOKEN
 const CK_BBOOL ON_TOKEN = CK_TRUE;
@@ -47,47 +45,6 @@ const CK_BBOOL IS_PUBLIC = CK_FALSE;
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SymmetricAlgorithmTests);
-
-void SymmetricAlgorithmTests::setUp()
-{
-//    printf("\nObjectTests\n");
-
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-
-	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
-	CK_SESSION_HANDLE hSession;
-
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, sopin,sopinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Open session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Login SO
-	rv = C_Login(hSession,CKU_SO, sopin, sopinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-
-	// Initialize the user pin
-	rv = C_InitPIN(hSession, pin, pinLength);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-}
-
-void SymmetricAlgorithmTests::tearDown()
-{
-	C_Finalize(NULL_PTR);
-}
 
 CK_RV SymmetricAlgorithmTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey)
 {
@@ -777,8 +734,6 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 void SymmetricAlgorithmTests::testAesEncryptDecrypt()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	// CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
 	// CK_ULONG sopinLength = sizeof(sopin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
@@ -788,7 +743,7 @@ void SymmetricAlgorithmTests::testAesEncryptDecrypt()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -796,15 +751,15 @@ void SymmetricAlgorithmTests::testAesEncryptDecrypt()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
@@ -821,8 +776,6 @@ void SymmetricAlgorithmTests::testAesEncryptDecrypt()
 void SymmetricAlgorithmTests::testAesWrapUnwrap()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	// CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
 	// CK_ULONG sopinLength = sizeof(sopin) - 1;
 	CK_SESSION_HANDLE hSession;
@@ -835,11 +788,11 @@ void SymmetricAlgorithmTests::testAesWrapUnwrap()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the session so we can create a private object
-	rv = C_Login(hSession,CKU_USER,pin,pinLength);
+	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
@@ -857,8 +810,6 @@ void SymmetricAlgorithmTests::testAesWrapUnwrap()
 void SymmetricAlgorithmTests::testDesEncryptDecrypt()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	// CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
 	// CK_ULONG sopinLength = sizeof(sopin) - 1;
 	CK_SESSION_HANDLE hSessionRO;
@@ -868,7 +819,7 @@ void SymmetricAlgorithmTests::testDesEncryptDecrypt()
 	C_Finalize(NULL_PTR);
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
@@ -876,15 +827,15 @@ void SymmetricAlgorithmTests::testDesEncryptDecrypt()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,pin,pinLength);
+	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 #ifndef WITH_FIPS
@@ -923,8 +874,6 @@ void SymmetricAlgorithmTests::testDesEncryptDecrypt()
 void SymmetricAlgorithmTests::testNullTemplate()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSession;
 	CK_MECHANISM mechanism1 = { CKM_DES3_KEY_GEN, NULL_PTR, 0 };
 	CK_MECHANISM mechanism2 = { CKM_AES_KEY_GEN, NULL_PTR, 0 };
@@ -938,11 +887,11 @@ void SymmetricAlgorithmTests::testNullTemplate()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, pin, pinLength);
+	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	rv = C_GenerateKey(hSession, &mechanism1, NULL_PTR, 0, &hKey);
@@ -958,8 +907,6 @@ void SymmetricAlgorithmTests::testNullTemplate()
 void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSession;
 	CK_MECHANISM mechanism = { CKM_DES3_KEY_GEN, NULL_PTR, 0 };
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
@@ -985,11 +932,11 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, pin, pinLength);
+	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	rv = C_GenerateKey(hSession, &mechanism,
@@ -1040,8 +987,6 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 void SymmetricAlgorithmTests::testCheckValue()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSession;
 	CK_MECHANISM mechanism = { CKM_AES_KEY_GEN, NULL_PTR, 0 };
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
@@ -1054,11 +999,11 @@ void SymmetricAlgorithmTests::testCheckValue()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, pin, pinLength);
+	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_ULONG bytes = 16;

--- a/src/lib/test/SymmetricAlgorithmTests.h
+++ b/src/lib/test/SymmetricAlgorithmTests.h
@@ -33,10 +33,10 @@
 #ifndef _SOFTHSM_V2_SYMENCRYPTDECRYPTTESTS_H
 #define _SOFTHSM_V2_SYMENCRYPTDECRYPTTESTS_H
 
+#include "TestsBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class SymmetricAlgorithmTests : public CppUnit::TestFixture
+class SymmetricAlgorithmTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(SymmetricAlgorithmTests);
 	CPPUNIT_TEST(testAesEncryptDecrypt);
@@ -55,9 +55,6 @@ public:
 	void testNullTemplate();
 	void testNonModifiableDesKeyGeneration();
 	void testCheckValue();
-
-	void setUp();
-	void tearDown();
 
 protected:
 	CK_RV generateAesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);

--- a/src/lib/test/TestsBase.cpp
+++ b/src/lib/test/TestsBase.cpp
@@ -25,24 +25,25 @@
  */
 
 /*****************************************************************************
- testconfig.h
+ TestsBase.cpp
 
- Contains parameters for the test cases
+ Base class for test classes.
  *****************************************************************************/
 
-#ifndef _SOFTHSM_V2_TESTCONFIG_H
-#define _SOFTHSM_V2_TESTCONFIG_H
+#include "TestsBase.h"
+#include <cppunit/extensions/HelperMacros.h>
 
-// Slots
-#define SLOT_INVALID 9999
-#define SLOT_INIT_TOKEN 0
-#define SLOT_NO_INIT_TOKEN 1
+void TestsBase::setUp() {
+	TestsNoPINInitBase::setUp();
 
-// PIN
-#define SLOT_0_SO1_PIN "12345678"
-#define SLOT_0_SO2_PIN "123456789"
-#define SLOT_0_USER1_PIN "1234"
-#define SLOT_0_USER2_PIN "12345"
+	CK_SESSION_HANDLE hSession;
 
-#endif // !_SOFTHSM_V2_TESTCONFIG_H
+	// Open session
+	CPPUNIT_ASSERT( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION|CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession)==CKR_OK );
 
+	// Login SO
+	CPPUNIT_ASSERT( C_Login(hSession,CKU_SO, m_soPin1, m_soPin1Length)==CKR_OK );
+
+	// Initialize the user pin
+	CPPUNIT_ASSERT( C_InitPIN(hSession, m_userPin1, m_userPin1Length)==CKR_OK );
+}

--- a/src/lib/test/TestsBase.h
+++ b/src/lib/test/TestsBase.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2010 SURFnet bv
+ * Copyright (c) 2010 .SE (The Internet Infrastructure Foundation)
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -10,7 +10,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -25,29 +25,20 @@
  */
 
 /*****************************************************************************
- p11test.cpp
+ TestsBase.h
 
- The main test executor for tests on the PKCS#11 interface in SoftHSM v2
+ Base class for test classes.
  *****************************************************************************/
 
-#include <cppunit/extensions/TestFactoryRegistry.h>
-#include <cppunit/ui/text/TestRunner.h>
-#include <stdlib.h>
+#ifndef SRC_LIB_TEST_TESTSBASE_H_
+#define SRC_LIB_TEST_TESTSBASE_H_
 
-int main(int /*argc*/, char** /*argv*/)
-{
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
+#include <TestsNoPINInitBase.h>
 
-	CppUnit::TextUi::TestRunner runner;
-	CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
+class TestsBase : public TestsNoPINInitBase {
+public:
+	virtual void setUp();
+};
 
-	runner.addTest(registry.makeTest());
-	bool wasSucessful = runner.run();
 
-	return wasSucessful ? 0 : 1;
-}
-
+#endif /* SRC_LIB_TEST_TESTSBASE_H_ */

--- a/src/lib/test/TestsNoPINInitBase.cpp
+++ b/src/lib/test/TestsNoPINInitBase.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010 .SE (The Internet Infrastructure Foundation)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*****************************************************************************
+ TestsNoPINInitBase.cpp
+
+ Base class for test classes. Used when there is no need for user login.
+ *****************************************************************************/
+
+#include "TestsNoPINInitBase.h"
+#include <cstring>
+#include <cppunit/extensions/HelperMacros.h>
+#include <vector>
+
+static void getSlotIDs( CK_SLOT_ID*const pInitializedTokenSlotID, CK_SLOT_ID*const pFreeTokenSlotID ) {
+	bool hasFoundFree(false);
+	bool hasFoundInitialized(false);
+	CK_ULONG nrOfSlots;
+	CPPUNIT_ASSERT( C_GetSlotList(CK_TRUE, NULL_PTR, &nrOfSlots)==CKR_OK );
+	std::vector<CK_SLOT_ID> slotIDs(nrOfSlots);
+	CPPUNIT_ASSERT( C_GetSlotList(CK_TRUE, &slotIDs.front(), &nrOfSlots)==CKR_OK );
+	for ( std::vector<CK_SLOT_ID>::iterator i=slotIDs.begin(); i!=slotIDs.end(); i++ ) {
+		CK_TOKEN_INFO tokenInfo;
+		CPPUNIT_ASSERT( C_GetTokenInfo(*i, &tokenInfo)==CKR_OK );
+		if ( tokenInfo.flags&CKF_TOKEN_INITIALIZED ) {
+			if ( !hasFoundInitialized ) {
+				hasFoundInitialized = true;
+				*pInitializedTokenSlotID = *i;
+			}
+		} else {
+			if ( !hasFoundFree ) {
+				hasFoundFree = true;
+				*pFreeTokenSlotID = *i;
+			}
+		}
+	}
+	if ( !hasFoundInitialized ) {
+		*pInitializedTokenSlotID = *pFreeTokenSlotID;
+	}
+}
+
+TestsNoPINInitBase::TestsNoPINInitBase() :
+	m_invalidSlotID(-1),
+	m_initializedTokenSlotID(m_invalidSlotID),
+	m_notInitializedTokenSlotID(m_invalidSlotID),
+	m_soPin1((CK_UTF8CHAR_PTR)"12345678"),
+	m_soPin1Length(strlen((char*)m_soPin1)),
+	m_userPin1((CK_UTF8CHAR_PTR)"1234"),
+	m_userPin1Length(strlen((char*)m_userPin1)) {};
+
+void TestsNoPINInitBase::setUp() {
+	CK_UTF8CHAR label[32];
+	memset(label, ' ', 32);
+	memcpy(label, "token1", strlen("token1"));
+
+	// initialize cryptoki
+	CPPUNIT_ASSERT( C_Initialize(NULL_PTR)==CKR_OK );
+	// update slot IDs to initialized and not initialized token.
+	getSlotIDs(&m_initializedTokenSlotID, &m_notInitializedTokenSlotID);
+	// (Re)initialize the token
+	CPPUNIT_ASSERT( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label)==CKR_OK );
+	// Reset cryptoki to get new slot IDs.
+	CPPUNIT_ASSERT( C_Finalize(NULL_PTR)==CKR_OK );
+	CPPUNIT_ASSERT( C_Initialize(NULL_PTR)==CKR_OK );
+	// slot IDs must be updated since the ID of the initialized token has changed.
+	getSlotIDs(&m_initializedTokenSlotID, &m_notInitializedTokenSlotID);
+}
+
+void TestsNoPINInitBase::tearDown()
+{
+	C_Finalize(NULL_PTR);
+}

--- a/src/lib/test/TestsNoPINInitBase.h
+++ b/src/lib/test/TestsNoPINInitBase.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2010 SURFnet bv
+ * Copyright (c) 2010 .SE (The Internet Infrastructure Foundation)
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -10,7 +10,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -25,29 +25,34 @@
  */
 
 /*****************************************************************************
- p11test.cpp
+ TestsNoPINInitBase.h
 
- The main test executor for tests on the PKCS#11 interface in SoftHSM v2
+ Base class for test classes. Used when there is no need for user login.
  *****************************************************************************/
 
-#include <cppunit/extensions/TestFactoryRegistry.h>
-#include <cppunit/ui/text/TestRunner.h>
-#include <stdlib.h>
+#ifndef SRC_LIB_TEST_TESTSNOPININITBASE_H_
+#define SRC_LIB_TEST_TESTSNOPININITBASE_H_
 
-int main(int /*argc*/, char** /*argv*/)
-{
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
+#include "cryptoki.h"
+#include <cppunit/TestFixture.h>
 
-	CppUnit::TextUi::TestRunner runner;
-	CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
+class TestsNoPINInitBase : public CppUnit::TestFixture {
+public:
+	TestsNoPINInitBase();
 
-	runner.addTest(registry.makeTest());
-	bool wasSucessful = runner.run();
+	virtual void setUp();
+	virtual void tearDown();
+protected:
+	const CK_SLOT_ID m_invalidSlotID;
+	CK_SLOT_ID m_initializedTokenSlotID;
+	CK_SLOT_ID m_notInitializedTokenSlotID;
 
-	return wasSucessful ? 0 : 1;
-}
+	const CK_UTF8CHAR_PTR m_soPin1;
+	const CK_ULONG m_soPin1Length;
 
+	const CK_UTF8CHAR_PTR m_userPin1;
+	const CK_ULONG m_userPin1Length;
+};
+
+
+#endif /* SRC_LIB_TEST_TESTSNOPININITBASE_H_ */

--- a/src/lib/test/TokenTests.cpp
+++ b/src/lib/test/TokenTests.cpp
@@ -33,34 +33,13 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "TokenTests.h"
-#include "testconfig.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TokenTests);
-
-void TokenTests::setUp()
-{
-//    printf("\nTokenTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-}
-
-void TokenTests::tearDown()
-{
-	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
-}
 
 void TokenTests::testInitToken()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_UTF8CHAR label[32];
 	CK_SESSION_HANDLE hSession;
 
@@ -70,37 +49,37 @@ void TokenTests::testInitToken()
 	// Just make sure that we finalize any previous failed tests
 	C_Finalize(NULL_PTR);
 
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
+	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitToken(SLOT_INIT_TOKEN, NULL_PTR, pinLength, label);
+	rv = C_InitToken(m_initializedTokenSlotID, NULL_PTR, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_InitToken(SLOT_INVALID, pin, pinLength, label);
+	rv = C_InitToken(m_invalidSlotID, m_soPin1, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
 	// Initialize
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
+	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Initialize with wrong password
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength - 1, label);
+	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length - 1, label);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
+	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_SESSION_EXISTS);
 
 	rv = C_CloseSession(hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Re-initialize
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
+	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	C_Finalize(NULL_PTR);

--- a/src/lib/test/TokenTests.h
+++ b/src/lib/test/TokenTests.h
@@ -33,10 +33,10 @@
 #ifndef _SOFTHSM_V2_TOKENTESTS_H
 #define _SOFTHSM_V2_TOKENTESTS_H
 
+#include "TestsNoPINInitBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class TokenTests : public CppUnit::TestFixture
+class TokenTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(TokenTests);
 	CPPUNIT_TEST(testInitToken);
@@ -44,9 +44,6 @@ class TokenTests : public CppUnit::TestFixture
 
 public:
 	void testInitToken();
-
-	void setUp();
-	void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_TOKENTESTS_H

--- a/src/lib/test/UserTests.cpp
+++ b/src/lib/test/UserTests.cpp
@@ -33,86 +33,46 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include "UserTests.h"
-#include "testconfig.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(UserTests);
-
-void UserTests::setUp()
-{
-//    printf("\nUserTests\n");
-
-#ifndef _WIN32
-	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
-#else
-	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
-#endif
-
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR label[32];
-	memset(label, ' ', 32);
-	memcpy(label, "token1", strlen("token1"));
-
-	// (Re)initialize the token
-	CK_RV rv = C_Initialize(NULL_PTR);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(SLOT_INIT_TOKEN, pin, pinLength, label);
-	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
-}
-
-void UserTests::tearDown()
-{
-	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
-}
 
 void UserTests::testInitPIN()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
 	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
 	C_Finalize(NULL_PTR);
 
-	rv = C_InitPIN(hSession, pin, pinLength);
+	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitPIN(hSession, pin, pinLength);
+	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_NOT_LOGGED_IN);
 
-	rv = C_Login(hSession, CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitPIN(CK_INVALID_HANDLE, pin, pinLength);
+	rv = C_InitPIN(CK_INVALID_HANDLE, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_InitPIN(hSession, pin, 0);
+	rv = C_InitPIN(hSession, m_userPin1, 0);
 	CPPUNIT_ASSERT(rv == CKR_PIN_LEN_RANGE);
 
-	rv = C_InitPIN(hSession, pin, pinLength);
+	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
 void UserTests::testLogin()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_USER1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
-	CK_UTF8CHAR sopin[] = SLOT_0_SO1_PIN;
-	CK_ULONG sopinLength = sizeof(sopin) - 1;
 	CK_SESSION_HANDLE hSession[2];
 
 	// Just make sure that we finalize any previous tests
@@ -121,79 +81,77 @@ void UserTests::testLogin()
 	// Set up user PIN
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_Login(hSession[0], CKU_USER, pin, pinLength);
+	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_PIN_NOT_INITIALIZED);
-	rv = C_Login(hSession[0], CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitPIN(hSession[0], pin, pinLength);
+	rv = C_InitPIN(hSession[0], m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	C_Finalize(NULL_PTR);
 
-	rv = C_Login(hSession[0], CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(CK_INVALID_HANDLE, CKU_SO, sopin, sopinLength);
+	rv = C_Login(CK_INVALID_HANDLE, CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_Login(hSession[0], CKU_SO, NULL_PTR, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, NULL_PTR, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_Login(hSession[0], CKU_SO, sopin, 0);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, 0);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession[1]);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession[1]);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY_EXISTS);
 
 	rv = C_CloseSession(hSession[1]);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_USER, pin, pinLength);
+	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_ANOTHER_ALREADY_LOGGED_IN);
 
 	rv = C_Logout(hSession[0]);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, sopin, sopinLength);
+	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_ALREADY_LOGGED_IN);
 
-	rv = C_Login(hSession[0], CKU_USER, pin, pinLength);
+	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_ANOTHER_ALREADY_LOGGED_IN);
 
 	rv = C_Logout(hSession[0]);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_USER, pin, pinLength - 1);
+	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length - 1);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_Login(hSession[0], CKU_USER, pin, pinLength);
+	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_USER, pin, pinLength);
+	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_ALREADY_LOGGED_IN);
 }
 
 void UserTests::testLogout()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG pinLength = sizeof(pin) - 1;
 	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
@@ -205,10 +163,10 @@ void UserTests::testLogout()
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_SO, pin, pinLength);
+	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_Logout(CK_INVALID_HANDLE);
@@ -224,14 +182,10 @@ void UserTests::testLogout()
 void UserTests::testSetPIN()
 {
 	CK_RV rv;
-	CK_UTF8CHAR pin1[] = SLOT_0_USER1_PIN;
-	CK_ULONG pin1Length = sizeof(pin1) - 1;
-	CK_UTF8CHAR pin2[] = SLOT_0_USER2_PIN;
-	CK_ULONG pin2Length = sizeof(pin2) - 1;
-	CK_UTF8CHAR so1pin[] = SLOT_0_SO1_PIN;
-	CK_ULONG so1pinLength = sizeof(so1pin) - 1;
-	CK_UTF8CHAR so2pin[] = SLOT_0_SO2_PIN;
-	CK_ULONG so2pinLength = sizeof(so2pin) - 1;
+	const CK_UTF8CHAR_PTR pin2((CK_UTF8CHAR_PTR)"12345");
+	const CK_ULONG pin2Length(strlen((char*)pin2));
+	const CK_UTF8CHAR_PTR so2pin((CK_UTF8CHAR_PTR)"123456789");
+	const CK_ULONG so2pinLength(strlen((char*)so2pin));
 	CK_SESSION_HANDLE hSession;
 
 	// Just make sure that we finalize any previous tests
@@ -240,77 +194,77 @@ void UserTests::testSetPIN()
 	// Set up user PIN
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_Login(hSession, CKU_SO, so1pin, so1pinLength);
+	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitPIN(hSession, pin1, pin1Length);
+	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	C_Finalize(NULL_PTR);
 
-	rv = C_SetPIN(hSession, pin1, pin1Length, pin2, pin2Length);
+	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	rv = C_Initialize(NULL_PTR);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(CK_INVALID_HANDLE, pin1, pin1Length, pin2, pin2Length);
+	rv = C_SetPIN(CK_INVALID_HANDLE, m_userPin1, m_userPin1Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_SetPIN(hSession, pin1, pin1Length, pin2, pin2Length);
+	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
 
 	rv = C_CloseSession(hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(SLOT_INIT_TOKEN, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, NULL_PTR, pin1Length, pin2, pin2Length);
+	rv = C_SetPIN(hSession, NULL_PTR, m_userPin1Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_SetPIN(hSession, pin1, pin1Length, NULL_PTR, pin2Length);
+	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, NULL_PTR, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_SetPIN(hSession, pin1, pin1Length, pin2, 0);
+	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, 0);
 	CPPUNIT_ASSERT(rv == CKR_PIN_LEN_RANGE);
 
 	rv = C_SetPIN(hSession, pin2, pin2Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, pin1, pin1Length, pin2, pin2Length);
+	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_Login(hSession, CKU_USER, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, pin1, pin1Length, pin2, pin2Length);
+	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, pin2, pin2Length, pin1, pin1Length);
+	rv = C_SetPIN(hSession, pin2, pin2Length, m_userPin1, m_userPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_SO, so1pin, so1pinLength);
+	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_USER_ANOTHER_ALREADY_LOGGED_IN);
 
 	rv = C_Logout(hSession);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_SO, so1pin, so1pinLength);
+	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_SetPIN(hSession, so2pin, so2pinLength, so2pin, so2pinLength);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, so1pin, so1pinLength, so2pin, so2pinLength);
+	rv = C_SetPIN(hSession, m_soPin1, m_soPin1Length, so2pin, so2pinLength);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, so1pin, so1pinLength, so1pin, so1pinLength);
+	rv = C_SetPIN(hSession, m_soPin1, m_soPin1Length, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, so2pin, so2pinLength, so1pin, so1pinLength);
+	rv = C_SetPIN(hSession, so2pin, so2pinLength, m_soPin1, m_soPin1Length);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }

--- a/src/lib/test/UserTests.h
+++ b/src/lib/test/UserTests.h
@@ -33,10 +33,10 @@
 #ifndef _SOFTHSM_V2_USERTESTS_H
 #define _SOFTHSM_V2_USERTESTS_H
 
+#include "TestsNoPINInitBase.h"
 #include <cppunit/extensions/HelperMacros.h>
-#include "cryptoki.h"
 
-class UserTests : public CppUnit::TestFixture
+class UserTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(UserTests);
 	CPPUNIT_TEST(testInitPIN);
@@ -50,9 +50,6 @@ public:
 	void testLogin();
 	void testLogout();
 	void testSetPIN();
-
-	void setUp();
-	void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_USERTESTS_H


### PR DESCRIPTION
It would be good if a specific token always could be fetched from a slot with a specific ID.
Now the slot ID where a specific token is found is often changed after a new token is initialized.

The reason is that there are applications that are not using C_GetSlotList but are assuming that a token will always be in a slot with the same ID. Of course the best thing should be to change the application to use C_GetSlotList  and then find the slotID with serial or label. But unfortunate you don't always have the possibility to change the code. An example is the [SunPKCS11 java provider](http://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html#Config). Most java application that are using p11 tokens are using this provider.

This patch sets the slot ID to the 31 LSBs (the ID is configured as a java int that can not be negative in SunPKCS11) of the token serial. Uninitialized tokens will get slot with ID as before.

The patch is also containing #198 since I need to have it in the branch that I am testing.