### PR TITLE
Possibility to test other p11 implementation with the cppunit test.

### DIFF
--- a/src/lib/test/AsymEncryptDecryptTests.cpp
+++ b/src/lib/test/AsymEncryptDecryptTests.cpp
@@ -101,18 +101,18 @@ void AsymEncryptDecryptTests::rsaEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 		mechanism.ulParameterLen = sizeof(oaepParams);
 	}
 
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulCipherTextLen = sizeof(cipherText);
-	rv =C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen);
+	rv =CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_DecryptInit(hSession,&mechanism,hPrivateKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hPrivateKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextLen = sizeof(recoveredText);
-	rv = C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen);
+	rv = CRYPTOKI_F_PTR( C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CPPUNIT_ASSERT(memcmp(plainText, &recoveredText[ulRecoveredTextLen-sizeof(plainText)], sizeof(plainText)) == 0);
@@ -126,40 +126,40 @@ void AsymEncryptDecryptTests::rsaOAEPParams(CK_SESSION_HANDLE hSession, CK_OBJEC
 	CK_MECHANISM mechanism = { CKM_RSA_PKCS_OAEP, NULL, 0 };
 	CK_RV rv;
 
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	mechanism.pParameter = &oaepParams;
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	mechanism.ulParameterLen = sizeof(oaepParams);
 
 	oaepParams.hashAlg = CKM_AES_CBC;
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	oaepParams.hashAlg = CKM_SHA_1;
 	oaepParams.mgf = CKG_MGF1_SHA256;
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	oaepParams.mgf = CKG_MGF1_SHA1;
 	oaepParams.source = CKZ_DATA_SPECIFIED - 1;
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	oaepParams.source = CKZ_DATA_SPECIFIED;
 	oaepParams.pSourceData = &oaepParams;
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	oaepParams.ulSourceDataLen = sizeof(oaepParams);
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 
 	oaepParams.pSourceData = NULL;
-	rv = C_EncryptInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_ARGUMENTS_BAD);
 }
 
@@ -170,26 +170,26 @@ void AsymEncryptDecryptTests::testRsaEncryptDecrypt()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPublicKey = CK_INVALID_HANDLE;

--- a/src/lib/test/AsymEncryptDecryptTests.cpp
+++ b/src/lib/test/AsymEncryptDecryptTests.cpp
@@ -78,10 +78,10 @@ CK_RV AsymEncryptDecryptTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK
 
 	hPuk = CK_INVALID_HANDLE;
 	hPrk = CK_INVALID_HANDLE;
-	return C_GenerateKeyPair(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism,
 							 pukAttribs, sizeof(pukAttribs)/sizeof(CK_ATTRIBUTE),
 							 prkAttribs, sizeof(prkAttribs)/sizeof(CK_ATTRIBUTE),
-							 &hPuk, &hPrk);
+							 &hPuk, &hPrk) );
 }
 
 void AsymEncryptDecryptTests::rsaEncryptDecrypt(CK_MECHANISM_TYPE mechanismType, CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicKey, CK_OBJECT_HANDLE hPrivateKey)

--- a/src/lib/test/AsymWrapUnwrapTests.cpp
+++ b/src/lib/test/AsymWrapUnwrapTests.cpp
@@ -63,9 +63,9 @@ CK_RV AsymWrapUnwrapTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_OBJECT_
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 CK_RV AsymWrapUnwrapTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk)
@@ -99,10 +99,10 @@ CK_RV AsymWrapUnwrapTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBO
 
 	hPuk = CK_INVALID_HANDLE;
 	hPrk = CK_INVALID_HANDLE;
-	return C_GenerateKeyPair(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism,
 							 pukAttribs, sizeof(pukAttribs)/sizeof(CK_ATTRIBUTE),
 							 prkAttribs, sizeof(prkAttribs)/sizeof(CK_ATTRIBUTE),
-							 &hPuk, &hPrk);
+							 &hPuk, &hPrk) );
 }
 
 void AsymWrapUnwrapTests::rsaWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicKey, CK_OBJECT_HANDLE hPrivateKey)

--- a/src/lib/test/AsymWrapUnwrapTests.cpp
+++ b/src/lib/test/AsymWrapUnwrapTests.cpp
@@ -148,38 +148,38 @@ void AsymWrapUnwrapTests::rsaWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_SESS
 	rv = generateAesKey(hSession, symKey);
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_GetAttributeValue(hSession, symKey, valueTemplate, sizeof(valueTemplate)/sizeof(CK_ATTRIBUTE));
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, symKey, valueTemplate, sizeof(valueTemplate)/sizeof(CK_ATTRIBUTE)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulSymValueLen = valueTemplate[0].ulValueLen;
 
 	// CKM_RSA_PKCS Wrap/Unwrap support
-	rv = C_GetMechanismInfo(m_initializedTokenSlotID, CKM_RSA_PKCS, &mechInfo);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismInfo(m_initializedTokenSlotID, CKM_RSA_PKCS, &mechInfo) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(mechInfo.flags&CKF_WRAP);
 	CPPUNIT_ASSERT(mechInfo.flags&CKF_UNWRAP);
 
 	// Estimate wrapped length
-	rv = C_WrapKey(hSession, &mechanism, hPublicKey, symKey, NULL_PTR, &wrappedLenEstimation);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hPublicKey, symKey, NULL_PTR, &wrappedLenEstimation) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(wrappedLenEstimation>0);
 
 	// This should always fail because wrapped data have to be longer than 0 bytes
 	ulCipherTextLen = 0;
-	rv = C_WrapKey(hSession, &mechanism, hPublicKey, symKey, cipherText, &ulCipherTextLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hPublicKey, symKey, cipherText, &ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_BUFFER_TOO_SMALL);
 
 	// Do real wrapping
 	ulCipherTextLen = sizeof(cipherText);
-	rv = C_WrapKey(hSession, &mechanism, hPublicKey, symKey, cipherText, &ulCipherTextLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hPublicKey, symKey, cipherText, &ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	// Check length 'estimation'
 	CPPUNIT_ASSERT(wrappedLenEstimation>=ulCipherTextLen);
 
-	rv = C_UnwrapKey(hSession, &mechanism, hPrivateKey, cipherText, ulCipherTextLen, unwrapTemplate, sizeof(unwrapTemplate)/sizeof(CK_ATTRIBUTE), &unwrappedKey);
+	rv = CRYPTOKI_F_PTR( C_UnwrapKey(hSession, &mechanism, hPrivateKey, cipherText, ulCipherTextLen, unwrapTemplate, sizeof(unwrapTemplate)/sizeof(CK_ATTRIBUTE), &unwrappedKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	valueTemplate[0].pValue = &unwrappedValue;
-	rv = C_GetAttributeValue(hSession, unwrappedKey, valueTemplate, sizeof(valueTemplate)/sizeof(CK_ATTRIBUTE));
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, unwrappedKey, valueTemplate, sizeof(valueTemplate)/sizeof(CK_ATTRIBUTE)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulUnwrappedValueLen = valueTemplate[0].ulValueLen;
 
@@ -194,26 +194,26 @@ void AsymWrapUnwrapTests::testRsaWrapUnwrap()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPublicKey = CK_INVALID_HANDLE;

--- a/src/lib/test/DeriveTests.cpp
+++ b/src/lib/test/DeriveTests.cpp
@@ -86,10 +86,10 @@ CK_RV DeriveTests::generateDhKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bToken
 
 	hPuk = CK_INVALID_HANDLE;
 	hPrk = CK_INVALID_HANDLE;
-	return C_GenerateKeyPair(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism,
 			pukAttribs, sizeof(pukAttribs)/sizeof(CK_ATTRIBUTE),
 			prkAttribs, sizeof(prkAttribs)/sizeof(CK_ATTRIBUTE),
-			&hPuk, &hPrk);
+			&hPuk, &hPrk) );
 }
 
 CK_RV DeriveTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey)
@@ -107,9 +107,9 @@ CK_RV DeriveTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, C
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 #ifndef WITH_FIPS
@@ -126,9 +126,9 @@ CK_RV DeriveTests::generateDesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, C
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 #endif
 
@@ -145,9 +145,9 @@ CK_RV DeriveTests::generateDes2Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, 
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 CK_RV DeriveTests::generateDes3Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey)
@@ -163,9 +163,9 @@ CK_RV DeriveTests::generateDes3Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, 
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 void DeriveTests::dhDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicKey, CK_OBJECT_HANDLE hPrivateKey, CK_OBJECT_HANDLE &hKey)
@@ -194,9 +194,9 @@ void DeriveTests::dhDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicK
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	rv = C_DeriveKey(hSession, &mechanism, hPrivateKey,
+	rv = CRYPTOKI_F_PTR( C_DeriveKey(hSession, &mechanism, hPrivateKey,
 			 keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			 &hKey);
+			 &hKey) );
 	free(valAttrib.pValue);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
@@ -387,15 +387,15 @@ void DeriveTests::symDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey, C
 	hDerive = CK_INVALID_HANDLE;
 	if (secLen > 0)
 	{
-		rv = C_DeriveKey(hSession, &mechanism, hKey,
+		rv = CRYPTOKI_F_PTR( C_DeriveKey(hSession, &mechanism, hKey,
 				 keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-				 &hDerive);
+				 &hDerive) );
 	}
 	else
 	{
-		rv = C_DeriveKey(hSession, &mechanism, hKey,
+		rv = CRYPTOKI_F_PTR( C_DeriveKey(hSession, &mechanism, hKey,
 				 keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE) - 1,
-				 &hDerive);
+				 &hDerive) );
 	}
 	CPPUNIT_ASSERT(rv == CKR_OK);
 

--- a/src/lib/test/DeriveTests.cpp
+++ b/src/lib/test/DeriveTests.cpp
@@ -171,10 +171,10 @@ CK_RV DeriveTests::generateDes3Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, 
 void DeriveTests::dhDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicKey, CK_OBJECT_HANDLE hPrivateKey, CK_OBJECT_HANDLE &hKey)
 {
 	CK_ATTRIBUTE valAttrib = { CKA_VALUE, NULL_PTR, 0 };
-	CK_RV rv = C_GetAttributeValue(hSession, hPublicKey, &valAttrib, 1);
+	CK_RV rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hPublicKey, &valAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	valAttrib.pValue = (CK_BYTE_PTR)malloc(valAttrib.ulValueLen);
-	rv = C_GetAttributeValue(hSession, hPublicKey, &valAttrib, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hPublicKey, &valAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CK_MECHANISM mechanism = { CKM_DH_PKCS_DERIVE, NULL_PTR, 0 };
 	mechanism.pParameter = valAttrib.pValue;
@@ -213,7 +213,7 @@ bool DeriveTests::compareSecret(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKe
 	keyAttribs[0].ulValueLen = sizeof(val1);
 	keyAttribs[1].pValue = check1;
 	keyAttribs[1].ulValueLen = sizeof(check1);
-	CK_RV rv = C_GetAttributeValue(hSession, hKey1, keyAttribs, 2);
+	CK_RV rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hKey1, keyAttribs, 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(keyAttribs[0].ulValueLen == 100);
 	CPPUNIT_ASSERT(keyAttribs[1].ulValueLen == 3);
@@ -223,7 +223,7 @@ bool DeriveTests::compareSecret(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKe
 	keyAttribs[0].ulValueLen = sizeof(val2);
 	keyAttribs[1].pValue = check2;
 	keyAttribs[1].ulValueLen = sizeof(check2);
-	rv = C_GetAttributeValue(hSession, hKey2, keyAttribs, 2);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hKey2, keyAttribs, 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(keyAttribs[0].ulValueLen == 100);
 	CPPUNIT_ASSERT(keyAttribs[1].ulValueLen == 3);
@@ -238,26 +238,26 @@ void DeriveTests::testDhDerive()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Public Session keys
@@ -406,7 +406,7 @@ void DeriveTests::symDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey, C
 	CK_BYTE check[3];
 	checkAttribs[0].pValue = check;
 	checkAttribs[0].ulValueLen = sizeof(check);
-	rv = C_GetAttributeValue(hSession, hDerive, checkAttribs, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hDerive, checkAttribs, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(checkAttribs[0].ulValueLen == 3);
 
@@ -417,18 +417,18 @@ void DeriveTests::symDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey, C
 	CK_BYTE recoveredText[300];
 	CK_ULONG ulRecoveredTextLen;
 
-	rv = C_EncryptInit(hSession,&mechEncrypt,hDerive);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechEncrypt,hDerive) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulCipherTextLen = sizeof(cipherText);
-	rv = C_Encrypt(hSession,data,sizeof(data),cipherText,&ulCipherTextLen);
+	rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,data,sizeof(data),cipherText,&ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_DecryptInit(hSession,&mechEncrypt,hDerive);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechEncrypt,hDerive) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextLen = sizeof(recoveredText);
-	rv = C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen);
+	rv = CRYPTOKI_F_PTR( C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(ulRecoveredTextLen==sizeof(data));
 
@@ -442,26 +442,26 @@ void DeriveTests::testSymDerive()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Generate base key

--- a/src/lib/test/DigestTests.cpp
+++ b/src/lib/test/DigestTests.cpp
@@ -46,31 +46,31 @@ void DigestTests::testDigestInit()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestInit(hSession, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_DigestInit(CK_INVALID_HANDLE, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(CK_INVALID_HANDLE, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_MECHANISM_INVALID);
 
 	mechanism.mechanism = CKM_SHA512;
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_ACTIVE);
 }
 
@@ -86,46 +86,46 @@ void DigestTests::testDigest()
 	CK_BYTE data[] = {"Text to digest"};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Digest(CK_INVALID_HANDLE, data, sizeof(data)-1, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(CK_INVALID_HANDLE, data, sizeof(data)-1, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 	
-	rv = C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Digest(hSession, NULL_PTR, sizeof(data)-1, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, NULL_PTR, sizeof(data)-1, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	digest = (CK_BYTE_PTR)malloc(digestLen);
 	digestLen = 0;
 
-	rv = C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
-	rv = C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	free(digest);
 
-	rv = C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
 }
 
@@ -139,30 +139,30 @@ void DigestTests::testDigestUpdate()
 	CK_BYTE data[] = {"Text to digest"};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_DigestUpdate(hSession, data, sizeof(data)-1);
+	rv = CRYPTOKI_F_PTR( C_DigestUpdate(hSession, data, sizeof(data)-1) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestUpdate(CK_INVALID_HANDLE, data, sizeof(data)-1);
+	rv = CRYPTOKI_F_PTR( C_DigestUpdate(CK_INVALID_HANDLE, data, sizeof(data)-1) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 	
-	rv = C_DigestUpdate(hSession, data, sizeof(data)-1);
+	rv = CRYPTOKI_F_PTR( C_DigestUpdate(hSession, data, sizeof(data)-1) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestUpdate(hSession, NULL_PTR, sizeof(data)-1);
+	rv = CRYPTOKI_F_PTR( C_DigestUpdate(hSession, NULL_PTR, sizeof(data)-1) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_DigestUpdate(hSession, data, sizeof(data)-1);
+	rv = CRYPTOKI_F_PTR( C_DigestUpdate(hSession, data, sizeof(data)-1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -176,15 +176,15 @@ void DigestTests::testDigestKey()
 	CK_BYTE data[] = {"Text to digest"};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_DigestKey(hSession, (CK_OBJECT_HANDLE)123UL);
+	rv = CRYPTOKI_F_PTR( C_DigestKey(hSession, (CK_OBJECT_HANDLE)123UL) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create the generic secret key to digest
@@ -204,23 +204,23 @@ void DigestTests::testDigestKey()
 	CK_OBJECT_HANDLE hKey;
 
 	hKey = CK_INVALID_HANDLE;
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hKey);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(hKey != CK_INVALID_HANDLE);
 
-	rv = C_DigestKey(CK_INVALID_HANDLE, hKey);
+	rv = CRYPTOKI_F_PTR( C_DigestKey(CK_INVALID_HANDLE, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 	
-	rv = C_DigestKey(hSession, hKey);
+	rv = CRYPTOKI_F_PTR( C_DigestKey(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestKey(hSession, CK_INVALID_HANDLE);
+	rv = CRYPTOKI_F_PTR( C_DigestKey(hSession, CK_INVALID_HANDLE) );
 	CPPUNIT_ASSERT(rv == CKR_KEY_HANDLE_INVALID);
 
-	rv = C_DigestKey(hSession, hKey);
+	rv = CRYPTOKI_F_PTR( C_DigestKey(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -236,46 +236,46 @@ void DigestTests::testDigestFinal()
 	CK_BYTE_PTR digest;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_DigestFinal(hSession, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestFinal(CK_INVALID_HANDLE, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(CK_INVALID_HANDLE, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 	
-	rv = C_DigestFinal(hSession, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
 
-	rv = C_DigestInit(hSession, &mechanism);
+	rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanism) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestUpdate(hSession, data, sizeof(data)-1);
+	rv = CRYPTOKI_F_PTR( C_DigestUpdate(hSession, data, sizeof(data)-1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DigestFinal(hSession, NULL_PTR, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, NULL_PTR, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_DigestFinal(hSession, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	digest = (CK_BYTE_PTR)malloc(digestLen);
 	digestLen = 0;
 
-	rv = C_DigestFinal(hSession, digest, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
-	rv = C_DigestFinal(hSession, digest, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	free(digest);
 
-	rv = C_DigestFinal(hSession, NULL_PTR, &digestLen);
+	rv = CRYPTOKI_F_PTR( C_DigestFinal(hSession, NULL_PTR, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
 }
 
@@ -301,25 +301,25 @@ void DigestTests::testDigestAll()
 	CK_BYTE data[] = {"Text to digest"};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	for (unsigned int i = 0; i < sizeof(mechanisms)/sizeof(CK_MECHANISM); i++)
 	{
-		rv = C_DigestInit(hSession, &mechanisms[i]);
+		rv = CRYPTOKI_F_PTR( C_DigestInit(hSession, &mechanisms[i]) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 
-		rv = C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen);
+		rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, NULL_PTR, &digestLen) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 
 		digest = (CK_BYTE_PTR)malloc(digestLen);
 
-		rv = C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen);
+		rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 		free(digest);
 	}

--- a/src/lib/test/DigestTests.cpp
+++ b/src/lib/test/DigestTests.cpp
@@ -123,10 +123,10 @@ void DigestTests::testDigest()
 
 	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	free(digest);
 
 	rv = CRYPTOKI_F_PTR( C_Digest(hSession, data, sizeof(data)-1, digest, &digestLen) );
 	CPPUNIT_ASSERT(rv == CKR_OPERATION_NOT_INITIALIZED);
+	free(digest);
 }
 
 void DigestTests::testDigestUpdate()

--- a/src/lib/test/InfoTests.cpp
+++ b/src/lib/test/InfoTests.cpp
@@ -44,21 +44,21 @@ void InfoTests::testGetInfo()
 	CK_INFO ckInfo;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetInfo(&ckInfo);
+	rv = CRYPTOKI_F_PTR( C_GetInfo(&ckInfo) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetInfo(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetInfo(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetInfo(&ckInfo);
+	rv = CRYPTOKI_F_PTR( C_GetInfo(&ckInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }
 
 void InfoTests::testGetFunctionList()
@@ -66,10 +66,10 @@ void InfoTests::testGetFunctionList()
 	CK_RV rv;
 	CK_FUNCTION_LIST_PTR ckFuncList;
 
-	rv = C_GetFunctionList(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetFunctionList(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetFunctionList(&ckFuncList);
+	rv = CRYPTOKI_F_PTR( C_GetFunctionList(&ckFuncList) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -80,48 +80,48 @@ void InfoTests::testGetSlotList()
 	CK_SLOT_ID_PTR pSlotList;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetSlotList(CK_FALSE, NULL_PTR, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_FALSE, NULL_PTR, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	// Get the size of the buffer
-	rv = C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_FALSE, NULL_PTR, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	pSlotList = (CK_SLOT_ID_PTR)malloc(ulSlotCount * sizeof(CK_SLOT_ID));
 
 	// Check if we have a too small buffer
 	ulSlotCount = 0;
-	rv = C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
 	// Get the slot list
-	rv = C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_FALSE, pSlotList, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	free(pSlotList);
 
 	// Get the number of slots with tokens
-	rv = C_GetSlotList(CK_TRUE, NULL_PTR, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_TRUE, NULL_PTR, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	pSlotList = (CK_SLOT_ID_PTR)malloc(ulSlotCount * sizeof(CK_SLOT_ID));
 
 	// Check if we have a too small buffer
 	ulSlotCount = 0;
-	rv = C_GetSlotList(CK_TRUE, pSlotList, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_TRUE, pSlotList, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
 	// Get the slot list
-	rv = C_GetSlotList(CK_TRUE, pSlotList, &ulSlotCount);
+	rv = CRYPTOKI_F_PTR( C_GetSlotList(CK_TRUE, pSlotList, &ulSlotCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	free(pSlotList);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }
 
 void InfoTests::testGetSlotInfo()
@@ -130,26 +130,26 @@ void InfoTests::testGetSlotInfo()
 	CK_SLOT_INFO slotInfo;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_notInitializedTokenSlotID, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetSlotInfo(m_invalidSlotID, &slotInfo);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_invalidSlotID, &slotInfo) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT ) == CKF_TOKEN_PRESENT);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_REMOVABLE_DEVICE ) == 0);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }
 
 void InfoTests::testGetSlotInfoAlt()
@@ -158,7 +158,7 @@ void InfoTests::testGetSlotInfoAlt()
 	CK_SLOT_INFO slotInfo;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 #ifndef _WIN32
     setenv("SOFTHSM2_CONF", "./softhsm2-alt.conf", 1);
@@ -171,30 +171,30 @@ void InfoTests::testGetSlotInfoAlt()
 	memcpy(label, "token1", strlen("token1"));
 
 	// (Re)initialize the token
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_notInitializedTokenSlotID, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetSlotInfo(m_invalidSlotID, &slotInfo);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_invalidSlotID, &slotInfo) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo);
+	rv = CRYPTOKI_F_PTR( C_GetSlotInfo(m_notInitializedTokenSlotID, &slotInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_TOKEN_PRESENT ) == CKF_TOKEN_PRESENT);
 	CPPUNIT_ASSERT((slotInfo.flags & CKF_REMOVABLE_DEVICE ) == CKF_REMOVABLE_DEVICE);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 #ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
 #else
@@ -209,31 +209,31 @@ void InfoTests::testGetTokenInfo()
 	CK_TOKEN_INFO tokenInfo;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetTokenInfo(m_notInitializedTokenSlotID, &tokenInfo);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_notInitializedTokenSlotID, &tokenInfo) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetTokenInfo(m_notInitializedTokenSlotID, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_notInitializedTokenSlotID, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetTokenInfo(m_invalidSlotID, &tokenInfo);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_invalidSlotID, &tokenInfo) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetTokenInfo(m_notInitializedTokenSlotID, &tokenInfo);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_notInitializedTokenSlotID, &tokenInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == 0);
 
-	rv = C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CPPUNIT_ASSERT((tokenInfo.flags & CKF_TOKEN_INITIALIZED) == CKF_TOKEN_INITIALIZED);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }
 
 void InfoTests::testGetMechanismList()
@@ -243,36 +243,36 @@ void InfoTests::testGetMechanismList()
 	CK_MECHANISM_TYPE_PTR pMechanismList;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetMechanismList(m_invalidSlotID, NULL_PTR, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_invalidSlotID, NULL_PTR, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
 	// Get the size of the buffer
-	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	pMechanismList = (CK_MECHANISM_TYPE_PTR)malloc(ulMechCount * sizeof(CK_MECHANISM_TYPE_PTR));
 
 	// Check if we have a too small buffer
 	ulMechCount = 0;
-	rv = C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
 	// Get the mechanism list
-	rv = C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	free(pMechanismList);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }
 
 void InfoTests::testGetMechanismInfo()
@@ -283,38 +283,38 @@ void InfoTests::testGetMechanismInfo()
 	CK_MECHANISM_TYPE_PTR pMechanismList;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GetMechanismInfo(m_initializedTokenSlotID, CKM_RSA_PKCS, &info);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismInfo(m_initializedTokenSlotID, CKM_RSA_PKCS, &info) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Get the mechanism list
-	rv = C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(ulMechCount != 0);
 	pMechanismList = (CK_MECHANISM_TYPE_PTR)malloc(ulMechCount * sizeof(CK_MECHANISM_TYPE_PTR));
-	rv = C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetMechanismInfo(m_initializedTokenSlotID, pMechanismList[0], NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismInfo(m_initializedTokenSlotID, pMechanismList[0], NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GetMechanismInfo(m_invalidSlotID, pMechanismList[0], &info);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismInfo(m_invalidSlotID, pMechanismList[0], &info) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_GetMechanismInfo(m_initializedTokenSlotID, CKM_VENDOR_DEFINED, &info);
+	rv = CRYPTOKI_F_PTR( C_GetMechanismInfo(m_initializedTokenSlotID, CKM_VENDOR_DEFINED, &info) );
 	CPPUNIT_ASSERT(rv == CKR_MECHANISM_INVALID);
 
 	for (unsigned int i = 0; i < ulMechCount; i++)
 	{
-		rv = C_GetMechanismInfo(m_initializedTokenSlotID, pMechanismList[i], &info);
+		rv = CRYPTOKI_F_PTR( C_GetMechanismInfo(m_initializedTokenSlotID, pMechanismList[i], &info) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 	}
 
 	free(pMechanismList);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }

--- a/src/lib/test/InitTests.cpp
+++ b/src/lib/test/InitTests.cpp
@@ -53,7 +53,7 @@ void InitTests::setUp()
 void InitTests::tearDown()
 {
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }
 
 void InitTests::testInit1()
@@ -61,15 +61,15 @@ void InitTests::testInit1()
 	CK_RV rv;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -90,19 +90,19 @@ void InitTests::testInit2()
 	InitArgs.pReserved = (CK_VOID_PTR)1;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	InitArgs.pReserved = NULL_PTR;
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -119,19 +119,19 @@ void InitTests::testInit3()
 	InitArgs.pReserved = NULL_PTR;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	InitArgs.UnlockMutex = NULL_PTR;
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -148,20 +148,20 @@ void InitTests::testInit4()
 	InitArgs.pReserved = NULL_PTR;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	InitArgs.UnlockMutex = NULL_PTR;
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	// If rv == CKR_CANT_LOCK then we cannot use multiple threads
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -178,20 +178,20 @@ void InitTests::testInit5()
 	InitArgs.pReserved = NULL_PTR;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	InitArgs.UnlockMutex = OSUnlockMutex;
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	// If rv == CKR_CANT_LOCK then we cannot use multiple threads
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -208,20 +208,20 @@ void InitTests::testInit6()
 	InitArgs.pReserved = NULL_PTR;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	InitArgs.UnlockMutex = OSUnlockMutex;
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	// If rv == CKR_CANT_LOCK then we cannot use multiple threads
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Initialize((CK_VOID_PTR)&InitArgs);
+	rv = CRYPTOKI_F_PTR( C_Initialize((CK_VOID_PTR)&InitArgs) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -230,18 +230,18 @@ void InitTests::testFinal()
 	CK_RV rv;
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// pReserved is reserved for future versions
-	rv = C_Finalize((CK_VOID_PTR)1);
+	rv = CRYPTOKI_F_PTR( C_Finalize((CK_VOID_PTR)1) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_Finalize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }

--- a/src/lib/test/InitTests.h
+++ b/src/lib/test/InitTests.h
@@ -34,8 +34,9 @@
 #define _SOFTHSM_V2_INITTESTS_H
 
 #include <cppunit/extensions/HelperMacros.h>
+#include "TestsNoPINInitBase.h"
 
-class InitTests : public CppUnit::TestFixture
+class InitTests : public TestsNoPINInitBase
 {
 	CPPUNIT_TEST_SUITE(InitTests);
 	CPPUNIT_TEST(testInit1);
@@ -56,8 +57,8 @@ public:
 	void testInit6();
 	void testFinal();
 
-	void setUp();
-	void tearDown();
+	virtual void setUp();
+	virtual void tearDown();
 };
 
 #endif // !_SOFTHSM_V2_INITTESTS_H

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -105,7 +105,7 @@ void ObjectTests::checkCommonObjectAttributes(CK_SESSION_HANDLE hSession, CK_OBJ
 		{ CKA_CLASS, &obj_class, sizeof(obj_class) }
 	};
 
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(obj_class == objClass);
 }
@@ -127,12 +127,12 @@ void ObjectTests::checkCommonStorageObjectAttributes(CK_SESSION_HANDLE hSession,
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 5);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 5) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulLabelLen);
 	CPPUNIT_ASSERT(obj_token == bToken);
@@ -157,14 +157,14 @@ void ObjectTests::checkDataObjectAttributes(CK_SESSION_HANDLE hSession, CK_OBJEC
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 3);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 3) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 	attribs[1].pValue = (CK_VOID_PTR)malloc(attribs[1].ulValueLen);
 	attribs[2].pValue = (CK_VOID_PTR)malloc(attribs[2].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 3);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 3) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulApplicationLen);
 	CPPUNIT_ASSERT(attribs[1].ulValueLen == ulObjectIdLen);
@@ -200,12 +200,12 @@ void ObjectTests::checkCommonCertificateObjectAttributes(CK_SESSION_HANDLE hSess
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 6);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 6) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulCheckValueLen);
 	CPPUNIT_ASSERT(obj_type == certType);
@@ -243,7 +243,7 @@ void ObjectTests::checkX509CertificateObjectAttributes(CK_SESSION_HANDLE hSessio
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 8);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 8) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 	attribs[1].pValue = (CK_VOID_PTR)malloc(attribs[1].ulValueLen);
@@ -255,7 +255,7 @@ void ObjectTests::checkX509CertificateObjectAttributes(CK_SESSION_HANDLE hSessio
 	attribs[7].pValue = (CK_VOID_PTR)malloc(attribs[7].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 10);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 10) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulSubjectLen);
 	CPPUNIT_ASSERT(attribs[1].ulValueLen == ulIdLen);
@@ -317,12 +317,12 @@ void ObjectTests::checkCommonKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 7);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 7) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulIdLen);
 	CPPUNIT_ASSERT(obj_type == keyType);
@@ -362,12 +362,12 @@ void ObjectTests::checkCommonPublicKeyAttributes(CK_SESSION_HANDLE hSession, CK_
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 7);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 7) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulSubjectLen);
 	/* Default is token-specifict
@@ -415,12 +415,12 @@ void ObjectTests::checkCommonPrivateKeyAttributes(CK_SESSION_HANDLE hSession, CK
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 12);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 12) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulSubjectLen);
 	CPPUNIT_ASSERT(obj_sensitive == bSensitive);
@@ -453,13 +453,13 @@ void ObjectTests::checkCommonRSAPublicKeyAttributes(CK_SESSION_HANDLE hSession, 
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 2);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 	attribs[1].pValue = (CK_VOID_PTR)malloc(attribs[1].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 3);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 3) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulModulusLen);
 	CPPUNIT_ASSERT(attribs[1].ulValueLen == ulPublicExponentLen);
@@ -490,13 +490,13 @@ void ObjectTests::checkCommonRSAPrivateKeyAttributes(CK_SESSION_HANDLE hSession,
 	};
 
 	// Get length
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 2);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 	attribs[1].pValue = (CK_VOID_PTR)malloc(attribs[1].ulValueLen);
 
 	// Check values
-	rv = C_GetAttributeValue(hSession, hObject, &attribs[0], 2);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulModulusLen);
 	CPPUNIT_ASSERT(attribs[1].ulValueLen == ulPrivateExponentLen);
@@ -528,7 +528,7 @@ CK_RV ObjectTests::createDataObjectMinimal(CK_SESSION_HANDLE hSession, CK_BBOOL 
 	 };
 
 	hObject = CK_INVALID_HANDLE;
-	return C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject);
+	return CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject) );
 }
 
 CK_RV ObjectTests::createDataObjectNormal(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hObject)
@@ -558,7 +558,7 @@ CK_RV ObjectTests::createDataObjectNormal(CK_SESSION_HANDLE hSession, CK_BBOOL b
 	};
 
 	hObject = CK_INVALID_HANDLE;
-	return C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject);
+	return CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject) );
 }
 
 CK_RV ObjectTests::createCertificateObjectIncomplete(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hObject)
@@ -573,7 +573,7 @@ CK_RV ObjectTests::createCertificateObjectIncomplete(CK_SESSION_HANDLE hSession,
 	};
 
 	hObject = CK_INVALID_HANDLE;
-	return C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject);
+	return CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject) );
 }
 
 CK_RV ObjectTests::createCertificateObjectX509(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hObject)
@@ -597,7 +597,7 @@ CK_RV ObjectTests::createCertificateObjectX509(CK_SESSION_HANDLE hSession, CK_BB
 	};
 
 	hObject = CK_INVALID_HANDLE;
-	return C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject);
+	return CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE),&hObject) );
 }
 
 CK_RV ObjectTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk)
@@ -677,9 +677,9 @@ void ObjectTests::testCreateObject()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	/////////////////////////////////
@@ -687,13 +687,13 @@ void ObjectTests::testCreateObject()
 	/////////////////////////////////
 
 	// Open read-only session and don't login
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should be allowed to create public session objects
 	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Only public objects can be created unless the normal user is logged in
@@ -712,19 +712,19 @@ void ObjectTests::testCreateObject()
 	/////////////////////////////////
 
 	// Login USER into the read-only session
-	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// We should be allowed to create public session objects
 	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should be allowed to create private session objects
 	rv  = createDataObjectMinimal(hSession, IN_SESSION, IS_PRIVATE, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should not be allowed to create token objects.
@@ -734,7 +734,7 @@ void ObjectTests::testCreateObject()
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	/////////////////////////////////
@@ -742,13 +742,13 @@ void ObjectTests::testCreateObject()
 	/////////////////////////////////
 
 	// Open as read-write session but don't login.
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should be allowed to create public session objects
 	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// [PKCS#11 v2.3 p97] seems to indicate CKR_OK while [PKCS#11 v2.3 p126] clearly indicates CKR_USER_NOT_LOGGED_IN
@@ -758,7 +758,7 @@ void ObjectTests::testCreateObject()
 	// We should be allowed to create public token objects even when not logged in.
 	rv = createDataObjectMinimal(hSession, ON_TOKEN, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv ==  CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should not be able to create private token objects because we are not logged in now
@@ -766,7 +766,7 @@ void ObjectTests::testCreateObject()
 	CPPUNIT_ASSERT(rv == CKR_USER_NOT_LOGGED_IN);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	/////////////////////////////////
@@ -774,39 +774,39 @@ void ObjectTests::testCreateObject()
 	/////////////////////////////////
 
 	// Open as read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login to the read-write session
-	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// We should always be allowed to create public session objects
 	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should be able allowed to create private session objects because we are logged in.
 	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PRIVATE, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should be allowed to create public token objects even when not logged in.
 	rv = createDataObjectMinimal(hSession, ON_TOKEN, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// We should be able to create private token objects because we are logged in now
 	rv = createDataObjectMinimal(hSession, ON_TOKEN, IS_PRIVATE, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	/////////////////////////////////
@@ -814,17 +814,17 @@ void ObjectTests::testCreateObject()
 	/////////////////////////////////
 
 	// Open as read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login to the read-write session
-	rv = C_Login(hSession,CKU_SO,m_soPin1,m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_SO,m_soPin1,m_soPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// We should always be allowed to create public session objects
 	rv = createDataObjectMinimal(hSession, IN_SESSION, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Only public objects can be created unless the normal user is logged in.
@@ -834,7 +834,7 @@ void ObjectTests::testCreateObject()
 	// We should be allowed to create public token objects even when not logged in.
 	rv = createDataObjectMinimal(hSession, ON_TOKEN, IS_PUBLIC, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Only public objects can be created unless the normal user is logged in.
@@ -842,7 +842,7 @@ void ObjectTests::testCreateObject()
 	CPPUNIT_ASSERT(rv == CKR_USER_NOT_LOGGED_IN);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	/////////////////////////////////
@@ -850,32 +850,32 @@ void ObjectTests::testCreateObject()
 	/////////////////////////////////
 
 	// Open as read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login to the read-write session
-	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Create a secret object
-	rv = C_GenerateRandom(hSession, keyPtr, keyLen);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, keyPtr, keyLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check value
-	rv = C_GetAttributeValue(hSession, hObject, getTemplate, 3);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, getTemplate, 3) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(local == CK_FALSE);
 	CPPUNIT_ASSERT(always == CK_FALSE);
 	CPPUNIT_ASSERT(never == CK_FALSE);
 
 	// Destroy the secret object
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -889,13 +889,13 @@ void ObjectTests::testCopyObject()
 	CK_OBJECT_HANDLE hObject1;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session and don't login
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Get a public session object
@@ -913,43 +913,43 @@ void ObjectTests::testCopyObject()
 		{ CKA_PRIVATE, &bPrivate, sizeof(bPrivate) },
 		{ CKA_CLASS, &cClass, sizeof(cClass) }
 	};
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 1, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 1, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession, hObject1);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Still allowed when still session and public
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession, hObject1);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	
 	// Not allowed to overwrite an !ck8 attribute
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 4, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 4, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_READ_ONLY);
 
 	// Not allowed to go on token
 	bToken = CK_TRUE;
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1) );
 	bToken = CK_FALSE;
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
 
 	// Not allowed to go to private
 	bPrivate = CK_TRUE;
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1) );
 	bPrivate = CK_FALSE;
 	CPPUNIT_ASSERT(rv == CKR_USER_NOT_LOGGED_IN);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create a read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private object
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Get a public session object
@@ -958,16 +958,16 @@ void ObjectTests::testCopyObject()
 
 	// Allowed to go on token
 	bToken = CK_TRUE;
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession, hObject1);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Allowed to go to private
 	bPrivate = CK_TRUE;
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_DestroyObject(hSession, hObject1);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Not allowed to change a !ck8 parameter
@@ -975,21 +975,21 @@ void ObjectTests::testCopyObject()
 	attribs[3].type = CKA_OBJECT_ID;
 	attribs[3].pValue = id;
 	attribs[3].ulValueLen = sizeof(id);
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 4, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 4, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_READ_ONLY);
 
 	// Not allowed to downgrade privacy
-	rv = C_DestroyObject(hSession, hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	rv = createDataObjectNormal(hSession, IN_SESSION, IS_PRIVATE, hObject);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	bToken = CK_FALSE;
 	bPrivate = CK_FALSE;
-	rv = C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1);
+	rv = CRYPTOKI_F_PTR( C_CopyObject(hSession, hObject, &attribs[0], 3, &hObject1) );
 	CPPUNIT_ASSERT(rv == CKR_TEMPLATE_INCONSISTENT);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -1015,38 +1015,38 @@ void ObjectTests::testDestroyObject()
 	CK_OBJECT_HANDLE hObjectTokenPrivate;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Try to destroy an invalid object using an invalid session
-	rv = C_DestroyObject(hSessionRO,CK_INVALID_HANDLE);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRO,CK_INVALID_HANDLE) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
 	// Create a read-only session.
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Trying to destroy an invalid object in a read-only session
-	rv = C_DestroyObject(hSessionRO,CK_INVALID_HANDLE);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRO,CK_INVALID_HANDLE) );
 	CPPUNIT_ASSERT(rv == CKR_OBJECT_HANDLE_INVALID);
 
 	// Create a read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Trying to destroy an invalid object in a read-write session
-	rv = C_DestroyObject(hSessionRO,CK_INVALID_HANDLE);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRO,CK_INVALID_HANDLE) );
 	CPPUNIT_ASSERT(rv == CKR_OBJECT_HANDLE_INVALID);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Create all permutations of session/token, public/private objects
@@ -1060,43 +1060,43 @@ void ObjectTests::testDestroyObject()
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// On a read-only session we should not be able to destroy the public token object
-	rv = C_DestroyObject(hSessionRO,hObjectTokenPublic);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRO,hObjectTokenPublic) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
 
 	// On a read-only session we should not be able to destroy the private token object
-	rv = C_DestroyObject(hSessionRO,hObjectTokenPrivate);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRO,hObjectTokenPrivate) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
 
 	// Logout with a different session than the one used for login should be fine.
-	rv = C_Logout(hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSessionRW) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Login USER into the sessions so we can destroy private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// We should be able to destroy the public session object from a read-only session.
-	rv = C_DestroyObject(hSessionRO,hObjectSessionPublic);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRO,hObjectSessionPublic) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// All private session objects should have been destroyed when logging out.
-	rv = C_DestroyObject(hSessionRW,hObjectSessionPrivate);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRW,hObjectSessionPrivate) );
 	CPPUNIT_ASSERT(rv == CKR_OBJECT_HANDLE_INVALID);
 
 	// We should be able to destroy the public token object now.
-	rv = C_DestroyObject(hSessionRW,hObjectTokenPublic);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRW,hObjectTokenPublic) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// All handles to private token objects should have been invalidated when logging out.
-	rv = C_DestroyObject(hSessionRW,hObjectTokenPrivate);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSessionRW,hObjectTokenPrivate) );
 	CPPUNIT_ASSERT(rv == CKR_OBJECT_HANDLE_INVALID);
 
 	// Close session
-	rv = C_CloseSession(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
-	rv = C_CloseSession(hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -1107,18 +1107,18 @@ void ObjectTests::testGetObjectSize()
 	CK_OBJECT_HANDLE hObject;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open a session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Get an object
@@ -1127,12 +1127,12 @@ void ObjectTests::testGetObjectSize()
 
 	// Get the object size
 	CK_ULONG objectSize;
-	rv = C_GetObjectSize(hSession, hObject, &objectSize);
+	rv = CRYPTOKI_F_PTR( C_GetObjectSize(hSession, hObject, &objectSize) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(objectSize == CK_UNAVAILABLE_INFORMATION);
 
 	// Close session
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -1144,26 +1144,26 @@ void ObjectTests::testGetAttributeValue()
 	CK_OBJECT_HANDLE hObjectSessionPublic;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Try to destroy an invalid object using an invalid session
-	rv = C_GetAttributeValue(hSessionRO,CK_INVALID_HANDLE,NULL,1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSessionRO,CK_INVALID_HANDLE,NULL,1) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
 	// Create all permutations of session/token, public/private objects
@@ -1175,15 +1175,15 @@ void ObjectTests::testGetAttributeValue()
 		{ CKA_CLASS, &cClass, sizeof(cClass) }
 	};
 
-	rv = C_GetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1);//sizeof(attribs)/sizeof(CK_ATTRIBUTE));
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1);//sizeof(attribs)/sizeof(CK_ATTRIBUTE)) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
-	rv = C_CloseSession(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
-	rv = C_CloseSession(hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -1246,26 +1246,26 @@ void ObjectTests::testSetAttributeValue()
 	CK_OBJECT_HANDLE hObjectTokenPrivate;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Create all permutations of session/token, public/private objects
@@ -1284,39 +1284,39 @@ void ObjectTests::testSetAttributeValue()
 		{ CKA_LABEL, (CK_UTF8CHAR_PTR)pLabel, strlen(pLabel) }
 	};
 
-	rv = C_SetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_SetAttributeValue (hSessionRO,hObjectSessionPrivate,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRO,hObjectSessionPrivate,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_SetAttributeValue (hSessionRO,hObjectTokenPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRO,hObjectTokenPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
-	rv = C_SetAttributeValue (hSessionRW,hObjectTokenPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRW,hObjectTokenPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_SetAttributeValue (hSessionRO,hObjectTokenPrivate,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRO,hObjectTokenPrivate,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
-	rv = C_SetAttributeValue (hSessionRW,hObjectTokenPrivate,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRW,hObjectTokenPrivate,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	attribs[0].pValue = NULL_PTR;
-	rv = C_GetAttributeValue(hSessionRO,hObjectSessionPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSessionRO,hObjectSessionPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == strlen(pLabel));
 
 	char pStoredLabel[64];
 	attribs[0].pValue = &pStoredLabel[0];
 	attribs[0].ulValueLen = 64;
-	rv = C_GetAttributeValue(hSessionRO,hObjectSessionPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSessionRO,hObjectSessionPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == strlen(pLabel));
 	CPPUNIT_ASSERT(memcmp(pLabel,pStoredLabel,strlen(pLabel)) == 0);
 
 
 	// Close session
-	rv = C_CloseSession(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
-	rv = C_CloseSession(hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -1331,26 +1331,26 @@ void ObjectTests::testFindObjects()
 	CK_OBJECT_HANDLE hObjectTokenPrivate;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Create all permutations of session/token, public/private objects
@@ -1368,60 +1368,60 @@ void ObjectTests::testFindObjects()
 	CK_ATTRIBUTE attribs[] = {
 		{ CKA_LABEL, (CK_UTF8CHAR_PTR)pLabel, strlen(pLabel) }
 	};
-	rv = C_SetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_SetAttributeValue (hSessionRO,hObjectSessionPrivate,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRO,hObjectSessionPrivate,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_SetAttributeValue (hSessionRW,hObjectTokenPublic,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRW,hObjectTokenPublic,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_SetAttributeValue (hSessionRW,hObjectTokenPrivate,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue (hSessionRW,hObjectTokenPrivate,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Now find the objects while logged in should find them all.
-	rv = C_FindObjectsInit(hSessionRO,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsInit(hSessionRO,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CK_OBJECT_HANDLE hObjects[16];
 	CK_ULONG ulObjectCount = 0;
-	rv = C_FindObjects(hSessionRO,&hObjects[0],16,&ulObjectCount);
+	rv = CRYPTOKI_F_PTR( C_FindObjects(hSessionRO,&hObjects[0],16,&ulObjectCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(4 == ulObjectCount);
-	rv = C_FindObjectsFinal(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsFinal(hSessionRO) );
 
 
-	rv = C_Logout(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Now find the objects while no longer logged in should find only 2
-	rv = C_FindObjectsInit(hSessionRO,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsInit(hSessionRO,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_FindObjects(hSessionRO,&hObjects[0],16,&ulObjectCount);
+	rv = CRYPTOKI_F_PTR( C_FindObjects(hSessionRO,&hObjects[0],16,&ulObjectCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(2 == ulObjectCount);
-	rv = C_FindObjectsFinal(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsFinal(hSessionRO) );
 
 	// Close the session used to create the session objects, should also destroy the session objects.
-	rv = C_CloseSession(hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Now find just the public token object as public session object should be gone now.
-	rv = C_FindObjectsInit(hSessionRW,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsInit(hSessionRW,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_FindObjects(hSessionRW,&hObjects[0],16,&ulObjectCount);
+	rv = CRYPTOKI_F_PTR( C_FindObjects(hSessionRW,&hObjects[0],16,&ulObjectCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(1 == ulObjectCount);
-	rv = C_FindObjectsFinal(hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsFinal(hSessionRW) );
 
 	// Login USER into the sessions so we can gain access to private objects
-	rv = C_Login(hSessionRW,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRW,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Now find just the public token object as public session object should be gone now.
-	rv = C_FindObjectsInit(hSessionRW,&attribs[0],1);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsInit(hSessionRW,&attribs[0],1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_FindObjects(hSessionRW,&hObjects[0],16,&ulObjectCount);
+	rv = CRYPTOKI_F_PTR( C_FindObjects(hSessionRW,&hObjects[0],16,&ulObjectCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(2 == ulObjectCount);
-	rv = C_FindObjectsFinal(hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_FindObjectsFinal(hSessionRW) );
 }
 
 
@@ -1432,26 +1432,26 @@ void ObjectTests::testGenerateKeys()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPuk = CK_INVALID_HANDLE;
@@ -1501,18 +1501,18 @@ void ObjectTests::testCreateCertificates()
 	CK_SESSION_HANDLE hSession;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hObject = CK_INVALID_HANDLE;
@@ -1527,7 +1527,7 @@ void ObjectTests::testCreateCertificates()
 		{ CKA_CHECK_VALUE, pCheckValue, sizeof(pCheckValue) }
 	};
 
-	rv = C_SetAttributeValue(hSession, hObject, attribs, 1);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, attribs, 1) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_READ_ONLY);
 }
 
@@ -1544,22 +1544,22 @@ void ObjectTests::testDefaultDataAttributes()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create minimal data object
-	rv = C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check attributes in data object
@@ -1589,29 +1589,29 @@ void ObjectTests::testDefaultX509CertAttributes()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create minimal X509 certificate
-	rv = C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check attributes in X509 certificate object
 	checkCommonObjectAttributes(hSession, hObject, objClass);
 	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_FALSE, CK_TRUE, NULL_PTR, 0, CK_TRUE);
 	memset(&emptyDate, 0, sizeof(emptyDate));
-	checkCommonCertificateObjectAttributes(hSession, hObject, CKC_X_509, CK_FALSE, 0, pCheckValue, sizeof(pCheckValue), emptyDate, 0, emptyDate, 0);
+	checkCommonCertificateObjectAttributes(hSession, hObject, CKCRYPTOKI_F_PTR( C_X_509, CK_FALSE, 0, pCheckValue, sizeof(pCheckValue), emptyDate, 0, emptyDate, 0) );
 	checkX509CertificateObjectAttributes(hSession, hObject, pSubject, sizeof(pSubject)-1, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, pValue, sizeof(pValue)-1, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, 0, CKM_SHA_1);
 }
 
@@ -1641,22 +1641,22 @@ void ObjectTests::testDefaultRSAPubAttributes()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create minimal RSA public key object
-	rv = C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check attributes in RSA public key object
@@ -1705,22 +1705,22 @@ void ObjectTests::testDefaultRSAPrivAttributes()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create minimal RSA public key object
-	rv = C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check attributes in RSA public key object
@@ -1758,42 +1758,42 @@ void ObjectTests::testAlwaysNeverAttribute()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create object
-	rv = C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk);
+	rv = CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check value
-	rv = C_GetAttributeValue(hSession, hPrk, getTemplate, 2);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hPrk, getTemplate, 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(always == CK_TRUE);
 	CPPUNIT_ASSERT(never == CK_TRUE);
 
 	// Set value
-	rv = C_SetAttributeValue(hSession, hPrk, prkAttribs, 2);
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hPrk, prkAttribs, 2) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_READ_ONLY);
 
 	// Create object
 	prkAttribs[0].pValue = &bFalse;
 	prkAttribs[1].pValue = &bTrue;
-	rv = C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk);
+	rv = CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check value
-	rv = C_GetAttributeValue(hSession, hPrk, getTemplate, 2);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hPrk, getTemplate, 2) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(always == CK_FALSE);
 	CPPUNIT_ASSERT(never == CK_FALSE);
@@ -1828,40 +1828,40 @@ void ObjectTests::testSensitiveAttributes()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create object
-	rv = C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk);
+	rv = CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check value
 	for (int i = 0; i < 6; i++)
 	{
-		rv = C_GetAttributeValue(hSession, hPrk, &getTemplate[i], 1);
+		rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hPrk, &getTemplate[i], 1) );
 		CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_SENSITIVE);
 	}
 
 	// Retry with non-sensitive object
 	bSensitive = CK_FALSE;
-	rv = C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk);
+	rv = CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism, pukAttribs, 1, prkAttribs, 2, &hPuk, &hPrk) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check value
 	for (int i = 0; i < 6; i++)
 	{
-		rv = C_GetAttributeValue(hSession, hPrk, &getTemplate[i], 1);
+		rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hPrk, &getTemplate[i], 1) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 	}
 }
@@ -1883,26 +1883,26 @@ void ObjectTests::testGetInvalidAttribute()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create minimal data object
-	rv = C_CreateObject(hSession, objTemplate, 1, &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, 1, &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Check value
-	rv = C_GetAttributeValue(hSession, hObject, getTemplate, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, getTemplate, 1) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_TYPE_INVALID);
 }
 
@@ -1939,22 +1939,22 @@ void ObjectTests::testArrayAttribute()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Create minimal RSA public key object
-	rv = C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CK_ATTRIBUTE wrapAttribs[] = {
@@ -1964,13 +1964,13 @@ void ObjectTests::testArrayAttribute()
 	CK_ATTRIBUTE wrapAttrib = { CKA_WRAP_TEMPLATE, NULL_PTR, 0 };
 
 	// Get number of elements
-	rv = C_GetAttributeValue(hSession, hObject, &wrapAttrib, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &wrapAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(wrapAttrib.ulValueLen == 2 * sizeof(CK_ATTRIBUTE));
 
 	// Get element types and sizes
 	wrapAttrib.pValue = wrapAttribs;
-	rv = C_GetAttributeValue(hSession, hObject, &wrapAttrib, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &wrapAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(wrapAttrib.ulValueLen == 2 * sizeof(CK_ATTRIBUTE));
 	if (wrapAttribs[0].type == CKA_KEY_TYPE)
@@ -1990,7 +1990,7 @@ void ObjectTests::testArrayAttribute()
 	// Get values
 	wrapAttribs[0].pValue = (CK_VOID_PTR)malloc(wrapAttribs[0].ulValueLen);
 	wrapAttribs[1].pValue = (CK_VOID_PTR)malloc(wrapAttribs[1].ulValueLen);
-	rv = C_GetAttributeValue(hSession, hObject, &wrapAttrib, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &wrapAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	if (wrapAttribs[0].type == CKA_KEY_TYPE)
 	{
@@ -2016,18 +2016,18 @@ void ObjectTests::testCreateSecretKey()
 	CK_SESSION_HANDLE hSession;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_BYTE genericKey[] = {
@@ -2076,61 +2076,61 @@ void ObjectTests::testCreateSecretKey()
 		{ CKA_CHECK_VALUE, pCheckValue, sizeof(pCheckValue) }
 	};
 
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_GetAttributeValue(hSession, hObject, attribKCV, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, attribKCV, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribKCV[0].ulValueLen == 3);
 	CPPUNIT_ASSERT(memcmp(pCheckValue, genericKCV, 3) == 0);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	keyType = CKK_AES;
 	attribs[0].pValue = aesKey;
 	attribs[0].ulValueLen = sizeof(aesKey);
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_GetAttributeValue(hSession, hObject, attribKCV, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, attribKCV, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribKCV[0].ulValueLen == 3);
 	CPPUNIT_ASSERT(memcmp(pCheckValue, aesKCV, 3) == 0);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	keyType = CKK_DES;
 	attribs[0].pValue = desKey;
 	attribs[0].ulValueLen = sizeof(desKey);
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_GetAttributeValue(hSession, hObject, attribKCV, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, attribKCV, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribKCV[0].ulValueLen == 3);
 	CPPUNIT_ASSERT(memcmp(pCheckValue, desKCV, 3) == 0);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	keyType = CKK_DES2;
 	attribs[0].pValue = des2Key;
 	attribs[0].ulValueLen = sizeof(des2Key);
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_GetAttributeValue(hSession, hObject, attribKCV, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, attribKCV, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribKCV[0].ulValueLen == 3);
 	CPPUNIT_ASSERT(memcmp(pCheckValue, des2KCV, 3) == 0);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	keyType = CKK_DES3;
 	attribs[0].pValue = des3Key;
 	attribs[0].ulValueLen = sizeof(des3Key);
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_GetAttributeValue(hSession, hObject, attribKCV, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, attribKCV, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribKCV[0].ulValueLen == 3);
 	CPPUNIT_ASSERT(memcmp(pCheckValue, des3KCV, 3) == 0);
-	rv = C_DestroyObject(hSession,hObject);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession,hObject) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -631,10 +631,10 @@ CK_RV ObjectTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL bToke
 
 	hPuk = CK_INVALID_HANDLE;
 	hPrk = CK_INVALID_HANDLE;
-	return C_GenerateKeyPair(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism,
 							 pukAttribs, sizeof(pukAttribs)/sizeof(CK_ATTRIBUTE),
 							 prkAttribs, sizeof(prkAttribs)/sizeof(CK_ATTRIBUTE),
-							 &hPuk, &hPrk);
+							 &hPuk, &hPrk) );
 }
 
 void ObjectTests::testCreateObject()
@@ -1175,7 +1175,7 @@ void ObjectTests::testGetAttributeValue()
 		{ CKA_CLASS, &cClass, sizeof(cClass) }
 	};
 
-	rv = CRYPTOKI_F_PTR( C_GetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1);//sizeof(attribs)/sizeof(CK_ATTRIBUTE)) );
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue (hSessionRO,hObjectSessionPublic,&attribs[0],1) );//sizeof(attribs)/sizeof(CK_ATTRIBUTE));
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Close session
@@ -1611,7 +1611,7 @@ void ObjectTests::testDefaultX509CertAttributes()
 	checkCommonObjectAttributes(hSession, hObject, objClass);
 	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_FALSE, CK_TRUE, NULL_PTR, 0, CK_TRUE);
 	memset(&emptyDate, 0, sizeof(emptyDate));
-	checkCommonCertificateObjectAttributes(hSession, hObject, CKCRYPTOKI_F_PTR( C_X_509, CK_FALSE, 0, pCheckValue, sizeof(pCheckValue), emptyDate, 0, emptyDate, 0) );
+	checkCommonCertificateObjectAttributes(hSession, hObject, CKC_X_509, CK_FALSE, 0, pCheckValue, sizeof(pCheckValue), emptyDate, 0, emptyDate, 0);
 	checkX509CertificateObjectAttributes(hSession, hObject, pSubject, sizeof(pSubject)-1, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, pValue, sizeof(pValue)-1, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, 0, CKM_SHA_1);
 }
 

--- a/src/lib/test/README
+++ b/src/lib/test/README
@@ -1,0 +1,16 @@
+To build for test of SoftHSM with static linking:
+make p11test
+
+To build for testing another p11 module provided as shared library:
+make p11test_DEPENDENCIES= p11test_LDADD= CPPFLAGS=-DP11M=\\\"./p11m.so\\\" p11test
+Substitute ./p11m.so with the path to your shared library.
+
+To run the test with first a test summary and then specific output of each failure:
+p11test
+
+To get output of each test after it is executed:
+p11test direct
+
+To run a specific test:
+p11test ObjectTests::testArrayAttribute
+Substitute 'ObjectTests::testArrayAttribute' with the test you want to run.

--- a/src/lib/test/README
+++ b/src/lib/test/README
@@ -4,13 +4,14 @@ make p11test
 To build for testing another p11 module provided as shared library:
 make p11test_DEPENDENCIES= p11test_LDADD= CPPFLAGS=-DP11M=\\\"./p11m.so\\\" p11test
 Substitute ./p11m.so with the path to your shared library.
+Note that nothing else of SoftHSMv2 has to be built in order to build the test of an external p11.
 
 To run the test with first a test summary and then specific output of each failure:
-p11test
+./p11test
 
 To get output of each test after it is executed:
-p11test direct
+./p11test direct
 
 To run a specific test:
-p11test ObjectTests::testArrayAttribute
+./p11test ObjectTests::testArrayAttribute
 Substitute 'ObjectTests::testArrayAttribute' with the test you want to run.

--- a/src/lib/test/RandomTests.cpp
+++ b/src/lib/test/RandomTests.cpp
@@ -44,24 +44,24 @@ void RandomTests::testSeedRandom()
 	CK_BYTE seed[] = {"Some random data"};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_SeedRandom(CK_INVALID_HANDLE, seed, sizeof(seed));
+	rv = CRYPTOKI_F_PTR( C_SeedRandom(CK_INVALID_HANDLE, seed, sizeof(seed)) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SeedRandom(hSession, NULL_PTR, sizeof(seed));
+	rv = CRYPTOKI_F_PTR( C_SeedRandom(hSession, NULL_PTR, sizeof(seed)) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_SeedRandom(hSession, seed, sizeof(seed));
+	rv = CRYPTOKI_F_PTR( C_SeedRandom(hSession, seed, sizeof(seed)) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SeedRandom(hSession, seed, sizeof(seed));
+	rv = CRYPTOKI_F_PTR( C_SeedRandom(hSession, seed, sizeof(seed)) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -72,23 +72,23 @@ void RandomTests::testGenerateRandom()
 	CK_BYTE randomData[40];
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_GenerateRandom(CK_INVALID_HANDLE, randomData, 40);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(CK_INVALID_HANDLE, randomData, 40) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GenerateRandom(hSession, NULL_PTR, 40);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, NULL_PTR, 40) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_GenerateRandom(hSession, randomData, 40);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, randomData, 40) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GenerateRandom(hSession, randomData, 40);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, randomData, 40) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }

--- a/src/lib/test/SessionTests.cpp
+++ b/src/lib/test/SessionTests.cpp
@@ -44,30 +44,30 @@ void SessionTests::testOpenSession()
 	CK_SESSION_HANDLE hSession;
 
     // Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-    rv = C_Initialize(NULL_PTR);
+    rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-    rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, NULL_PTR);
+    rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-    rv = C_OpenSession(m_invalidSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+    rv = CRYPTOKI_F_PTR( C_OpenSession(m_invalidSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-    rv = C_OpenSession(m_notInitializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+    rv = CRYPTOKI_F_PTR( C_OpenSession(m_notInitializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_TOKEN_NOT_RECOGNIZED);
 
-    rv = C_OpenSession(m_initializedTokenSlotID, 0, NULL_PTR, NULL_PTR, &hSession);
+    rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, 0, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_PARALLEL_NOT_SUPPORTED);
 
-    rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+    rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-    rv = C_CloseSession(hSession);
+    rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -77,27 +77,27 @@ void SessionTests::testCloseSession()
 	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_CloseSession(CK_INVALID_HANDLE);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(CK_INVALID_HANDLE) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_CloseSession(hSession + 1);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession + 1) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 }
 
@@ -108,30 +108,30 @@ void SessionTests::testCloseAllSessions()
 	CK_SESSION_INFO info;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_CloseAllSessions(m_initializedTokenSlotID);
+	rv = CRYPTOKI_F_PTR( C_CloseAllSessions(m_initializedTokenSlotID) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_CloseAllSessions(m_invalidSlotID);
+	rv = CRYPTOKI_F_PTR( C_CloseAllSessions(m_invalidSlotID) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
-	rv = C_CloseAllSessions(m_notInitializedTokenSlotID);
+	rv = CRYPTOKI_F_PTR( C_CloseAllSessions(m_notInitializedTokenSlotID) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetSessionInfo(hSession, &info);
+	rv = CRYPTOKI_F_PTR( C_GetSessionInfo(hSession, &info) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_CloseAllSessions(m_initializedTokenSlotID);
+	rv = CRYPTOKI_F_PTR( C_CloseAllSessions(m_initializedTokenSlotID) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 }
 
@@ -142,35 +142,35 @@ void SessionTests::testGetSessionInfo()
 	CK_SESSION_INFO info;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-    rv = C_GetSessionInfo(hSession, &info);
+    rv = CRYPTOKI_F_PTR( C_GetSessionInfo(hSession, &info) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-    rv = C_Initialize(NULL_PTR);
+    rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-    rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+    rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-    rv = C_GetSessionInfo(CK_INVALID_HANDLE, &info);
+    rv = CRYPTOKI_F_PTR( C_GetSessionInfo(CK_INVALID_HANDLE, &info) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-    rv = C_GetSessionInfo(hSession + 1, &info);
+    rv = CRYPTOKI_F_PTR( C_GetSessionInfo(hSession + 1, &info) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_GetSessionInfo(hSession, NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_GetSessionInfo(hSession, NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-    rv = C_GetSessionInfo(hSession, &info);
+    rv = CRYPTOKI_F_PTR( C_GetSessionInfo(hSession, &info) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
     CPPUNIT_ASSERT(info.state == CKS_RO_PUBLIC_SESSION);
 	CPPUNIT_ASSERT(info.flags == CKF_SERIAL_SESSION);
 
-    rv = C_CloseSession(hSession);
+    rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-    rv = C_GetSessionInfo(hSession, &info);
+    rv = CRYPTOKI_F_PTR( C_GetSessionInfo(hSession, &info) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 }

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -86,10 +86,10 @@ CK_RV SignVerifyTests::generateRsaKeyPair(CK_SESSION_HANDLE hSession, CK_BBOOL b
 
 	hPuk = CK_INVALID_HANDLE;
 	hPrk = CK_INVALID_HANDLE;
-	return C_GenerateKeyPair(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism,
 							 pukAttribs, sizeof(pukAttribs)/sizeof(CK_ATTRIBUTE),
 							 prkAttribs, sizeof(prkAttribs)/sizeof(CK_ATTRIBUTE),
-							 &hPuk, &hPrk);
+							 &hPuk, &hPrk) );
 }
 
 void SignVerifyTests::rsaPkcsSignVerify(CK_MECHANISM_TYPE mechanismType, CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicKey, CK_OBJECT_HANDLE hPrivateKey)

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -100,17 +100,17 @@ void SignVerifyTests::rsaPkcsSignVerify(CK_MECHANISM_TYPE mechanismType, CK_SESS
 	CK_BYTE signature[256];
 	CK_ULONG ulSignatureLen = 0;
 
-	rv = C_SignInit(hSession,&mechanism,hPrivateKey);
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession,&mechanism,hPrivateKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulSignatureLen = sizeof(signature);
-	rv = C_Sign(hSession,data,sizeof(data),signature,&ulSignatureLen);
+	rv = CRYPTOKI_F_PTR( C_Sign(hSession,data,sizeof(data),signature,&ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_VerifyInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_Verify(hSession,data,sizeof(data),signature,ulSignatureLen);
+	rv = CRYPTOKI_F_PTR( C_Verify(hSession,data,sizeof(data),signature,ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 }
 
@@ -122,34 +122,34 @@ void SignVerifyTests::digestRsaPkcsSignVerify(CK_MECHANISM_TYPE mechanismType, C
 	CK_BYTE signature[256];
 	CK_ULONG ulSignatureLen = 0;
 
-	rv = C_SignInit(hSession,&mechanism,hPrivateKey);
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession,&mechanism,hPrivateKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv =C_SignUpdate(hSession,data,sizeof(data));
+	rv =CRYPTOKI_F_PTR( C_SignUpdate(hSession,data,sizeof(data)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulSignatureLen = sizeof(signature);
-	rv =C_SignFinal(hSession,signature,&ulSignatureLen);
+	rv =CRYPTOKI_F_PTR( C_SignFinal(hSession,signature,&ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_VerifyInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyUpdate(hSession,data,sizeof(data));
+	rv = CRYPTOKI_F_PTR( C_VerifyUpdate(hSession,data,sizeof(data)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyFinal(hSession,signature,ulSignatureLen);
+	rv = CRYPTOKI_F_PTR( C_VerifyFinal(hSession,signature,ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// verify again, but now change the input that is being signed.
-	rv = C_VerifyInit(hSession,&mechanism,hPublicKey);
+	rv = CRYPTOKI_F_PTR( C_VerifyInit(hSession,&mechanism,hPublicKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	data[0] = 0xff;
-	rv = C_VerifyUpdate(hSession,data,sizeof(data));
+	rv = CRYPTOKI_F_PTR( C_VerifyUpdate(hSession,data,sizeof(data)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyFinal(hSession,signature,ulSignatureLen);
+	rv = CRYPTOKI_F_PTR( C_VerifyFinal(hSession,signature,ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_SIGNATURE_INVALID);
 }
 
@@ -168,26 +168,26 @@ void SignVerifyTests::testRsaSignVerify()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hPuk = CK_INVALID_HANDLE;
@@ -299,17 +299,17 @@ CK_RV SignVerifyTests::generateKey(CK_SESSION_HANDLE hSession, CK_KEY_TYPE keyTy
 		{ CKA_GOST28147_PARAMS, oid, sizeof(oid) }
 	};
 
-	rv = C_GenerateRandom(hSession, val, GEN_KEY_LEN);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, val, GEN_KEY_LEN) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	hKey = CK_INVALID_HANDLE;
 	if (keyType == CKK_GOST28147)
 	{
-		return C_CreateObject(hSession, kAttribs, 9, &hKey);
+		return CRYPTOKI_F_PTR( C_CreateObject(hSession, kAttribs, 9, &hKey) );
 	}
 	else
 	{
-		return C_CreateObject(hSession, kAttribs, 8, &hKey);
+		return CRYPTOKI_F_PTR( C_CreateObject(hSession, kAttribs, 8, &hKey) );
 	}
 }
 
@@ -321,34 +321,34 @@ void SignVerifyTests::hmacSignVerify(CK_MECHANISM_TYPE mechanismType, CK_SESSION
 	CK_BYTE signature[256];
 	CK_ULONG ulSignatureLen = 0;
 
-	rv = C_SignInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv =C_SignUpdate(hSession,data,sizeof(data));
+	rv =CRYPTOKI_F_PTR( C_SignUpdate(hSession,data,sizeof(data)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulSignatureLen = sizeof(signature);
-	rv =C_SignFinal(hSession,signature,&ulSignatureLen);
+	rv =CRYPTOKI_F_PTR( C_SignFinal(hSession,signature,&ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_VerifyInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyUpdate(hSession,data,sizeof(data));
+	rv = CRYPTOKI_F_PTR( C_VerifyUpdate(hSession,data,sizeof(data)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyFinal(hSession,signature,ulSignatureLen);
+	rv = CRYPTOKI_F_PTR( C_VerifyFinal(hSession,signature,ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// verify again, but now change the input that is being signed.
-	rv = C_VerifyInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_VerifyInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	data[0] = 0xff;
-	rv = C_VerifyUpdate(hSession,data,sizeof(data));
+	rv = CRYPTOKI_F_PTR( C_VerifyUpdate(hSession,data,sizeof(data)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_VerifyFinal(hSession,signature,ulSignatureLen);
+	rv = CRYPTOKI_F_PTR( C_VerifyFinal(hSession,signature,ulSignatureLen) );
 	CPPUNIT_ASSERT(rv==CKR_SIGNATURE_INVALID);
 }
 
@@ -359,26 +359,26 @@ void SignVerifyTests::testHmacSignVerify()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Public Session keys

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -63,9 +63,9 @@ CK_RV SymmetricAlgorithmTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_BBO
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 #ifndef WITH_FIPS
@@ -82,9 +82,9 @@ CK_RV SymmetricAlgorithmTests::generateDesKey(CK_SESSION_HANDLE hSession, CK_BBO
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 CK_RV SymmetricAlgorithmTests::generateDes2Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey)
@@ -100,9 +100,9 @@ CK_RV SymmetricAlgorithmTests::generateDes2Key(CK_SESSION_HANDLE hSession, CK_BB
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 #endif
 
@@ -119,9 +119,9 @@ CK_RV SymmetricAlgorithmTests::generateDes3Key(CK_SESSION_HANDLE hSession, CK_BB
 	};
 
 	hKey = CK_INVALID_HANDLE;
-	return C_GenerateKey(hSession, &mechanism,
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-			     &hKey);
+			     &hKey) );
 }
 
 void SymmetricAlgorithmTests::aesEncryptDecrypt(CK_MECHANISM_TYPE mechanismType, CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey)
@@ -939,9 +939,9 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 		keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
-		&hKey);
+		&hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
@@ -952,9 +952,9 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 	keyAttribs[2].pValue = &bFalse;
 	keyAttribs[2].ulValueLen = sizeof(bFalse);
 
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 		keyAttribs, sizeof(keyAttribs) / sizeof(CK_ATTRIBUTE),
-		&hKey);
+		&hKey) );
 	// The call would fail with CKR_ATTRIBUTE_READ_ONLY
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
@@ -969,18 +969,18 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 		{ CKA_MODIFIABLE, &bTrue, sizeof(bTrue) }
 	};
 
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 		keyAttribs1, sizeof(keyAttribs1) / sizeof(CK_ATTRIBUTE),
-		&hKey);
+		&hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Now when CKA_MODIFIABLE is bFalse the key generation succeeds
 	keyAttribs1[2].pValue = &bFalse;
 	keyAttribs1[2].ulValueLen = sizeof(bFalse);
 
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 		keyAttribs1, sizeof(keyAttribs1) / sizeof(CK_ATTRIBUTE),
-		&hKey);
+		&hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -1021,15 +1021,15 @@ void SymmetricAlgorithmTests::testCheckValue()
 		{ CKA_CHECK_VALUE, &pCheckValue, sizeof(pCheckValue) }
 	};
 
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			   keyAttribs, 8,
-			   &hKey);
+			   &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_VALUE_INVALID);
 
 	keyAttribs[7].ulValueLen = 0;
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			   keyAttribs, 8,
-			   &hKey);
+			   &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CK_ATTRIBUTE checkAttrib[] = {
@@ -1043,9 +1043,9 @@ void SymmetricAlgorithmTests::testCheckValue()
 	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GenerateKey(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
 			   keyAttribs, 7,
-			   &hKey);
+			   &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hKey, checkAttrib, 1) );

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -141,20 +141,20 @@ void SymmetricAlgorithmTests::aesEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	CK_ULONG ulRecoveredTextMultiPartLen;
 	CK_RV rv;
 
-	rv = C_GenerateRandom(hSession, plainText, sizeof(plainText));
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, plainText, sizeof(plainText)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	if (mechanismType == CKM_AES_CBC ||
 	    mechanismType == CKM_AES_CBC_PAD)
 	{
-		rv = C_GenerateRandom(hSession, iv, sizeof(iv));
+		rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, iv, sizeof(iv)) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 		mechanism.pParameter = iv;
 		mechanism.ulParameterLen = sizeof(iv);
 	}
 
 	// Single-part encryption
-	rv = C_EncryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid plain text size
@@ -162,14 +162,14 @@ void SymmetricAlgorithmTests::aesEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	    mechanismType == CKM_AES_CBC)
 	{
 		ulCipherTextLen = sizeof(cipherText);
-		rv = C_Encrypt(hSession,plainText,sizeof(plainText)-1,cipherText,&ulCipherTextLen);
+		rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText)-1,cipherText,&ulCipherTextLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_EncryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulCipherTextLen = sizeof(cipherText);
-	rv = C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen);
+	rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	if (mechanismType == CKM_AES_CBC_PAD)
 	{
@@ -181,7 +181,7 @@ void SymmetricAlgorithmTests::aesEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	}
 
 	// Multi-part encryption
-	rv = C_EncryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid plain text size
@@ -189,41 +189,41 @@ void SymmetricAlgorithmTests::aesEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	    mechanismType == CKM_AES_CBC)
 	{
 		ulCipherTextMultiLen = sizeof(cipherTextMulti);
-		rv = C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2-1,cipherTextMulti,&ulCipherTextMultiLen);
+		rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2-1,cipherTextMulti,&ulCipherTextMultiLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_EncryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulCipherTextMultiLen = sizeof(cipherTextMulti);
-	rv = C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2,cipherTextMulti,&ulCipherTextMultiLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2,cipherTextMulti,&ulCipherTextMultiLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulCipherTextMultiPartLen = sizeof(cipherTextMulti) - ulCipherTextMultiLen;
-	rv = C_EncryptUpdate(hSession,plainText+sizeof(plainText)/2,sizeof(plainText)/2,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText+sizeof(plainText)/2,sizeof(plainText)/2,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulCipherTextMultiLen += ulCipherTextMultiPartLen;
 
 	ulCipherTextMultiPartLen = sizeof(cipherTextMulti) - ulCipherTextMultiLen;
-	rv = C_EncryptFinal(hSession,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptFinal(hSession,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulCipherTextMultiLen += ulCipherTextMultiPartLen;
 	CPPUNIT_ASSERT(ulCipherTextLen==ulCipherTextMultiLen);
 	CPPUNIT_ASSERT(memcmp(cipherText, cipherTextMulti, ulCipherTextLen) == 0);
 
 	// Single-part decryption
-	rv = C_DecryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextLen = sizeof(recoveredText);
-	rv = C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen);
+	rv = CRYPTOKI_F_PTR( C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(ulRecoveredTextLen==sizeof(plainText));
 
 	CPPUNIT_ASSERT(memcmp(plainText, recoveredText, sizeof(plainText)) == 0);
 
 	// Multi-part decryption
-	rv = C_DecryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid cipher text size
@@ -231,23 +231,23 @@ void SymmetricAlgorithmTests::aesEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	    mechanismType == CKM_AES_CBC)
 	{
 		ulRecoveredTextMultiLen = sizeof(recoveredTextMulti);
-		rv = C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2-1,recoveredTextMulti,&ulRecoveredTextMultiLen);
+		rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2-1,recoveredTextMulti,&ulRecoveredTextMultiLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_DecryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulRecoveredTextMultiLen = sizeof(recoveredTextMulti);
-	rv = C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2,recoveredTextMulti,&ulRecoveredTextMultiLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2,recoveredTextMulti,&ulRecoveredTextMultiLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextMultiPartLen = sizeof(recoveredTextMulti) - ulRecoveredTextMultiLen;
-	rv = C_DecryptUpdate(hSession,cipherText+ulCipherTextLen/2,ulCipherTextLen/2,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText+ulCipherTextLen/2,ulCipherTextLen/2,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulRecoveredTextMultiLen += ulRecoveredTextMultiPartLen;
 
 	ulRecoveredTextMultiPartLen = sizeof(recoveredTextMulti) - ulRecoveredTextMultiLen;
-	rv = C_DecryptFinal(hSession,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptFinal(hSession,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulRecoveredTextMultiLen += ulRecoveredTextMultiPartLen;
 	CPPUNIT_ASSERT(ulRecoveredTextLen==ulRecoveredTextMultiLen);
@@ -272,20 +272,20 @@ void SymmetricAlgorithmTests::desEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	CK_ULONG ulRecoveredTextMultiPartLen;
 	CK_RV rv;
 
-	rv = C_GenerateRandom(hSession, plainText, sizeof(plainText));
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, plainText, sizeof(plainText)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	if (mechanismType == CKM_DES_CBC ||
 	    mechanismType == CKM_DES_CBC_PAD)
 	{
-		rv = C_GenerateRandom(hSession, iv, sizeof(iv));
+		rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, iv, sizeof(iv)) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 		mechanism.pParameter = iv;
 		mechanism.ulParameterLen = sizeof(iv);
 	}
 
 	// Single-part encryption
-	rv = C_EncryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid plain text size
@@ -293,14 +293,14 @@ void SymmetricAlgorithmTests::desEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	    mechanismType == CKM_DES_CBC)
 	{
 		ulCipherTextLen = sizeof(cipherText);
-		rv = C_Encrypt(hSession,plainText,sizeof(plainText)-1,cipherText,&ulCipherTextLen);
+		rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText)-1,cipherText,&ulCipherTextLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_EncryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulCipherTextLen = sizeof(cipherText);
-	rv = C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen);
+	rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	if (mechanismType == CKM_DES_CBC_PAD)
 	{
@@ -312,7 +312,7 @@ void SymmetricAlgorithmTests::desEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	}
 
 	// Multi-part encryption
-	rv = C_EncryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid plain text size
@@ -320,41 +320,41 @@ void SymmetricAlgorithmTests::desEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	    mechanismType == CKM_DES_CBC)
 	{
 		ulCipherTextMultiLen = sizeof(cipherTextMulti);
-		rv = C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2-1,cipherTextMulti,&ulCipherTextMultiLen);
+		rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2-1,cipherTextMulti,&ulCipherTextMultiLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_EncryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulCipherTextMultiLen = sizeof(cipherTextMulti);
-	rv = C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2,cipherTextMulti,&ulCipherTextMultiLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2,cipherTextMulti,&ulCipherTextMultiLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulCipherTextMultiPartLen = sizeof(cipherTextMulti) - ulCipherTextMultiLen;
-	rv = C_EncryptUpdate(hSession,plainText+sizeof(plainText)/2,sizeof(plainText)/2,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText+sizeof(plainText)/2,sizeof(plainText)/2,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulCipherTextMultiLen += ulCipherTextMultiPartLen;
 
 	ulCipherTextMultiPartLen = sizeof(cipherTextMulti) - ulCipherTextMultiLen;
-	rv = C_EncryptFinal(hSession,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptFinal(hSession,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulCipherTextMultiLen += ulCipherTextMultiPartLen;
 	CPPUNIT_ASSERT(ulCipherTextLen==ulCipherTextMultiLen);
 	CPPUNIT_ASSERT(memcmp(cipherText, cipherTextMulti, ulCipherTextLen) == 0);
 
 	// Single-part decryption
-	rv = C_DecryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextLen = sizeof(recoveredText);
-	rv = C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen);
+	rv = CRYPTOKI_F_PTR( C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(ulRecoveredTextLen==sizeof(plainText));
 
 	CPPUNIT_ASSERT(memcmp(plainText, recoveredText, sizeof(plainText)) == 0);
 
 	// Multi-part decryption
-	rv = C_DecryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid cipher text size
@@ -362,23 +362,23 @@ void SymmetricAlgorithmTests::desEncryptDecrypt(CK_MECHANISM_TYPE mechanismType,
 	    mechanismType == CKM_DES_CBC)
 	{
 		ulRecoveredTextMultiLen = sizeof(recoveredTextMulti);
-		rv = C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2-1,recoveredTextMulti,&ulRecoveredTextMultiLen);
+		rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2-1,recoveredTextMulti,&ulRecoveredTextMultiLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_DecryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulRecoveredTextMultiLen = sizeof(recoveredTextMulti);
-	rv = C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2,recoveredTextMulti,&ulRecoveredTextMultiLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2,recoveredTextMulti,&ulRecoveredTextMultiLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextMultiPartLen = sizeof(recoveredTextMulti) - ulRecoveredTextMultiLen;
-	rv = C_DecryptUpdate(hSession,cipherText+ulCipherTextLen/2,ulCipherTextLen/2,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText+ulCipherTextLen/2,ulCipherTextLen/2,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulRecoveredTextMultiLen += ulRecoveredTextMultiPartLen;
 
 	ulRecoveredTextMultiPartLen = sizeof(recoveredTextMulti) - ulRecoveredTextMultiLen;
-	rv = C_DecryptFinal(hSession,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptFinal(hSession,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulRecoveredTextMultiLen += ulRecoveredTextMultiPartLen;
 	CPPUNIT_ASSERT(ulRecoveredTextLen==ulRecoveredTextMultiLen);
@@ -403,20 +403,20 @@ void SymmetricAlgorithmTests::des3EncryptDecrypt(CK_MECHANISM_TYPE mechanismType
 	CK_ULONG ulRecoveredTextMultiPartLen;
 	CK_RV rv;
 
-	rv = C_GenerateRandom(hSession, plainText, sizeof(plainText));
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, plainText, sizeof(plainText)) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	if (mechanismType == CKM_DES3_CBC ||
 	    mechanismType == CKM_DES3_CBC_PAD)
 	{
-		rv = C_GenerateRandom(hSession, iv, sizeof(iv));
+		rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, iv, sizeof(iv)) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 		mechanism.pParameter = iv;
 		mechanism.ulParameterLen = sizeof(iv);
 	}
 
 	// Single-part encryption
-	rv = C_EncryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid plain text size
@@ -424,14 +424,14 @@ void SymmetricAlgorithmTests::des3EncryptDecrypt(CK_MECHANISM_TYPE mechanismType
 	    mechanismType == CKM_DES3_CBC)
 	{
 		ulCipherTextLen = sizeof(cipherText);
-		rv = C_Encrypt(hSession,plainText,sizeof(plainText)-1,cipherText,&ulCipherTextLen);
+		rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText)-1,cipherText,&ulCipherTextLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_EncryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulCipherTextLen = sizeof(cipherText);
-	rv = C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen);
+	rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText),cipherText,&ulCipherTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	if (mechanismType == CKM_DES3_CBC_PAD)
 	{
@@ -443,7 +443,7 @@ void SymmetricAlgorithmTests::des3EncryptDecrypt(CK_MECHANISM_TYPE mechanismType
 	}
 
 	// Multi-part encryption
-	rv = C_EncryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid plain text size
@@ -451,41 +451,41 @@ void SymmetricAlgorithmTests::des3EncryptDecrypt(CK_MECHANISM_TYPE mechanismType
 	    mechanismType == CKM_DES3_CBC)
 	{
 		ulCipherTextMultiLen = sizeof(cipherTextMulti);
-		rv = C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2-1,cipherTextMulti,&ulCipherTextMultiLen);
+		rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2-1,cipherTextMulti,&ulCipherTextMultiLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_EncryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulCipherTextMultiLen = sizeof(cipherTextMulti);
-	rv = C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2,cipherTextMulti,&ulCipherTextMultiLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)/2,cipherTextMulti,&ulCipherTextMultiLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulCipherTextMultiPartLen = sizeof(cipherTextMulti) - ulCipherTextMultiLen;
-	rv = C_EncryptUpdate(hSession,plainText+sizeof(plainText)/2,sizeof(plainText)/2,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText+sizeof(plainText)/2,sizeof(plainText)/2,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulCipherTextMultiLen += ulCipherTextMultiPartLen;
 
 	ulCipherTextMultiPartLen = sizeof(cipherTextMulti) - ulCipherTextMultiLen;
-	rv = C_EncryptFinal(hSession,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptFinal(hSession,cipherTextMulti+ulCipherTextMultiLen,&ulCipherTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulCipherTextMultiLen += ulCipherTextMultiPartLen;
 	CPPUNIT_ASSERT(ulCipherTextLen==ulCipherTextMultiLen);
 	CPPUNIT_ASSERT(memcmp(cipherText, cipherTextMulti, ulCipherTextLen) == 0);
 
 	// Single-part decryption
-	rv = C_DecryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextLen = sizeof(recoveredText);
-	rv = C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen);
+	rv = CRYPTOKI_F_PTR( C_Decrypt(hSession,cipherText,ulCipherTextLen,recoveredText,&ulRecoveredTextLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	CPPUNIT_ASSERT(ulRecoveredTextLen==sizeof(plainText));
 
 	CPPUNIT_ASSERT(memcmp(plainText, recoveredText, sizeof(plainText)) == 0);
 
 	// Multi-part decryption
-	rv = C_DecryptInit(hSession,&mechanism,hKey);
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	// Test invalid cipher text size
@@ -493,23 +493,23 @@ void SymmetricAlgorithmTests::des3EncryptDecrypt(CK_MECHANISM_TYPE mechanismType
 	    mechanismType == CKM_DES3_CBC)
 	{
 		ulRecoveredTextMultiLen = sizeof(recoveredTextMulti);
-		rv = C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2-1,recoveredTextMulti,&ulRecoveredTextMultiLen);
+		rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2-1,recoveredTextMulti,&ulRecoveredTextMultiLen) );
 		CPPUNIT_ASSERT(rv==CKR_DATA_LEN_RANGE);
-		rv = C_DecryptInit(hSession,&mechanism,hKey);
+		rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
 		CPPUNIT_ASSERT(rv==CKR_OK);
 	}
 
 	ulRecoveredTextMultiLen = sizeof(recoveredTextMulti);
-	rv = C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2,recoveredTextMulti,&ulRecoveredTextMultiLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText,ulCipherTextLen/2,recoveredTextMulti,&ulRecoveredTextMultiLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	ulRecoveredTextMultiPartLen = sizeof(recoveredTextMulti) - ulRecoveredTextMultiLen;
-	rv = C_DecryptUpdate(hSession,cipherText+ulCipherTextLen/2,ulCipherTextLen/2,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,cipherText+ulCipherTextLen/2,ulCipherTextLen/2,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulRecoveredTextMultiLen += ulRecoveredTextMultiPartLen;
 
 	ulRecoveredTextMultiPartLen = sizeof(recoveredTextMulti) - ulRecoveredTextMultiLen;
-	rv = C_DecryptFinal(hSession,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptFinal(hSession,recoveredTextMulti+ulRecoveredTextMultiLen,&ulRecoveredTextMultiPartLen) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 	ulRecoveredTextMultiLen += ulRecoveredTextMultiPartLen;
 	CPPUNIT_ASSERT(ulRecoveredTextLen==ulRecoveredTextMultiLen);
@@ -557,7 +557,7 @@ CK_RV SymmetricAlgorithmTests::generateRsaPrivateKey(CK_SESSION_HANDLE hSession,
 			       &hPub, &hKey);
 	if (hPub != CK_INVALID_HANDLE)
 	{
-		C_DestroyObject(hSession, hPub);
+		CRYPTOKI_F_PTR( C_DestroyObject(hSession, hPub) );
 	}
 	return rv;
 }
@@ -585,11 +585,11 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 	CK_OBJECT_HANDLE hSecret;
 	CK_RV rv;
 
-	rv = C_GenerateRandom(hSession, keyPtr, keyLen);
+	rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, keyPtr, keyLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	hSecret = CK_INVALID_HANDLE;
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hSecret);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hSecret) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(hSecret != CK_INVALID_HANDLE);
 
@@ -599,32 +599,32 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 	CK_ULONG rndKeyLen = keyLen;
 	if (mechanismType == CKM_AES_KEY_WRAP_PAD)
 		rndKeyLen =  (keyLen + 7) & ~7;
-	rv = C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &wrappedLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &wrappedLen) );
 	CPPUNIT_ASSERT(rv == CKR_KEY_UNEXTRACTABLE);
-	rv = C_DestroyObject(hSession, hSecret);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hSecret) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	attribs[0].pValue = &bTrue;
 
 	hSecret = CK_INVALID_HANDLE;
-	rv = C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hSecret);
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hSecret) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(hSecret != CK_INVALID_HANDLE);
 
 	// Estimate wrapped length
-	rv = C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &wrappedLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &wrappedLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(wrappedLen == rndKeyLen + 8);
 
 	wrappedPtr = (CK_BYTE_PTR) malloc(wrappedLen);
 	CPPUNIT_ASSERT(wrappedPtr != NULL_PTR);
-	rv = C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &wrappedLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &wrappedLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(wrappedLen == rndKeyLen + 8);
 
 	// This should always fail because wrapped data have to be longer than 0 bytes
 	zero = 0;
-	rv = C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &zero);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hKey, hSecret, wrappedPtr, &zero) );
 	CPPUNIT_ASSERT(rv == CKR_BUFFER_TOO_SMALL);
 
 	CK_ATTRIBUTE nattribs[] = {
@@ -640,13 +640,13 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 	CK_OBJECT_HANDLE hNew;
 
 	hNew = CK_INVALID_HANDLE;
-	rv = C_UnwrapKey(hSession, &mechanism, hKey, wrappedPtr, wrappedLen, nattribs, sizeof(nattribs)/sizeof(CK_ATTRIBUTE), &hNew);
+	rv = CRYPTOKI_F_PTR( C_UnwrapKey(hSession, &mechanism, hKey, wrappedPtr, wrappedLen, nattribs, sizeof(nattribs)/sizeof(CK_ATTRIBUTE), &hNew) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(hNew != CK_INVALID_HANDLE);
 
 	free(wrappedPtr);
 	wrappedPtr = NULL_PTR;
-	rv = C_DestroyObject(hSession, hSecret);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hSecret) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 #ifdef HAVE_AES_KEY_WRAP_PAD
@@ -668,7 +668,7 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 		{ CKA_PRIME_2, NULL_PTR, 0UL }
 	};
 
-	rv = C_GetAttributeValue(hSession, hRsa, rsaAttribs, sizeof(rsaAttribs)/sizeof(CK_ATTRIBUTE));
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hRsa, rsaAttribs, sizeof(rsaAttribs)/sizeof(CK_ATTRIBUTE)) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CPPUNIT_ASSERT(rsaAttribs[0].ulValueLen == sizeof(CK_OBJECT_CLASS));
@@ -682,18 +682,18 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 	rsaAttribs[2].pValue = p2Ptr;
 	rsaAttribs[2].ulValueLen = p2Len;
 
-	rv = C_GetAttributeValue(hSession, hRsa, rsaAttribs, sizeof(rsaAttribs)/sizeof(CK_ATTRIBUTE));
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hRsa, rsaAttribs, sizeof(rsaAttribs)/sizeof(CK_ATTRIBUTE)) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(rsaAttribs[2].ulValueLen == p2Len);
 
-	rv = C_WrapKey(hSession, &mechanism, hKey, hRsa, wrappedPtr, &wrappedLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hKey, hRsa, wrappedPtr, &wrappedLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	wrappedPtr = (CK_BYTE_PTR) malloc(wrappedLen);
 	CPPUNIT_ASSERT(wrappedPtr != NULL_PTR);
-	rv = C_WrapKey(hSession, &mechanism, hKey, hRsa, wrappedPtr, &wrappedLen);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &mechanism, hKey, hRsa, wrappedPtr, &wrappedLen) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DestroyObject(hSession, hRsa);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hRsa) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CK_ATTRIBUTE nRsaAttribs[] = {
@@ -709,12 +709,12 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 	};
 
 	hRsa = CK_INVALID_HANDLE;
-	rv = C_UnwrapKey(hSession, &mechanism, hKey, wrappedPtr, wrappedLen, nRsaAttribs, sizeof(nRsaAttribs)/sizeof(CK_ATTRIBUTE), &hRsa);
+	rv = CRYPTOKI_F_PTR( C_UnwrapKey(hSession, &mechanism, hKey, wrappedPtr, wrappedLen, nRsaAttribs, sizeof(nRsaAttribs)/sizeof(CK_ATTRIBUTE), &hRsa) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(hRsa != CK_INVALID_HANDLE);
 
 	rsaAttribs[2].pValue = p2Ptr + p2Len;
-	rv = C_GetAttributeValue(hSession, hRsa, rsaAttribs, sizeof(rsaAttribs)/sizeof(CK_ATTRIBUTE));
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hRsa, rsaAttribs, sizeof(rsaAttribs)/sizeof(CK_ATTRIBUTE)) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	CPPUNIT_ASSERT(rsaAttribs[0].ulValueLen == sizeof(CK_OBJECT_CLASS));
@@ -726,7 +726,7 @@ void SymmetricAlgorithmTests::aesWrapUnwrap(CK_MECHANISM_TYPE mechanismType, CK_
 
 	free(wrappedPtr);
 	free(p2Ptr);
-	rv = C_DestroyObject(hSession, hRsa);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hRsa) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 #endif
 }
@@ -740,26 +740,26 @@ void SymmetricAlgorithmTests::testAesEncryptDecrypt()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
@@ -781,18 +781,18 @@ void SymmetricAlgorithmTests::testAesWrapUnwrap()
 	CK_SESSION_HANDLE hSession;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the session so we can create a private object
-	rv = C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
@@ -816,26 +816,26 @@ void SymmetricAlgorithmTests::testDesEncryptDecrypt()
 	CK_SESSION_HANDLE hSessionRW;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Open read-only session on when the token is not initialized should fail
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-only session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSessionRW) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 #ifndef WITH_FIPS
@@ -880,27 +880,27 @@ void SymmetricAlgorithmTests::testNullTemplate()
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
-	rv = C_GenerateKey(hSession, &mechanism1, NULL_PTR, 0, &hKey);
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism1, NULL_PTR, 0, &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DestroyObject(hSession, hKey);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GenerateKey(hSession, &mechanism2, NULL_PTR, 0, &hKey);
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism2, NULL_PTR, 0, &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_TEMPLATE_INCOMPLETE);
 }
 
@@ -925,18 +925,18 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 	};
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	rv = C_GenerateKey(hSession, &mechanism,
@@ -944,7 +944,7 @@ void SymmetricAlgorithmTests::testNonModifiableDesKeyGeneration()
 		&hKey);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_DestroyObject(hSession, hKey);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// The C_GenerateKey call failed if CKA_MODIFIABLE was bFalse
@@ -992,18 +992,18 @@ void SymmetricAlgorithmTests::testCheckValue()
 	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Initialize the library and start the test.
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Open read-write session
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Login USER into the sessions so we can create a private objects
-	rv = C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv==CKR_OK);
 
 	CK_ULONG bytes = 16;
@@ -1036,11 +1036,11 @@ void SymmetricAlgorithmTests::testCheckValue()
 		{ CKA_CHECK_VALUE, &pCheckValue, sizeof(pCheckValue) }
 	};
 
-	rv = C_GetAttributeValue(hSession, hKey, checkAttrib, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hKey, checkAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(checkAttrib[0].ulValueLen == 0);
 
-	rv = C_DestroyObject(hSession, hKey);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	rv = C_GenerateKey(hSession, &mechanism,
@@ -1048,10 +1048,10 @@ void SymmetricAlgorithmTests::testCheckValue()
 			   &hKey);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_GetAttributeValue(hSession, hKey, checkAttrib, 1);
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hKey, checkAttrib, 1) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(checkAttrib[0].ulValueLen == 3);
 
-	rv = C_DestroyObject(hSession, hKey);
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -551,10 +551,10 @@ CK_RV SymmetricAlgorithmTests::generateRsaPrivateKey(CK_SESSION_HANDLE hSession,
 	CK_OBJECT_HANDLE hPub = CK_INVALID_HANDLE;
 	hKey = CK_INVALID_HANDLE;
 	CK_RV rv;
-	rv = C_GenerateKeyPair(hSession, &mechanism,
+	rv = CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &mechanism,
 			       pubAttribs, sizeof(pubAttribs)/sizeof(CK_ATTRIBUTE),
 			       privAttribs, sizeof(privAttribs)/sizeof(CK_ATTRIBUTE),
-			       &hPub, &hKey);
+			       &hPub, &hKey) );
 	if (hPub != CK_INVALID_HANDLE)
 	{
 		CRYPTOKI_F_PTR( C_DestroyObject(hSession, hPub) );

--- a/src/lib/test/TestsBase.cpp
+++ b/src/lib/test/TestsBase.cpp
@@ -39,11 +39,11 @@ void TestsBase::setUp() {
 	CK_SESSION_HANDLE hSession;
 
 	// Open session
-	CPPUNIT_ASSERT( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION|CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession)==CKR_OK );
+	CPPUNIT_ASSERT( CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION|CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession)==CKR_OK ) );
 
 	// Login SO
-	CPPUNIT_ASSERT( C_Login(hSession,CKU_SO, m_soPin1, m_soPin1Length)==CKR_OK );
+	CPPUNIT_ASSERT( CRYPTOKI_F_PTR( C_Login(hSession,CKU_SO, m_soPin1, m_soPin1Length)==CKR_OK ) );
 
 	// Initialize the user pin
-	CPPUNIT_ASSERT( C_InitPIN(hSession, m_userPin1, m_userPin1Length)==CKR_OK );
+	CPPUNIT_ASSERT( CRYPTOKI_F_PTR( C_InitPIN(hSession, m_userPin1, m_userPin1Length)==CKR_OK ) );
 }

--- a/src/lib/test/TestsNoPINInitBase.cpp
+++ b/src/lib/test/TestsNoPINInitBase.cpp
@@ -36,13 +36,14 @@
 #include <vector>
 #include <sstream>
 
+#ifdef P11M
 #ifdef _WIN32
 CK_FUNCTION_LIST_PTR FunctionList::getFunctionListPtr(const char*const libName,  HINSTANCE__* p11Library, const char*getFunctionList) {
 #else
 #include <dlfcn.h>
 
 static CK_FUNCTION_LIST_PTR getFunctionListPtr(const char*const libName, void *const p11Library, const char*getFunctionList) {
-#endif
+#endif //_WIN32
 	CPPUNIT_ASSERT_MESSAGE(libName, p11Library);
 #ifdef _WIN32
 	const CK_C_GetFunctionList pGFL( (CK_C_GetFunctionList)GetProcAddress(
@@ -54,7 +55,7 @@ static CK_FUNCTION_LIST_PTR getFunctionListPtr(const char*const libName, void *c
 			p11Library,
 			getFunctionList
 	) );
-#endif
+#endif //_WIN32
 	CPPUNIT_ASSERT_MESSAGE(libName, pGFL);
 	CK_FUNCTION_LIST_PTR ptr(NULL_PTR);
 	const CK_RV retCode( pGFL(&ptr) );
@@ -65,6 +66,7 @@ static CK_FUNCTION_LIST_PTR getFunctionListPtr(const char*const libName, void *c
 	}
 	return ptr;
 }
+#endif //P11M
 void TestsNoPINInitBase::getSlotIDs() {
 	bool hasFoundFree(false);
 	bool hasFoundInitialized(false);
@@ -137,6 +139,7 @@ void TestsNoPINInitBase::tearDown() {
 	CPPUNIT_ASSERT_MESSAGE(oss.str(), false);
 }
 
+#ifdef P11M
 TestsNoPINInitBase::~TestsNoPINInitBase() {
 	if ( !p11Library ) {
 		return;
@@ -145,12 +148,13 @@ TestsNoPINInitBase::~TestsNoPINInitBase() {
 	FreeLibrary(p11Library);
 #else
 	dlclose(p11Library);
-#endif
+#endif // _WIN32
 }
 
-#ifdef P11M
 void softHSMLog(const int, const char*, const char*, const int, const char*, ...)
 {
 
 }
-#endif
+#else
+TestsNoPINInitBase::~TestsNoPINInitBase() {}
+#endif // P11M

--- a/src/lib/test/TestsNoPINInitBase.cpp
+++ b/src/lib/test/TestsNoPINInitBase.cpp
@@ -101,7 +101,7 @@ TestsNoPINInitBase::TestsNoPINInitBase() :
 #endif
 		m_ptr(getFunctionListPtr(P11M, p11Library, "C_GetFunctionList")),
 #endif
-		m_invalidSlotID(-1),
+		m_invalidSlotID(((CK_SLOT_ID)1<<40)-1),
 		m_initializedTokenSlotID(m_invalidSlotID),
 		m_notInitializedTokenSlotID(m_invalidSlotID),
 		m_soPin1((CK_UTF8CHAR_PTR)"12345678"),
@@ -149,7 +149,7 @@ TestsNoPINInitBase::~TestsNoPINInitBase() {
 }
 
 #ifdef P11M
-void softHSMLog(const int loglevel, const char* functionName, const char* fileName, const int lineNo, const char* format, ...)
+void softHSMLog(const int, const char*, const char*, const int, const char*, ...)
 {
 
 }

--- a/src/lib/test/TestsNoPINInitBase.h
+++ b/src/lib/test/TestsNoPINInitBase.h
@@ -38,7 +38,7 @@
 
 
 #ifdef P11M
-#define CRYPTOKI_F_PTR(func) ptr->func
+#define CRYPTOKI_F_PTR(func) m_ptr->func
 #else
 #define CRYPTOKI_F_PTR(func)
 #endif
@@ -50,15 +50,16 @@ public:
 
 	virtual void setUp();
 	virtual void tearDown();
-#ifdef P11M
 private:
+	void getSlotIDs();
+#ifdef P11M
 #ifdef _WIN32
 	HINSTANCE__* p11Library;
 #else
 	void *const p11Library;
 #endif
 protected:
-	const CK_FUNCTION_LIST_PTR ptr;
+	const CK_FUNCTION_LIST_PTR m_ptr;
 #else
 protected:
 #endif

--- a/src/lib/test/TestsNoPINInitBase.h
+++ b/src/lib/test/TestsNoPINInitBase.h
@@ -36,13 +36,32 @@
 #include "cryptoki.h"
 #include <cppunit/TestFixture.h>
 
+
+#ifdef P11M
+#define CRYPTOKI_F_PTR(func) ptr->func
+#else
+#define CRYPTOKI_F_PTR(func)
+#endif
+
 class TestsNoPINInitBase : public CppUnit::TestFixture {
 public:
 	TestsNoPINInitBase();
+	virtual ~TestsNoPINInitBase();
 
 	virtual void setUp();
 	virtual void tearDown();
+#ifdef P11M
+private:
+#ifdef _WIN32
+	HINSTANCE__* p11Library;
+#else
+	void *const p11Library;
+#endif
 protected:
+	const CK_FUNCTION_LIST_PTR ptr;
+#else
+protected:
+#endif
 	const CK_SLOT_ID m_invalidSlotID;
 	CK_SLOT_ID m_initializedTokenSlotID;
 	CK_SLOT_ID m_notInitializedTokenSlotID;

--- a/src/lib/test/TestsNoPINInitBase.h
+++ b/src/lib/test/TestsNoPINInitBase.h
@@ -40,7 +40,7 @@
 #ifdef P11M
 #define CRYPTOKI_F_PTR(func) m_ptr->func
 #else
-#define CRYPTOKI_F_PTR(func)
+#define CRYPTOKI_F_PTR(func) func
 #endif
 
 class TestsNoPINInitBase : public CppUnit::TestFixture {

--- a/src/lib/test/TokenTests.cpp
+++ b/src/lib/test/TokenTests.cpp
@@ -49,50 +49,50 @@ void TokenTests::testInitToken()
 	memcpy(label, "token1", strlen("token1"));
 
 	// Just make sure that we finalize any previous failed tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitToken(m_initializedTokenSlotID, NULL_PTR, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, NULL_PTR, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_InitToken(m_invalidSlotID, m_soPin1, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_invalidSlotID, m_soPin1, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_SLOT_ID_INVALID);
 
 	// Initialize
-	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Get token serial
-	rv = C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	memcpy(serialNumber, tokenInfo.serialNumber, 16);
 
 	// Initialize with wrong password
-	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length - 1, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length - 1, label) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_EXISTS);
 
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Re-initialize
-	rv = C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label);
+	rv = CRYPTOKI_F_PTR( C_InitToken(m_initializedTokenSlotID, m_soPin1, m_soPin1Length, label) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	// Compare token serial
-	rv = C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo);
+	rv = CRYPTOKI_F_PTR( C_GetTokenInfo(m_initializedTokenSlotID, &tokenInfo) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(memcmp(serialNumber, tokenInfo.serialNumber, 16) == 0);
 
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 }

--- a/src/lib/test/UserTests.cpp
+++ b/src/lib/test/UserTests.cpp
@@ -43,30 +43,30 @@ void UserTests::testInitPIN()
 	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(hSession, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(hSession, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_NOT_LOGGED_IN);
 
-	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_InitPIN(CK_INVALID_HANDLE, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(CK_INVALID_HANDLE, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_InitPIN(hSession, m_userPin1, 0);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(hSession, m_userPin1, 0) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_LEN_RANGE);
 
-	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(hSession, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -76,76 +76,76 @@ void UserTests::testLogin()
 	CK_SESSION_HANDLE hSession[2];
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Set up user PIN
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_PIN_NOT_INITIALIZED);
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitPIN(hSession[0], m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(hSession[0], m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession[0]) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(CK_INVALID_HANDLE, CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(CK_INVALID_HANDLE, CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_Login(hSession[0], CKU_SO, NULL_PTR, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, NULL_PTR, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, 0);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, 0) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession[1]);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession[1]) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY_EXISTS);
 
-	rv = C_CloseSession(hSession[1]);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession[1]) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_ANOTHER_ALREADY_LOGGED_IN);
 
-	rv = C_Logout(hSession[0]);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSession[0]) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_ALREADY_LOGGED_IN);
 
-	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_ANOTHER_ALREADY_LOGGED_IN);
 
-	rv = C_Logout(hSession[0]);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSession[0]) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length - 1);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length - 1) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession[0], CKU_USER, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_ALREADY_LOGGED_IN);
 }
 
@@ -155,27 +155,27 @@ void UserTests::testLogout()
 	CK_SESSION_HANDLE hSession = CK_INVALID_HANDLE;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_Logout(hSession);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Logout(CK_INVALID_HANDLE);
+	rv = CRYPTOKI_F_PTR( C_Logout(CK_INVALID_HANDLE) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_Logout(hSession);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Logout(hSession);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
@@ -189,82 +189,82 @@ void UserTests::testSetPIN()
 	CK_SESSION_HANDLE hSession;
 
 	// Just make sure that we finalize any previous tests
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
 	// Set up user PIN
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	rv = C_InitPIN(hSession, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_InitPIN(hSession, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	C_Finalize(NULL_PTR);
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
 
-	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
 
-	rv = C_Initialize(NULL_PTR);
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(CK_INVALID_HANDLE, m_userPin1, m_userPin1Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(CK_INVALID_HANDLE, m_userPin1, m_userPin1Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_HANDLE_INVALID);
 
-	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_SESSION_READ_ONLY);
 
-	rv = C_CloseSession(hSession);
+	rv = CRYPTOKI_F_PTR( C_CloseSession(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession);
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, NULL_PTR, m_userPin1Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, NULL_PTR, m_userPin1Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, NULL_PTR, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_userPin1, m_userPin1Length, NULL_PTR, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
 
-	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, 0);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, 0) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_LEN_RANGE);
 
-	rv = C_SetPIN(hSession, pin2, pin2Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, pin2, pin2Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_USER, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_userPin1, m_userPin1Length, pin2, pin2Length) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, pin2, pin2Length, m_userPin1, m_userPin1Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, pin2, pin2Length, m_userPin1, m_userPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_USER_ANOTHER_ALREADY_LOGGED_IN);
 
-	rv = C_Logout(hSession);
+	rv = CRYPTOKI_F_PTR( C_Logout(hSession) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_SO, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, so2pin, so2pinLength, so2pin, so2pinLength);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, so2pin, so2pinLength, so2pin, so2pinLength) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, m_soPin1, m_soPin1Length, so2pin, so2pinLength);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_soPin1, m_soPin1Length, so2pin, so2pinLength) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
-	rv = C_SetPIN(hSession, m_soPin1, m_soPin1Length, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, m_soPin1, m_soPin1Length, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_PIN_INCORRECT);
 
-	rv = C_SetPIN(hSession, so2pin, so2pinLength, m_soPin1, m_soPin1Length);
+	rv = CRYPTOKI_F_PTR( C_SetPIN(hSession, so2pin, so2pinLength, m_soPin1, m_soPin1Length) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }

--- a/src/lib/test/p11test.cpp
+++ b/src/lib/test/p11test.cpp
@@ -52,7 +52,7 @@ class MyListener : public CPPUNIT_NS::TestListener {
 		std::cout << message.details() << std::endl << std::endl;
 	}
 };
-int main(int argc, char** /* argv */)
+int main(int argc, char**const argv)
 {
 #ifndef _WIN32
 	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
@@ -62,12 +62,14 @@ int main(int argc, char** /* argv */)
 
 	CPPUNIT_NS::TestFactoryRegistry &registry( CPPUNIT_NS::TestFactoryRegistry::getRegistry() );
 
+	CPPUNIT_NS::TextTestRunner runner;
+	runner.addTest(registry.makeTest());
 	if ( argc<2 ) {
-		CPPUNIT_NS::TextTestRunner runner;
-		runner.addTest(registry.makeTest());
 		return runner.run() ? 0 : 1;
 	}
-	CPPUNIT_NS::TestRunner runner;
+	if ( std::string("direct").find(*(argv+1))==std::string::npos ) {
+		return runner.run(*(argv+1)) ? 0 : 1;
+	}
 	runner.addTest(registry.makeTest());
 	CPPUNIT_NS::TestResult controller;
 	CPPUNIT_NS::TestResultCollector result;


### PR DESCRIPTION
I have modified the cppunit test so that it also can test other p11 implementations.
If the test is built as before (make p11test) you will get the same test that you had before (static linking of the SoftHSMv2 p11).
But with this change it will also be possible to build the test so that any p11 implementation with a shared library could be tested.
I have also added 2 new options to the test (no arguments will test as before):
- Printing of test name before a test is executed. This is good if the p11 that you are testing is crashes when some test is executed.
- Possibility to run a specific test. This is good to have when debugging

The new build and execution options are documented in: ./src/lib/test/README

I believe that it will be good for the SoftHSM project if the test is used for testing other p11 implementations. If the test is used for testing other implementations enhancement of the test might be done by those using it to test those implementations.