### PR TITLE
Issue #230: Install p11-kit module file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,12 @@
 ACLOCAL_AMFLAGS = -I m4
 
+if P11_MODULE_FILE
+p11moddir = $(pk_module_configs)
+p11mod_DATA = softhsm2.module
+endif
+
 MAINTAINERCLEANFILES = \
-        config.log config.status \
+        config.log config.status softhsm2.module \
         $(srcdir)/Makefile.in \
         $(srcdir)/config.h.in $(srcdir)/config.h.in~ \
         $(srcdir)/configure \

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,19 @@ softhsmtokendir=${full_localstatedir}/lib/softhsm/tokens/
 full_libdir="$full_libdir/softhsm"
 libdir=$full_libdir
 
+AC_ARG_ENABLE([p11-kit],
+	AS_HELP_STRING([--disable-p11-kit], [Disable p11-kit integration]),
+	[use_p11kit=$enableval], [use_p11kit=yes])
+
+pk_module_configs=
+if test "x${use_p11kit}" != "xno"; then
+	AC_PATH_PROG(PKGCONFIG, [pkg-config])
+	if test "x${PKGCONFIG}" != "x" && ${PKGCONFIG} --exists p11-kit-1; then
+		pk_module_configs=`${PKGCONFIG} --variable=p11_module_configs p11-kit-1`
+	fi
+fi
+AM_CONDITIONAL([P11_MODULE_FILE], [test "x${pk_module_configs}" != "x"])
+
 # For getConfigPath()
 AC_CHECK_FUNCS([getpwuid_r])
 
@@ -174,6 +187,7 @@ AC_DEFINE_UNQUOTED(
 	[The default PKCS#11 library]
 )
 
+AC_SUBST([pk_module_configs])
 AC_SUBST([softhsmtokendir])
 AC_SUBST([default_softhsm2_conf])
 
@@ -184,6 +198,7 @@ AC_PROG_LIBTOOL
 # Generate the makefiles
 AC_CONFIG_FILES([
 	Makefile
+	softhsm2.module
 	src/Makefile
 	src/lib/Makefile
 	src/lib/common/Makefile

--- a/softhsm2.module.in
+++ b/softhsm2.module.in
@@ -1,0 +1,4 @@
+# This file describes how to load the pk11 module
+# See: http://p11-glue.freedesktop.org/doc/p11-kit/config.html
+
+module: @libdir@/libsofthsm2.so

--- a/testing/build-softhsm2.sh
+++ b/testing/build-softhsm2.sh
@@ -28,6 +28,7 @@ case "$DISTRIBUTION" in
 			cd build &&
 			../configure --prefix="$INSTALL_ROOT" \
 				--disable-non-paged-memory \
+				--disable-p11-kit \
 				--with-migrate \
 				--with-crypto-backend=botan \
 				--with-botan="$INSTALL_ROOT" &&
@@ -45,6 +46,7 @@ case "$DISTRIBUTION" in
 			cd build &&
 			../configure --prefix="$INSTALL_ROOT" \
 				--disable-non-paged-memory \
+				--disable-p11-kit \
 				--with-migrate \
 				--with-crypto-backend=botan \
 				--with-botan="$INSTALL_ROOT" \
@@ -83,6 +85,7 @@ case "$DISTRIBUTION" in
 			cd build &&
 			../configure --prefix="$INSTALL_ROOT" \
 				--disable-non-paged-memory \
+				--disable-p11-kit \
 				--with-migrate \
 				--with-crypto-backend=botan \
 				--with-botan="$INSTALL_ROOT" &&


### PR DESCRIPTION
In order for well-behaved applications to discover and use the PKCS#11
provider module, we should install a p11-kit module file for it.