### PR TITLE
Use GetEnvironmentVariable instead of getenv on Windows

### DIFF
--- a/src/lib/common/SimpleConfigLoader.cpp
+++ b/src/lib/common/SimpleConfigLoader.cpp
@@ -240,20 +240,58 @@ static char *get_user_path(void)
 	return NULL;
 }
 
+static char *get_env_var_path(void)
+{
+#ifdef _WIN32
+
+	LPSTR value = NULL;
+	DWORD size = 0;
+
+	size = GetEnvironmentVariableA("SOFTHSM2_CONF", value, size);
+	if (size == 0) {
+		return NULL;
+	}
+	
+	value = (LPSTR) malloc(size);
+	if (NULL == value) {
+		return NULL;
+	}
+
+	if (GetEnvironmentVariableA("SOFTHSM2_CONF", value, size) != (size - 1)) {
+		free(value);
+		return NULL;
+	}
+
+	return value;
+
+#else
+
+	char *value = getenv("SOFTHSM2_CONF");
+
+	if (value == NULL) {
+		return value;
+	} else {
+		return strdup(value);
+	}
+
+#endif
+}
+
 char* SimpleConfigLoader::getConfigPath()
 {
-	const char* configPath = getenv("SOFTHSM2_CONF");
+	char* configPath = get_env_var_path();
 	char *tpath;
 
-	if (configPath == NULL) {
+	if (configPath != NULL) {
+		return configPath;
+	} else {
 		tpath = get_user_path();
 		if (tpath != NULL) {
 			return tpath;
 		}
 		configPath = DEFAULT_SOFTHSM2_CONF;
+		return strdup(configPath);
 	}
-
-	return strdup(configPath);
 } 
 
 char* SimpleConfigLoader::trimString(char* text)


### PR DESCRIPTION
Values of all environment variables seems to be cached when Visual C++ redistributable libraries are loaded into the process. Any later call to `getenv()` function returns only cached values regardless of any subsequent environment modifications. More detailed analysis of this phenomenon has been previously published at [codeproject.com](http://www.codeproject.com/Articles/43029/When-what-you-set-is-not-what-you-get-SetEnvironme).

I have personally encountered this IMO strange behavior in [pkcs11-logger project](https://github.com/Pkcs11Interop/pkcs11-logger) and fixed it easily by reading the values of environment variables with `GetEnvironmentVariable()` function instead of `getenv()` function. Proposed patch does the same for `SOFTHSM2_CONF` environment variable.

I believe this patch also fixes issues discussed in  #227 where @matthauck wants to inject custom ConfigLoader implementation as a workaround.