### PR TITLE
Issue #239: Crash on module unload with OpenSSL

### DIFF
--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -55,9 +55,6 @@
 #include "OSSLGOST.h"
 #endif
 
-#ifdef HAVE_PTHREAD_H
-#include <pthread.h>
-#endif
 #include <algorithm>
 #include <string.h>
 #include <openssl/ssl.h>
@@ -70,14 +67,6 @@
 #ifdef WITH_FIPS
 // Initialise the FIPS 140-2 selftest status
 bool OSSLCryptoFactory::FipsSelfTestStatus = false;
-#endif
-
-// Thread ID callback
-#ifdef HAVE_PTHREAD_H
-static unsigned long id_callback()
-{
-	return (unsigned long) pthread_self();
-}
 #endif
 
 static unsigned nlocks;
@@ -116,9 +105,6 @@ OSSLCryptoFactory::OSSLCryptoFactory()
 	{
 		locks[i] = MutexFactory::i()->getMutex();
 	}
-#ifdef HAVE_PTHREAD_H
-	CRYPTO_set_id_callback(id_callback);
-#endif
 	CRYPTO_set_locking_callback(lock_callback);
 
 #ifdef WITH_FIPS


### PR DESCRIPTION
We use CRYPTO_set_id_callback() to set a callback, but we don't ever
remove it again on unload. So OpenSSL crashes the next time it needs a
thread-id.

CRYPTO_set_id_callback() has been deprecated since OpenSSL 1.0.0, the
oldest we support. And redundant too, since OpenSSL has fallbacks which
include the address of errno. Which is going to work on any platform
with pthreads... and we were only calling CRYPTO_set_id_callback() on
platforms with pthreads.

So just rip it out.