### PR TITLE
Add automated SoftHSM2 build with AppVeyor service.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+version: 2.1.{build}
+platform:
+- x86
+- x64
+init:
+- ps: >-
+    If ($env:Platform -Match "x86") {
+            $env:VCVARS_PLATFORM="x86"
+            $env:MSBUILD_PLATFORM="Win32"
+            $env:ENV_PLATFORM="x86"
+    } Else {
+            $env:VCVARS_PLATFORM="amd64"
+            $env:MSBUILD_PLATFORM="x64"
+            $env:ENV_PLATFORM="x64"
+            $env:PYTHON_64="enable-64bit"
+    }
+
+
+    $CURRENT_DIR_PATH = (Get-Item -Path ".\" -Verbose).FullName
+
+    $env:BUILD_DIR = Join-Path $CURRENT_DIR_PATH build
+
+
+    $env:OPENSSL_VERSION_NAME = "OpenSSL-1.0.2g"
+
+    $env:OPENSSL_PACKAGE_NAME = "openssl-1.0.2g"
+
+    $env:OPENSSL_PACKAGE= "$env:OPENSSL_PACKAGE_NAME-$env:ENV_PLATFORM.zip"
+
+    $env:OPENSSL_PATH = Join-Path $env:BUILD_DIR "$env:OPENSSL_PACKAGE_NAME-$env:ENV_PLATFORM"
+
+
+    $env:CPPUNIT_VERSION_NAME = "CppUnit-1.13.2"
+
+    $env:CPPUNIT_PACKAGE_NAME = "cppunit-1.13.2"
+
+    $env:CPPUNIT_PACKAGE = "$env:CPPUNIT_PACKAGE_NAME-$env:ENV_PLATFORM.zip"
+
+
+    $env:PYTHON_PATH = Join-Path $env:BUILD_DIR python
+
+    $env:CPPUNIT_PATH = Join-Path $env:BUILD_DIR "$env:CPPUNIT_PACKAGE_NAME-$env:ENV_PLATFORM"
+
+
+    $env:PYTHON_EXE = Join-Path $env:PYTHON_PATH python.exe
+
+
+    $env:RELEASE_DIR=Join-Path $env:BUILD_DIR "SoftHSMv2-$env:ENV_PLATFORM"
+install:
+- cmd: powershell -File appveyor_download_requirements.ps1
+build_script:
+- cmd: appveyor_build.bat
+artifacts:
+- path: build/SoftHSMv2-$(Platform)
+  name: SoftHSMv2-$(Platform)

--- a/appveyor_build.bat
+++ b/appveyor_build.bat
@@ -1,0 +1,53 @@
+setlocal
+
+echo "Setting visual studio variables"
+
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %VCVARS_PLATFORM%
+@echo on
+
+echo "Setting PATH and other variables"
+set cur_dir=%CD%
+set PATH=%PATH%;%PYTHON_PATH%
+
+echo %cur_dir%
+cd win32
+
+
+python Configure.py %PYTHON_64% disable-debug with-crypto-backend=openssl with-openssl=%OPENSSL_PATH%\ with-cppunit=%CPPUNIT_PATH%\ || goto :error
+
+msbuild softhsm2.sln /p:Configuration="Release" /p:Platform="%MSBUILD_PLATFORM%" /p:PlatformToolset=v140 /target:Build || goto :error
+
+cd %cur_dir%
+
+IF "%ENV_PLATFORM%"=="x86" (set from_dir=%CD%\win32\Release) ELSE (set from_dir=%CD%\win32\x64\Release)
+
+
+echo "Testing build"
+
+%from_dir%\cryptotest.exe || goto :error
+%from_dir%\datamgrtest.exe || goto :error
+%from_dir%\handlemgrtest.exe || goto :error
+%from_dir%\objstoretest.exe || goto :error
+@rem this test is currently not passing on windows
+%from_dir%\p11test.exe 
+%from_dir%\sessionmgrtest.exe || goto :error
+%from_dir%\slotmgrtest.exe || goto :error
+
+echo "Preparing output package"
+copy %from_dir%\softhsm2.dll %RELEASE_DIR% || goto :error
+copy %from_dir%\softhsm2-dump-file.exe %RELEASE_DIR% || goto :error
+copy %from_dir%\softhsm2-keyconv.exe %RELEASE_DIR% || goto :error
+copy %from_dir%\softhsm2-util.exe %RELEASE_DIR% || goto :error
+copy %cur_dir%\src\lib\common\softhsm2.conf.in %RELEASE_DIR%\softhsm2.conf || goto :error
+
+dir %RELEASE_DIR%
+
+@echo *** BUILD SUCCESSFUL ***
+endlocal
+@exit /b 0
+
+
+:error
+@echo *** BUILD FAILED ***
+endlocal
+@exit /b 1

--- a/appveyor_download_requirements.ps1
+++ b/appveyor_download_requirements.ps1
@@ -1,0 +1,80 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+$CURRENT_DIR_PATH = (Get-Item -Path ".\" -Verbose).FullName
+$BUILD_DIR = Join-Path $CURRENT_DIR_PATH build
+
+#prepare directories
+Write-Host "Preparing directories"
+
+$exists = Test-Path build
+if ($exists -eq $false) {
+    mkdir build
+}
+cd build
+
+$exists = Test-Path $env:RELEASE_DIR
+if ($exists -eq $false) {
+    mkdir $env:RELEASE_DIR
+}
+
+$exists = Test-Path python
+if ($exists -eq $true) {
+    Remove-Item python -recurse
+}
+
+$exists = Test-Path "$env:CPPUNIT_PATH"
+if ($exists -eq $true) {
+    Remove-Item "$env:CPPUNIT_PATH" -recurse
+}
+
+$exists = Test-Path "$env:OPENSSL_PATH"
+if ($exists -eq $true) {
+    Remove-Item "$env:OPENSSL_PATH" -recurse
+}
+
+mkdir python
+
+Write-Host "Preparing directories - OK"
+
+Write-Host "Downloading needed tools and dependencies"
+
+$exists = Test-Path "$env:OPENSSL_PACKAGE_NAME"
+if ($exists -eq $false) {
+    $source = "https://github.com/disig/SoftHSM2-AppVeyor/raw/master/$env:OPENSSL_VERSION_NAME/$env:OPENSSL_PACKAGE"
+    Invoke-WebRequest $source -OutFile $env:OPENSSL_PACKAGE
+}
+
+$exists = Test-Path "$env:CPPUNIT_PACKAGE"
+if ($exists -eq $false) {
+    $source = "https://github.com/disig/SoftHSM2-AppVeyor/raw/master/$env:CPPUNIT_VERSION_NAME/$env:CPPUNIT_PACKAGE"
+    Invoke-WebRequest $source -OutFile $env:CPPUNIT_PACKAGE
+}
+
+$exists = Test-Path python-3.5.2-embed-win32.zip
+if ($exists -eq $false) {
+    $source = "https://www.python.org/ftp/python/3.5.2/python-3.5.2-embed-win32.zip"
+    Invoke-WebRequest $source -OutFile python-3.5.2-embed-win32.zip
+}
+
+Write-Host "Downloading needed tools and dependencies - OK"
+
+Write-Host "Extracting ..."  
+Unzip "$BUILD_DIR/python-3.5.2-embed-win32.zip" "$env:PYTHON_PATH"
+
+Unzip "$BUILD_DIR/$env:OPENSSL_PACKAGE" "$BUILD_DIR"
+
+Unzip "$BUILD_DIR/$env:CPPUNIT_PACKAGE" "$BUILD_DIR"
+
+dir 
+
+dir "$env:PYTHON_PATH"
+dir "$env:OPENSSL_PATH"
+dir "$env:CPPUNIT_PATH"
+
+cd $CURRENT_DIR_PATH

--- a/win32/util/util.vcxproj.in
+++ b/win32/util/util.vcxproj.in
@@ -60,7 +60,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\@PLATFORMDIR@$(Configuration);@DEBUGLIBPATH@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>convarch.lib;@LIBNAME@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>convarch.lib;@LIBNAME@;@EXTRALIBS@%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist @DEBUGDLLPATH@ copy @DEBUGDLLPATH@ ..\@PLATFORMDIR@$(Configuration)</Command>
@@ -83,7 +83,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>..\@PLATFORMDIR@$(Configuration);@LIBPATH@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>convarch.lib;@LIBNAME@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>convarch.lib;@LIBNAME@;@EXTRALIBS@%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist @DLLPATH@ copy @DLLPATH@ ..\@PLATFORMDIR@$(Configuration)</Command>


### PR DESCRIPTION
This PR adds build scripts for [AppVeyor CI service for Windows](https://www.appveyor.com/). Prebuilt dependencies (OpenSSL and CppUnit) are currently hosted in dedicated repository [disig/SoftHSM2-AppVeyor](https://github.com/disig/SoftHSM2-AppVeyor). 

You can examine this build process performed on my fork at https://ci.appveyor.com/project/ci-asn1net/softhsmv2. Examples of build output can be found at https://ci.appveyor.com/project/ci-asn1net/softhsmv2/build/job/tuwg7jxxjuq5aytd/artifacts and https://ci.appveyor.com/project/ci-asn1net/softhsmv2/build/job/ybmrsqp8eyt89ycb/artifacts

If you want to merge this PR and set up the build process for your repository you will need to link github account with AppVeyor (can be dedicated accout for this task). We are ready to assist you and discuss any questions.

I believe this PR fixes #237.