### PR TITLE
Allow config path to be specified in C_Initialize() call

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -362,8 +362,15 @@ CK_RV SoftHSM::C_Initialize(CK_VOID_PTR pInitArgs)
 		// Must be set to NULL_PTR in this version of PKCS#11
 		if (args->pReserved != NULL_PTR)
 		{
-			DEBUG_MSG("pReserved must be set to NULL_PTR");
-			return CKR_ARGUMENTS_BAD;
+			static const char *confstr = "SOFTHSM2_CONF=";
+			char *init_args = (char *)args->pReserved;
+
+			if (strncmp(init_args, confstr, strlen(confstr)) != 0 ||
+			    init_args[strlen(confstr)] == '\0') {
+				DEBUG_MSG("pReserved must be set to NULL_PTR or \"SOFTHSM2_CONF=...\"");
+				return CKR_ARGUMENTS_BAD;
+			}
+			SimpleConfigLoader::i()->setConfigPath(init_args + strlen(confstr));
 		}
 
 		// Can we spawn our own threads?

--- a/src/lib/common/SimpleConfigLoader.cpp
+++ b/src/lib/common/SimpleConfigLoader.cpp
@@ -56,6 +56,9 @@ std::unique_ptr<SimpleConfigLoader> SimpleConfigLoader::instance(nullptr);
 std::auto_ptr<SimpleConfigLoader> SimpleConfigLoader::instance(NULL);
 #endif
 
+static char *get_user_path(void);
+static char *get_env_var_path(void);
+
 // Return the one-and-only instance
 SimpleConfigLoader* SimpleConfigLoader::i()
 {
@@ -70,7 +73,11 @@ SimpleConfigLoader* SimpleConfigLoader::i()
 // Constructor
 SimpleConfigLoader::SimpleConfigLoader()
 {
-	configPath = getConfigPath();
+	configPath = get_env_var_path();
+	if (configPath == NULL)
+		configPath = get_user_path();
+	if (configPath == NULL)
+		configPath = strdup(DEFAULT_SOFTHSM2_CONF);
 }
 
 // Destructor
@@ -286,23 +293,6 @@ static char *get_env_var_path(void)
 
 #endif
 }
-
-char* SimpleConfigLoader::getConfigPath()
-{
-	char* configPath = get_env_var_path();
-	char *tpath;
-
-	if (configPath != NULL) {
-		return configPath;
-	} else {
-		tpath = get_user_path();
-		if (tpath != NULL) {
-			return tpath;
-		}
-		configPath = DEFAULT_SOFTHSM2_CONF;
-		return strdup(configPath);
-	}
-} 
 
 char* SimpleConfigLoader::trimString(char* text)
 {

--- a/src/lib/common/SimpleConfigLoader.cpp
+++ b/src/lib/common/SimpleConfigLoader.cpp
@@ -70,22 +70,32 @@ SimpleConfigLoader* SimpleConfigLoader::i()
 // Constructor
 SimpleConfigLoader::SimpleConfigLoader()
 {
+	configPath = getConfigPath();
+}
+
+// Destructor
+SimpleConfigLoader::~SimpleConfigLoader()
+{
+	free(configPath);
+}
+
+// Override the default configPath;
+void SimpleConfigLoader::setConfigPath(char *path)
+{
+	free(configPath);
+	configPath = strdup(path);
 }
 
 // Load the configuration
 bool SimpleConfigLoader::loadConfiguration()
 {
-	char* configPath = getConfigPath();
-
 	FILE* fp = fopen(configPath,"r");
 
 	if (fp == NULL)
 	{
 		ERROR_MSG("Could not open the config file: %s", configPath);
-		free(configPath);
 		return false;
 	}
-	free(configPath);
 
 	char fileBuf[1024];
 

--- a/src/lib/common/SimpleConfigLoader.h
+++ b/src/lib/common/SimpleConfigLoader.h
@@ -42,9 +42,11 @@ class SimpleConfigLoader : public ConfigLoader
 public:
 	static SimpleConfigLoader* i();
 
-	virtual ~SimpleConfigLoader() { }
+	virtual ~SimpleConfigLoader();
 
 	virtual bool loadConfiguration();
+
+	virtual void setConfigPath(char *);
 
 private:
 	SimpleConfigLoader();
@@ -52,6 +54,7 @@ private:
 	char* trimString(char* text);
 	bool string2bool(std::string stringValue, bool* boolValue);
 
+	char *configPath;
 #ifdef HAVE_CXX11
 	static std::unique_ptr<SimpleConfigLoader> instance;
 #else

--- a/src/lib/common/SimpleConfigLoader.h
+++ b/src/lib/common/SimpleConfigLoader.h
@@ -50,7 +50,6 @@ public:
 
 private:
 	SimpleConfigLoader();
-	char* getConfigPath();
 	char* trimString(char* text);
 	bool string2bool(std::string stringValue, bool* boolValue);
 


### PR DESCRIPTION
The `pReserved` field of `pInitArgs` can be used in a token-specific way, to indicate the config path. This provides an alternative to setting the `SOFTHSM2_CONF` environment variable, which may be non-trivial _(or indeed impossible, if you want to do it from a multi-threaded program before loading the SoftHSM token)_.

This is exactly how the NSS softokn module does it, and p11-kit supports the setting of a string in this field by means of the `x-init-reserved:` directive in its module file, thus:

```
module:libsofthsm2.so
x-init-reserved:SOFTHSM2_CONF=/home/dwmw2/git/openconnect/tests/softhsm2.conf
```

Obviously it's entirely optional; it overrides the existing environment variable and `DEFAULT_SOFTHSM2_CONF` if provided, but doesn't have to be present.
