### PR TITLE
Add missing dependency on winsock

### DIFF
--- a/win32/Configure.py
+++ b/win32/Configure.py
@@ -638,7 +638,7 @@ int main() {\n\
     else:
 
         condvals["OPENSSL"] = True
-        varvals["EXTRALIBS"] = "crypt32.lib;"
+        varvals["EXTRALIBS"] = "crypt32.lib;ws2_32.lib;"
         openssl_path = os.path.abspath(openssl_path)
         openssl_inc = os.path.join(openssl_path, "include")
         if not os.path.exists(os.path.join(openssl_inc, "openssl\\ssl.h")):
@@ -693,7 +693,7 @@ int main() {\n\
         if os.path.exists(openssl_dll):
             subprocess.call(["copy", openssl_dll, "."], shell=True)
         else:
-            system_libs = ["user32.lib", "advapi32.lib", "gdi32.lib", "crypt32.lib"]
+            system_libs = ["user32.lib", "advapi32.lib", "gdi32.lib", "crypt32.lib", "ws2_32.lib"]
         inc = openssl_inc
         lib = os.path.join(openssl_lib, openssl_lib_name)
         testfile = open("testossl.c", "w")

--- a/win32/keyconv/keyconv.vcxproj.in
+++ b/win32/keyconv/keyconv.vcxproj.in
@@ -60,7 +60,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>@DEBUGLIBPATH@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>@LIBNAME@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>@LIBNAME@;@EXTRALIBS@%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|@PLATFORM@'">
@@ -80,7 +80,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>@LIBPATH@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>@LIBNAME@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>@LIBNAME@;@EXTRALIBS@%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
I've received following errors when building current `develop` branch on WIN10 with VS2015 and OpenSSL 1.1.0b:

```
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__ioctlsocket@12 referenced in function _BIO_socket_ioctl
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__getsockname@12 referenced in function _BIO_sock_info
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__getsockopt@20 referenced in function _BIO_sock_error
libcrypto.lib(b_sock2.obj) : error LNK2001: unresolved external symbol __imp__getsockopt@20
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__ntohs@4 referenced in function _BIO_get_port
libcrypto.lib(b_addr.obj) : error LNK2001: unresolved external symbol __imp__ntohs@4
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__gethostbyname@4 referenced in function _BIO_gethostbyname
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__WSAStartup@8 referenced in function _BIO_sock_init
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__WSACleanup@0 referenced in function _bio_sock_cleanup_int
libcrypto.lib(b_sock.obj) : error LNK2019: unresolved external symbol __imp__WSAGetLastError@0 referenced in function _BIO_accept
libcrypto.lib(bss_sock.obj) : error LNK2001: unresolved external symbol __imp__WSAGetLastError@0
libcrypto.lib(b_sock2.obj) : error LNK2001: unresolved external symbol __imp__WSAGetLastError@0
libcrypto.lib(b_addr.obj) : error LNK2019: unresolved external symbol __imp__getaddrinfo@16 referenced in function _BIO_lookup
libcrypto.lib(b_addr.obj) : error LNK2019: unresolved external symbol __imp__freeaddrinfo@4 referenced in function _BIO_ADDRINFO_free
libcrypto.lib(b_addr.obj) : error LNK2019: unresolved external symbol __imp__getnameinfo@28 referenced in function _addr_strings
libcrypto.lib(bss_sock.obj) : error LNK2019: unresolved external symbol __imp__recv@16 referenced in function _sock_read
libcrypto.lib(bss_sock.obj) : error LNK2019: unresolved external symbol __imp__send@16 referenced in function _sock_write
libcrypto.lib(bss_sock.obj) : error LNK2019: unresolved external symbol __imp__WSASetLastError@4 referenced in function _sock_write
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__accept@12 referenced in function _BIO_accept_ex
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__bind@12 referenced in function _BIO_listen
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__closesocket@4 referenced in function _BIO_accept_ex
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__connect@12 referenced in function _BIO_connect
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__listen@8 referenced in function _BIO_listen
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__setsockopt@20 referenced in function _BIO_connect
libcrypto.lib(b_sock2.obj) : error LNK2019: unresolved external symbol __imp__socket@12 referenced in function _BIO_socket
```

I've resolved them by adding `ws2_32.lib` as an additional linker dependency.