### PR TITLE
Set CKA_DECRYPT/CKA_ENCRYPT flags on key import to true.

### DIFF
--- a/src/bin/util/softhsm2-util-botan.cpp
+++ b/src/bin/util/softhsm2-util-botan.cpp
@@ -236,8 +236,8 @@ int crypto_save_rsa
 		{ CKA_ID,               objID,        objIDLen },
 		{ CKA_TOKEN,            &ckToken,     sizeof(ckToken) },
 		{ CKA_VERIFY,           &ckTrue,      sizeof(ckTrue) },
-		{ CKA_ENCRYPT,          &ckFalse,     sizeof(ckFalse) },
-		{ CKA_WRAP,             &ckFalse,     sizeof(ckFalse) },
+		{ CKA_ENCRYPT,          &ckTrue,      sizeof(ckTrue) },
+		{ CKA_WRAP,             &ckTrue,      sizeof(ckTrue) },
 		{ CKA_PUBLIC_EXPONENT,  keyMat->bigE, keyMat->sizeE },
 		{ CKA_MODULUS,          keyMat->bigN, keyMat->sizeN }
 	};
@@ -247,8 +247,8 @@ int crypto_save_rsa
 		{ CKA_LABEL,            label,           strlen(label) },
 		{ CKA_ID,               objID,           objIDLen },
 		{ CKA_SIGN,             &ckTrue,         sizeof(ckTrue) },
-		{ CKA_DECRYPT,          &ckFalse,        sizeof(ckFalse) },
-		{ CKA_UNWRAP,           &ckFalse,        sizeof(ckFalse) },
+		{ CKA_DECRYPT,          &ckTrue,         sizeof(ckTrue) },
+		{ CKA_UNWRAP,           &ckTrue,         sizeof(ckTrue) },
 		{ CKA_SENSITIVE,        &ckTrue,         sizeof(ckTrue) },
 		{ CKA_TOKEN,            &ckTrue,         sizeof(ckTrue) },
 		{ CKA_PRIVATE,          &ckTrue,         sizeof(ckTrue) },

--- a/src/bin/util/softhsm2-util-ossl.cpp
+++ b/src/bin/util/softhsm2-util-ossl.cpp
@@ -238,8 +238,8 @@ int crypto_save_rsa
 		{ CKA_ID,               objID,        objIDLen },
 		{ CKA_TOKEN,            &ckToken,     sizeof(ckToken) },
 		{ CKA_VERIFY,           &ckTrue,      sizeof(ckTrue) },
-		{ CKA_ENCRYPT,          &ckFalse,     sizeof(ckFalse) },
-		{ CKA_WRAP,             &ckFalse,     sizeof(ckFalse) },
+		{ CKA_ENCRYPT,          &ckTrue,      sizeof(ckTrue) },
+		{ CKA_WRAP,             &ckTrue,      sizeof(ckTrue) },
 		{ CKA_PUBLIC_EXPONENT,  keyMat->bigE, keyMat->sizeE },
 		{ CKA_MODULUS,          keyMat->bigN, keyMat->sizeN }
 	};
@@ -249,8 +249,8 @@ int crypto_save_rsa
 		{ CKA_LABEL,            label,           strlen(label) },
 		{ CKA_ID,               objID,           objIDLen },
 		{ CKA_SIGN,             &ckTrue,         sizeof(ckTrue) },
-		{ CKA_DECRYPT,          &ckFalse,        sizeof(ckFalse) },
-		{ CKA_UNWRAP,           &ckFalse,        sizeof(ckFalse) },
+		{ CKA_DECRYPT,          &ckTrue,         sizeof(ckTrue) },
+		{ CKA_UNWRAP,           &ckTrue,         sizeof(ckTrue) },
 		{ CKA_SENSITIVE,        &ckTrue,         sizeof(ckTrue) },
 		{ CKA_TOKEN,            &ckTrue,         sizeof(ckTrue) },
 		{ CKA_PRIVATE,          &ckTrue,         sizeof(ckTrue) },


### PR DESCRIPTION
When importing keys with the `softhsm2-util` the private and public key objects were attributed so that they couldn't be used for de-/encryption. This pull-request sets the attributes

* `CKA_WRAP`/`CKA_ENCRYPT` for the public key, and
* `CKA_UNWRAP`/`CKA_DECRYPT` for the private key

to true. This is supposed to fix #257 