### PR TITLE
Fix c++11 check to look for unique_ptr

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -37,6 +37,8 @@
 #serial 4
 
 m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
+  #include <memory>
+
   template <typename T>
     struct check
     {
@@ -49,6 +51,8 @@ m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
     struct Child : public Base {
     virtual void f() override {}
     };
+
+    std::unique_ptr<Base> ptr_to_base;
 
     typedef check<check<bool>> right_angle_brackets;
 


### PR DESCRIPTION
Strangely enough Mac 10.8 passes the other C++11 checks
but does not have std::unique_ptr.