### PR TITLE
Test minor fixups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ ACX_VISIBILITY
 # If we should install the p11-kit module
 ACX_P11KIT
 
+# cppunit setetings
+ACX_CPPUNIT
+
 # Set full directory paths
 full_sysconfdir=`eval eval eval eval eval echo "${sysconfdir}" | sed "s#NONE#${prefix}#" | sed "s#NONE#${ac_default_prefix}#"`
 full_localstatedir=`eval eval eval eval eval echo "${localstatedir}" | sed "s#NONE#${prefix}#" | sed "s#NONE#${ac_default_prefix}#"`

--- a/m4/acx_cppunit.m4
+++ b/m4/acx_cppunit.m4
@@ -1,0 +1,4 @@
+AC_DEFUN([ACX_CPPUNIT],[
+	PKG_PROG_PKG_CONFIG
+	PKG_CHECK_MODULES([CPPUNIT], [cppunit], [have_cppunit=yes], [have_cppunit=no])
+])

--- a/src/lib/crypto/test/Makefile.am
+++ b/src/lib/crypto/test/Makefile.am
@@ -8,8 +8,9 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
-				@CRYPTO_INCLUDES@ \
-				`cppunit-config --cflags`
+				@CRYPTO_INCLUDES@
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		cryptotest
 
@@ -32,7 +33,7 @@ cryptotest_SOURCES =		cryptotest.cpp \
 
 cryptotest_LDADD =		../../libsofthsm_convarch.la
 
-cryptotest_LDFLAGS = 		@CRYPTO_LIBS@ -no-install `cppunit-config --libs`
+cryptotest_LDFLAGS = 		@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install
 
 TESTS = 			cryptotest
 

--- a/src/lib/data_mgr/test/Makefile.am
+++ b/src/lib/data_mgr/test/Makefile.am
@@ -8,8 +8,9 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
-				@CRYPTO_INCLUDES@ \
-				`cppunit-config --cflags`
+				@CRYPTO_INCLUDES@
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		datamgrtest
 
@@ -20,7 +21,7 @@ datamgrtest_SOURCES =		datamgrtest.cpp \
 
 datamgrtest_LDADD =		../../libsofthsm_convarch.la 
 
-datamgrtest_LDFLAGS = 		@CRYPTO_LIBS@ -no-install `cppunit-config --libs`
+datamgrtest_LDFLAGS = 		@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install
 
 TESTS = 			datamgrtest
 

--- a/src/lib/handle_mgr/test/Makefile.am
+++ b/src/lib/handle_mgr/test/Makefile.am
@@ -8,8 +8,9 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
-				-I$(srcdir)/../../data_mgr \
-				`cppunit-config --cflags`
+				-I$(srcdir)/../../data_mgr
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		handlemgrtest
 
@@ -18,7 +19,7 @@ handlemgrtest_SOURCES =		handlemgrtest.cpp \
 
 handlemgrtest_LDADD =		../../libsofthsm_convarch.la 
 
-handlemgrtest_LDFLAGS = 	@CRYPTO_LIBS@ -no-install `cppunit-config --libs`
+handlemgrtest_LDFLAGS = 	@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install
 
 TESTS = 			handlemgrtest
 

--- a/src/lib/object_store/test/Makefile.am
+++ b/src/lib/object_store/test/Makefile.am
@@ -8,8 +8,9 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../data_mgr \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
-				@CRYPTO_INCLUDES@ \
-				`cppunit-config --cflags`
+				@CRYPTO_INCLUDES@
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		objstoretest
 
@@ -32,7 +33,7 @@ endif
 
 objstoretest_LDADD =		../../libsofthsm_convarch.la 
 
-objstoretest_LDFLAGS = 		@CRYPTO_LIBS@ -no-install `cppunit-config --libs` -pthread
+objstoretest_LDFLAGS = 		@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install -pthread
 
 TESTS = 			objstoretest
 

--- a/src/lib/session_mgr/test/Makefile.am
+++ b/src/lib/session_mgr/test/Makefile.am
@@ -8,8 +8,9 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../data_mgr \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
-				-I$(srcdir)/../../object_store \
-				`cppunit-config --cflags`
+				-I$(srcdir)/../../object_store
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		sessionmgrtest
 
@@ -18,7 +19,7 @@ sessionmgrtest_SOURCES =	sessionmgrtest.cpp \
 
 sessionmgrtest_LDADD =		../../libsofthsm_convarch.la 
 
-sessionmgrtest_LDFLAGS =	@CRYPTO_LIBS@ -no-install `cppunit-config --libs` -pthread
+sessionmgrtest_LDFLAGS =	@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install -pthread
 
 TESTS = 			sessionmgrtest
 

--- a/src/lib/slot_mgr/test/Makefile.am
+++ b/src/lib/slot_mgr/test/Makefile.am
@@ -8,8 +8,9 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../data_mgr \
-				@CRYPTO_INCLUDES@ \
-				`cppunit-config --cflags`
+				@CRYPTO_INCLUDES@
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		slotmgrtest
 
@@ -18,7 +19,7 @@ slotmgrtest_SOURCES =		slotmgrtest.cpp \
 
 slotmgrtest_LDADD =		../../libsofthsm_convarch.la 
 
-slotmgrtest_LDFLAGS = 		@CRYPTO_LIBS@ -no-install `cppunit-config --libs` -pthread
+slotmgrtest_LDFLAGS = 		@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install -pthread
 
 TESTS = 			slotmgrtest
 

--- a/src/lib/test/Makefile.am
+++ b/src/lib/test/Makefile.am
@@ -2,8 +2,9 @@ MAINTAINERCLEANFILES = 		$(srcdir)/Makefile.in
 
 AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../cryptoki_compat \
-				-I$(srcdir)/../common \
-				`cppunit-config --cflags`
+				-I$(srcdir)/../common
+
+AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		p11test
 
@@ -30,7 +31,7 @@ p11test_SOURCES =		p11test.cpp \
 
 p11test_LDADD =			../libsofthsm2.la 
 
-p11test_LDFLAGS = 		@CRYPTO_LIBS@ -no-install `cppunit-config --libs` -pthread -static
+p11test_LDFLAGS = 		@CRYPTO_LIBS@ @CPPUNIT_LIBS@ -no-install -pthread -static
 
 TESTS = 			p11test
 

--- a/src/lib/test/Makefile.am
+++ b/src/lib/test/Makefile.am
@@ -25,6 +25,7 @@ p11test_SOURCES =		p11test.cpp \
 				AsymWrapUnwrapTests.cpp \
 				TestsBase.cpp \
 				TestsNoPINInitBase.cpp \
+				../common/log.cpp \
 				../common/osmutex.cpp
 
 p11test_LDADD =			../libsofthsm2.la 


### PR DESCRIPTION
Hi,

Minor fixups for tests.
1. A missing log object that is required to resolve all symbols.
2. Switch to autoconf based cppunit detection.

The cppunit detection is performed using pkg-config standard detection, I see you have some proprietary methods, I suggest to sync these as well. If for some reason you prefer the proprietary methods I can do that, just explain why you are using those.

Thanks!