### PR TITLE
crypto: openssl: libressl support

### DIFF
--- a/m4/acx_openssl_gost.m4
+++ b/m4/acx_openssl_gost.m4
@@ -22,7 +22,7 @@ AC_DEFUN([ACX_OPENSSL_GOST],[
 				OpenSSL_add_all_algorithms();
 
 				/* Load engines */
-			#if OPENSSL_VERSION_NUMBER < 0x10100000L
+			#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 				ENGINE_load_builtin_engines();
 			#else
 				OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN | OPENSSL_INIT_LOAD_CONFIG, NULL);

--- a/src/lib/crypto/OSSLComp.cpp
+++ b/src/lib/crypto/OSSLComp.cpp
@@ -34,7 +34,7 @@
 #include "OSSLComp.h"
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 /*
  * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.

--- a/src/lib/crypto/OSSLComp.h
+++ b/src/lib/crypto/OSSLComp.h
@@ -36,7 +36,7 @@
 #include "config.h"
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>

--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -134,7 +134,7 @@ OSSLCryptoFactory::OSSLCryptoFactory()
 
 #ifdef WITH_GOST
 	// Load engines
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	ENGINE_load_builtin_engines();
 #else
 	OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN |

--- a/src/lib/crypto/OSSLDHPrivateKey.cpp
+++ b/src/lib/crypto/OSSLDHPrivateKey.cpp
@@ -210,7 +210,7 @@ void OSSLDHPrivateKey::createOSSLKey()
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLDHPublicKey.cpp
+++ b/src/lib/crypto/OSSLDHPublicKey.cpp
@@ -151,7 +151,7 @@ void OSSLDHPublicKey::createOSSLKey()
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLDSAPrivateKey.cpp
+++ b/src/lib/crypto/OSSLDSAPrivateKey.cpp
@@ -227,7 +227,7 @@ void OSSLDSAPrivateKey::createOSSLKey()
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLDSAPublicKey.cpp
+++ b/src/lib/crypto/OSSLDSAPublicKey.cpp
@@ -168,7 +168,7 @@ void OSSLDSAPublicKey::createOSSLKey()
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLECDH.cpp
+++ b/src/lib/crypto/OSSLECDH.cpp
@@ -187,7 +187,7 @@ bool OSSLECDH::deriveKey(SymmetricKey **ppSymmetricKey, PublicKey* publicKey, Pr
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -78,7 +78,7 @@ bool OSSLECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())
@@ -170,7 +170,7 @@ bool OSSLECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLRSAPrivateKey.cpp
+++ b/src/lib/crypto/OSSLRSAPrivateKey.cpp
@@ -289,7 +289,7 @@ void OSSLRSAPrivateKey::createOSSLKey()
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/src/lib/crypto/OSSLRSAPublicKey.cpp
+++ b/src/lib/crypto/OSSLRSAPublicKey.cpp
@@ -133,7 +133,7 @@ void OSSLRSAPublicKey::createOSSLKey()
 	}
 
 	// Use the OpenSSL implementation and not any engine
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #ifdef WITH_FIPS
 	if (FIPS_mode())

--- a/win32/Configure.py
+++ b/win32/Configure.py
@@ -789,7 +789,7 @@ int main() {\n\
  ENGINE *eg;\n\
  const EVP_MD* EVP_GOST_34_11;\n\
  OpenSSL_add_all_algorithms();\n\
-#if OPENSSL_VERSION_NUMBER < 0x10100000L\n\
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)\n\
  ENGINE_load_builtin_engines();\n\
 #else\n\
  OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN | OPENSSL_INIT_LOAD_CONFIG, NULL);\n\


### PR DESCRIPTION
Hi,

Support libressl with trivial changes, passes all tests.

BTW: Running programs during autoconf is highly discouraged as cross-compile will fail. Please consider to use only the pre-processor in order to detect algorithms and versions.

BTW2: If you run something while allowing to specify --with-xxx=prefix, you should also set LD_PRELOAD.

Thanks!