### PR TITLE
Minor fix of 'EVP_CipherFinal_ex' call

### DIFF
--- a/src/lib/crypto/OSSLAES.cpp
+++ b/src/lib/crypto/OSSLAES.cpp
@@ -183,7 +183,7 @@ bool OSSLAES::wrapUnwrapKey(const SymmetricKey* key, const SymWrap::Type mode, c
 	rv = EVP_CipherUpdate(pWrapCTX, &out[0], &curBlockLen, in.const_byte_str(), in.size());
 	if (rv == 1) {
 		outLen = curBlockLen;
-		rv = EVP_CipherFinal_ex(pWrapCTX, &out[0], &curBlockLen);
+		rv = EVP_CipherFinal_ex(pWrapCTX, &out[0] + outLen, &curBlockLen);
 	}
 	if (rv != 1)
 	{


### PR DESCRIPTION
EVP_CipherFinal_ex is called without shift for output pointer -- so that
the final padded block is written at the begining of the output buffer,
and not appended to the result of the previous EVP_CipherUpdate.

It works now as expected because "padding is handled by cipher mode separately ..."
and final padded block has zero length.