### PR TITLE
Issue #297: Fix build with cppunit

### DIFF
--- a/src/lib/crypto/test/Makefile.am
+++ b/src/lib/crypto/test/Makefile.am
@@ -8,9 +8,8 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../pkcs11 \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
+				@CPPUNIT_CFLAGS@ \
 				@CRYPTO_INCLUDES@
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		cryptotest
 

--- a/src/lib/data_mgr/test/Makefile.am
+++ b/src/lib/data_mgr/test/Makefile.am
@@ -8,9 +8,8 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../pkcs11 \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
+				@CPPUNIT_CFLAGS@ \
 				@CRYPTO_INCLUDES@
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		datamgrtest
 

--- a/src/lib/handle_mgr/test/Makefile.am
+++ b/src/lib/handle_mgr/test/Makefile.am
@@ -8,9 +8,8 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../pkcs11 \
 				-I$(srcdir)/../../session_mgr \
-				-I$(srcdir)/../../slot_mgr
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
+				-I$(srcdir)/../../slot_mgr \
+				@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		handlemgrtest
 

--- a/src/lib/object_store/test/Makefile.am
+++ b/src/lib/object_store/test/Makefile.am
@@ -8,9 +8,8 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../pkcs11 \
 				-I$(srcdir)/../../session_mgr \
 				-I$(srcdir)/../../slot_mgr \
+				@CPPUNIT_CFLAGS@ \
 				@CRYPTO_INCLUDES@
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		objstoretest
 

--- a/src/lib/session_mgr/test/Makefile.am
+++ b/src/lib/session_mgr/test/Makefile.am
@@ -8,9 +8,8 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../pkcs11 \
 				-I$(srcdir)/../../session_mgr \
-				-I$(srcdir)/../../slot_mgr
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
+				-I$(srcdir)/../../slot_mgr \
+				@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		sessionmgrtest
 

--- a/src/lib/slot_mgr/test/Makefile.am
+++ b/src/lib/slot_mgr/test/Makefile.am
@@ -8,9 +8,8 @@ AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../../object_store \
 				-I$(srcdir)/../../pkcs11 \
 				-I$(srcdir)/../../session_mgr \
+				@CPPUNIT_CFLAGS@ \
 				@CRYPTO_INCLUDES@
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		slotmgrtest
 

--- a/src/lib/test/Makefile.am
+++ b/src/lib/test/Makefile.am
@@ -2,9 +2,8 @@ MAINTAINERCLEANFILES = 		$(srcdir)/Makefile.in
 
 AM_CPPFLAGS = 			-I$(srcdir)/.. \
 				-I$(srcdir)/../common \
-				-I$(srcdir)/../pkcs11
-
-AM_CFLAGS =			@CPPUNIT_CFLAGS@
+				-I$(srcdir)/../pkcs11 \
+				@CPPUNIT_CFLAGS@
 
 check_PROGRAMS =		p11test
 


### PR DESCRIPTION
@CPPUNIT_CFLAGS@ was not correctly used.
So the cppunit header files were not found if not installed in the
default folder.