### PR TITLE
Issue #280: HMAC with sizes less than L bytes is strongly discouraged…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,9 @@ SoftHSM 2.3.0 - 2017-xx-xx
 Bugfixes:
 * Issue #216: Better handling of CRYPTO_set_locking_callback() for OpenSSL.
 * Issue #265: Fix deriving shared secret with ECC.
+* Issue #280: HMAC with sizes less than L bytes is strongly discouraged.
+  Set a lower bound equal to L bytes in ulMinKeySize and check it when
+  initializing the operation.
 * Issue #281: Fix test of p11 shared library.
   (Patch from Lars Silvén)
 * Issue #289: Minor fix of 'EVP_CipherFinal_ex'.

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -438,7 +438,7 @@ CK_RV SignVerifyTests::generateKey(CK_SESSION_HANDLE hSession, CK_KEY_TYPE keyTy
 #ifndef WITH_BOTAN
 #define GEN_KEY_LEN	75
 #else
-#define GEN_KEY_LEN	55
+#define GEN_KEY_LEN	64
 #endif
 	CK_RV rv;
 	CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -587,7 +587,7 @@ void SignVerifyTests::testHmacSignVerify()
 
 	rv = generateKey(hSessionRW,CKK_SHA224_HMAC,IN_SESSION,IS_PRIVATE,hKey);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	hmacSignVerify(CKM_SHA256_HMAC, hSessionRW, hKey);
+	hmacSignVerify(CKM_SHA224_HMAC, hSessionRW, hKey);
 
 	rv = generateKey(hSessionRW,CKK_SHA256_HMAC,IN_SESSION,IS_PRIVATE,hKey);
 	CPPUNIT_ASSERT(rv == CKR_OK);


### PR DESCRIPTION
…. Set a lower bound equal to L bytes in ulMinKeySize and check it when initializing the operation.