### PR TITLE
Support for CKA_ALLOWED_MECHANISMS

### DIFF
--- a/src/bin/dump/common.h
+++ b/src/bin/dump/common.h
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <map>
+#include <set>
 #include <string>
 #include <stdexcept>
 #include <vector>
@@ -436,6 +437,7 @@ public:
 	uint8_t boolValue;
 	I ulongValue;
 	std::vector<uint8_t> bytestrValue;
+	std::set<I> mechSetValue;
 
 	// Dump an array (in fact an Attribute vector) value
 	void dumpType() const;
@@ -445,6 +447,7 @@ public:
 	bool isBoolean() const;
 	bool isInteger() const;
 	bool isBinary() const;
+	bool isMechSet() const;
 	void dump() const {
 		dumpType();
 		if ((sizeof(type) > 4) &&
@@ -479,6 +482,19 @@ public:
 			dumpULongValue(size);
 			printf("(length %lu)\n", (unsigned long) size);
 			dumpBytes(bytestrValue, true);
+		}
+		else if (isMechSet())
+		{
+			printf("mechanism set attribute\n");
+			I size = mechSetValue.size();
+			dumpULongValue(size);
+			printf("(length %lu)\n", (unsigned long) size);
+			for (typename std::set<I>::const_iterator i = mechSetValue.begin(); i != mechSetValue.end(); ++i)
+			{
+                                dumpULongValue(*i);
+                                dumpCKM(*i, 47);
+                                printf("\n");
+                        }
 		}
 		else
 		{

--- a/src/bin/dump/softhsm2-dump-db.cpp
+++ b/src/bin/dump/softhsm2-dump-db.cpp
@@ -70,6 +70,13 @@ bool Attribute::isBinary() const
 }
 
 template<>
+bool Attribute::isMechSet() const
+{
+	// Mechanism sets are stored as binary in the database
+	return false;
+}
+
+template<>
 void Attribute::dumpType() const
 {
 	if (sizeof(type) == 4)

--- a/src/bin/dump/softhsm2-dump-file.cpp
+++ b/src/bin/dump/softhsm2-dump-file.cpp
@@ -66,6 +66,12 @@ bool Attribute::isBinary() const
 }
 
 template<>
+bool Attribute::isMechSet() const
+{
+	return kind == MECHSET_ATTR;
+}
+
+template<>
 void Attribute::dumpType() const
 {
 	dumpULong(type, true);
@@ -248,6 +254,39 @@ bool readMap(FILE* stream, uint64_t len, std::vector<Attribute>& value)
 				return false;
 			}
 			len -= size;
+		}
+		else if (attr.kind == MECHSET_ATTR)
+		{
+			uint64_t size;
+			if (len < 8)
+			{
+				(void) fsetpos(stream, &pos);
+				return false;
+			}
+			if (!readULong(stream, size))
+			{
+				(void) fsetpos(stream, &pos);
+				return false;
+			}
+			len -= 8;
+
+			if (len < size * 8)
+			{
+				(void) fsetpos(stream, &pos);
+				return false;
+			}
+
+			for (unsigned long i = 0; i < size; i++)
+			{
+				uint64_t mech;
+				if (!readULong(stream, mech))
+				{
+					(void) fsetpos(stream, &pos);
+					return false;
+				}
+				attr.mechSetValue.insert(mech);
+			}
+			len -= size * 8;
 		}
 		else
 		{

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -286,6 +286,10 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 			else
 				attrSize = attr.getByteStringValue().size();
 		}
+		else if (attr.isMechanismTypeSetAttribute())
+		{
+			attrSize = attr.getMechanismTypeSetValue().size() * sizeof(CK_MECHANISM_TYPE);
+		}
 		else if (attr.isAttributeMapAttribute())
 		{
 			attrSize = attr.getAttributeMapValue().size() * sizeof(CK_ATTRIBUTE);
@@ -344,6 +348,15 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 				const unsigned char* attrPtr = attr.getByteStringValue().const_byte_str();
 				memcpy(pValue,attrPtr,attrSize);
 			}
+		}
+		else if (attr.isMechanismTypeSetAttribute())
+		{
+			CK_MECHANISM_TYPE_PTR pTemplate = (CK_MECHANISM_TYPE_PTR) pValue;
+			size_t i = 0;
+
+			std::set<CK_MECHANISM_TYPE> set = attr.getMechanismTypeSetValue();
+			for (std::set<CK_MECHANISM_TYPE>::const_iterator it = set.begin(); it != set.end(); ++it)
+				pTemplate[++i] = *it;
 		}
 		else
 		{

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -2479,3 +2479,36 @@ CK_RV P11AttrUnwrapTemplate::updateAttr(Token* /*token*/, bool /*isPrivate*/, CK
 
 	return CKR_OK;
 }
+
+/*****************************************
+ * CKA_ALLOWED_MECHANISMS
+ *****************************************/
+
+// Set default value
+bool P11AttrAllowedMechanisms::setDefault()
+{
+	std::set<CK_MECHANISM_TYPE> emptyMap;
+	return osobject->setAttribute(type, OSAttribute(emptyMap));
+}
+
+// Update the value if allowed
+CK_RV P11AttrAllowedMechanisms::updateAttr(Token* /*token*/, bool /*isPrivate*/, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int /*op*/)
+{
+	if (ulValueLen == 0 || (ulValueLen % sizeof(CK_MECHANISM_TYPE)) != 0)
+	{
+		return CKR_ATTRIBUTE_VALUE_INVALID;
+	}
+
+	CK_MECHANISM_TYPE_PTR mechType = (CK_MECHANISM_TYPE_PTR) pValue;
+
+	// Fill the set with values
+	std::set<CK_MECHANISM_TYPE> data;
+	for (size_t i = 0; i < ulValueLen / sizeof(CK_MECHANISM_TYPE); ++i, ++mechType)
+	{
+		data.insert(*mechType);
+	}
+
+	// Store data
+	osobject->setAttribute(type, OSAttribute(data));
+	return CKR_OK;
+}

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -131,22 +131,22 @@ CK_ATTRIBUTE_TYPE P11Attribute::getChecks()
 	return checks;
 }
 
-// Retrieve a template array
-static CK_RV retrieveArray(CK_ATTRIBUTE_PTR pTemplate, const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& array)
+// Retrieve a template map
+static CK_RV retrieveAttributeMap(CK_ATTRIBUTE_PTR pTemplate, const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& map)
 {
 	size_t nullcnt = 0;
 
-	for (size_t i = 0; i < array.size(); ++i)
+	for (size_t i = 0; i < map.size(); ++i)
 	{
 		if (pTemplate[i].pValue == NULL_PTR)
 			++nullcnt;
 	}
 
 	// Caller wants type & size
-	if (nullcnt == array.size())
+	if (nullcnt == map.size())
 	{
-		std::map<CK_ATTRIBUTE_TYPE,OSAttribute>::const_iterator a = array.begin();
-		for (size_t i = 0; i < array.size(); ++i, ++a)
+		std::map<CK_ATTRIBUTE_TYPE,OSAttribute>::const_iterator a = map.begin();
+		for (size_t i = 0; i < map.size(); ++i, ++a)
 		{
 			pTemplate[i].type = a->first;
 			const OSAttribute& attr = a->second;
@@ -165,7 +165,7 @@ static CK_RV retrieveArray(CK_ATTRIBUTE_PTR pTemplate, const std::map<CK_ATTRIBU
 			else
 			{
 				// Impossible
-				ERROR_MSG("Internal error: bad attribute in array");
+				ERROR_MSG("Internal error: bad attribute in attribute map");
 
 				return CKR_GENERAL_ERROR;
 			}
@@ -175,10 +175,10 @@ static CK_RV retrieveArray(CK_ATTRIBUTE_PTR pTemplate, const std::map<CK_ATTRIBU
 	}
 
 	// Callers wants to get values
-	for (size_t i = 0; i < array.size(); ++i)
+	for (size_t i = 0; i < map.size(); ++i)
 	{
-		std::map<CK_ATTRIBUTE_TYPE,OSAttribute>::const_iterator a = array.find(pTemplate[i].type);
-		if (a == array.end())
+		std::map<CK_ATTRIBUTE_TYPE,OSAttribute>::const_iterator a = map.find(pTemplate[i].type);
+		if (a == map.end())
 		{
 			pTemplate[i].ulValueLen = CK_UNAVAILABLE_INFORMATION;
 			return CKR_ATTRIBUTE_TYPE_INVALID;
@@ -218,7 +218,7 @@ static CK_RV retrieveArray(CK_ATTRIBUTE_PTR pTemplate, const std::map<CK_ATTRIBU
 		else
 		{
 			// Impossible
-			ERROR_MSG("Internal error: bad attribute in array");
+			ERROR_MSG("Internal error: bad attribute in attribute map");
 
 			return CKR_GENERAL_ERROR;
 		}
@@ -286,9 +286,9 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 			else
 				attrSize = attr.getByteStringValue().size();
 		}
-		else if (attr.isArrayAttribute())
+		else if (attr.isAttributeMapAttribute())
 		{
-			attrSize = attr.getArrayValue().size() * sizeof(CK_ATTRIBUTE);
+			attrSize = attr.getAttributeMapValue().size() * sizeof(CK_ATTRIBUTE);
 		}
 		else
 		{
@@ -347,8 +347,8 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 		}
 		else
 		{
-			// attr is already retrieved and verified to be an Array
-			rv = retrieveArray((CK_ATTRIBUTE_PTR)pValue, attr.getArrayValue());
+			// attr is already retrieved and verified to be an Attribute Map
+			rv = retrieveAttributeMap((CK_ATTRIBUTE_PTR)pValue, attr.getAttributeMapValue());
 		}
 		*pulValueLen = attrSize;
 		return rv;

--- a/src/lib/P11Attributes.h
+++ b/src/lib/P11Attributes.h
@@ -1243,4 +1243,22 @@ protected:
 	virtual CK_RV updateAttr(Token *token, bool isPrivate, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int op);
 };
 
+/*****************************************
+ * CKA_ALLOWED_MECHANISMS
+ *****************************************/
+
+class P11AttrAllowedMechanisms : public P11Attribute
+{
+public:
+	// Constructor
+	P11AttrAllowedMechanisms(OSObject* inobject) : P11Attribute(inobject) { type = CKA_ALLOWED_MECHANISMS; checks = 0; }
+
+protected:
+	// Set the default value of the attribute
+	virtual bool setDefault();
+
+	// Update the value if allowed
+	virtual CK_RV updateAttr(Token *token, bool isPrivate, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int op);
+};
+
 #endif // !_SOFTHSM_V2_P11ATTRIBUTES_H

--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -619,7 +619,7 @@ bool P11KeyObj::init(OSObject *inobject)
 	P11Attribute* attrDerive = new P11AttrDerive(osobject);
 	P11Attribute* attrLocal = new P11AttrLocal(osobject,P11Attribute::ck6);
 	P11Attribute* attrKeyGenMechanism = new P11AttrKeyGenMechanism(osobject);
-	// TODO: CKA_ALLOWED_MECHANISMS is not supported
+	P11Attribute* attrAllowedMechanisms = new P11AttrAllowedMechanisms(osobject);
 
 	// Initialize the attributes
 	if
@@ -630,7 +630,8 @@ bool P11KeyObj::init(OSObject *inobject)
 		!attrEndDate->init() ||
 		!attrDerive->init() ||
 		!attrLocal->init() ||
-		!attrKeyGenMechanism->init()
+		!attrKeyGenMechanism->init() ||
+		!attrAllowedMechanisms->init()
 	)
 	{
 		ERROR_MSG("Could not initialize the attribute");
@@ -641,6 +642,7 @@ bool P11KeyObj::init(OSObject *inobject)
 		delete attrDerive;
 		delete attrLocal;
 		delete attrKeyGenMechanism;
+		delete attrAllowedMechanisms;
 		return false;
 	}
 
@@ -652,6 +654,7 @@ bool P11KeyObj::init(OSObject *inobject)
 	attributes[attrDerive->getType()] = attrDerive;
 	attributes[attrLocal->getType()] = attrLocal;
 	attributes[attrKeyGenMechanism->getType()] = attrKeyGenMechanism;
+	attributes[attrAllowedMechanisms->getType()] = attrAllowedMechanisms;
 
 	initialized = true;
 	return true;

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1953,8 +1953,12 @@ CK_RV SoftHSM::SymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 	}
 
 	// Check if key can be used for encryption
-        if (!key->getBooleanValue(CKA_ENCRYPT, false))
+	if (!key->getBooleanValue(CKA_ENCRYPT, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get the symmetric algorithm matching the mechanism
 	SymAlgo::Type algo = SymAlgo::Unknown;
@@ -2148,7 +2152,7 @@ CK_RV SoftHSM::AsymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMec
 	}
 
 	// Check if key can be used for encryption
-        if (!key->getBooleanValue(CKA_ENCRYPT, false))
+	if (!key->getBooleanValue(CKA_ENCRYPT, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
 
 	// Get the asymmetric algorithm matching the mechanism
@@ -2604,8 +2608,13 @@ CK_RV SoftHSM::SymDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 	}
 
 	// Check if key can be used for decryption
-        if (!key->getBooleanValue(CKA_DECRYPT, false))
+	if (!key->getBooleanValue(CKA_DECRYPT, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get the symmetric algorithm matching the mechanism
 	SymAlgo::Type algo = SymAlgo::Unknown;
@@ -2799,8 +2808,12 @@ CK_RV SoftHSM::AsymDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMec
 	}
 
 	// Check if key can be used for decryption
-        if (!key->getBooleanValue(CKA_DECRYPT, false))
+	if (!key->getBooleanValue(CKA_DECRYPT, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get the asymmetric algorithm matching the mechanism
 	AsymMech::Type mechanism = AsymMech::Unknown;
@@ -3558,8 +3571,12 @@ CK_RV SoftHSM::MacSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechani
 	}
 
 	// Check if key can be used for signing
-        if (!key->getBooleanValue(CKA_SIGN, false))
+	if (!key->getBooleanValue(CKA_SIGN, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get key info
 	CK_KEY_TYPE keyType = key->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED);
@@ -3694,8 +3711,12 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 	}
 
 	// Check if key can be used for signing
-        if (!key->getBooleanValue(CKA_SIGN, false))
+	if (!key->getBooleanValue(CKA_SIGN, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get the asymmetric algorithm matching the mechanism
 	AsymMech::Type mechanism = AsymMech::Unknown;
@@ -4402,8 +4423,12 @@ CK_RV SoftHSM::MacVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 	}
 
 	// Check if key can be used for verifying
-        if (!key->getBooleanValue(CKA_VERIFY, false))
+	if (!key->getBooleanValue(CKA_VERIFY, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get key info
 	CK_KEY_TYPE keyType = key->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED);
@@ -4538,8 +4563,12 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 	}
 
 	// Check if key can be used for verifying
-        if (!key->getBooleanValue(CKA_VERIFY, false))
+	if (!key->getBooleanValue(CKA_VERIFY, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Get the asymmetric algorithm matching the mechanism
 	AsymMech::Type mechanism = AsymMech::Unknown;
@@ -5742,6 +5771,10 @@ CK_RV SoftHSM::C_WrapKey
 	if (wrapKey->getBooleanValue(CKA_WRAP, false) == false)
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
 
+    // Check if the specified mechanism is allowed for the wrapping key
+    if (!isMechanismPermitted(wrapKey, pMechanism))
+		return CKR_MECHANISM_INVALID;
+
 	// Check the to be wrapped key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
 	if (key == NULL_PTR || !key->isValid()) return CKR_KEY_HANDLE_INVALID;
@@ -6111,6 +6144,10 @@ CK_RV SoftHSM::C_UnwrapKey
 	if (unwrapKey->getBooleanValue(CKA_UNWRAP, false) == false)
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
 
+	// Check if the specified mechanism is allowed for the unwrap key
+	if (!isMechanismPermitted(unwrapKey, pMechanism))
+		return CKR_MECHANISM_INVALID;
+
 	// Extract information from the template that is needed to create the object.
 	CK_OBJECT_CLASS objClass;
 	CK_KEY_TYPE keyType;
@@ -6367,8 +6404,12 @@ CK_RV SoftHSM::C_DeriveKey
 	}
 
 	// Check if key can be used for derive
-        if (!key->getBooleanValue(CKA_DERIVE, false))
+	if (!key->getBooleanValue(CKA_DERIVE, false))
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+	// Check if the specified mechanism is allowed for the key
+	if (!isMechanismPermitted(key, pMechanism))
+		return CKR_MECHANISM_INVALID;
 
 	// Extract information from the template that is needed to create the object.
 	CK_OBJECT_CLASS objClass;
@@ -10861,4 +10902,14 @@ CK_RV SoftHSM::MechParamCheckRSAPKCSOAEP(CK_MECHANISM_PTR pMechanism)
 		return CKR_ARGUMENTS_BAD;
 	}
 	return CKR_OK;
+}
+
+bool SoftHSM::isMechanismPermitted(OSObject* key, CK_MECHANISM_PTR pMechanism) {
+	OSAttribute attribute = key->getAttribute(CKA_ALLOWED_MECHANISMS);
+	std::set<CK_MECHANISM_TYPE> allowed = attribute.getMechanismTypeSetValue();
+	if (allowed.empty()) {
+		return true;
+	}
+
+	return allowed.find(pMechanism->mechanism) != allowed.end();
 }

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -5778,13 +5778,13 @@ CK_RV SoftHSM::C_WrapKey
 	{
 		OSAttribute attr = wrapKey->getAttribute(CKA_WRAP_TEMPLATE);
 
-		if (attr.isArrayAttribute())
+		if (attr.isAttributeMapAttribute())
 		{
-			typedef std::map<CK_ATTRIBUTE_TYPE,OSAttribute> array_type;
+			typedef std::map<CK_ATTRIBUTE_TYPE,OSAttribute> attrmap_type;
 
-			const array_type& array = attr.getArrayValue();
+			const attrmap_type& map = attr.getAttributeMapValue();
 
-			for (array_type::const_iterator it = array.begin(); it != array.end(); ++it)
+			for (attrmap_type::const_iterator it = map.begin(); it != map.end(); ++it)
 			{
 				if (!key->attributeExists(it->first))
 				{
@@ -6174,13 +6174,13 @@ CK_RV SoftHSM::C_UnwrapKey
 	{
 		OSAttribute unwrapAttr = unwrapKey->getAttribute(CKA_UNWRAP_TEMPLATE);
 
-		if (unwrapAttr.isArrayAttribute())
+		if (unwrapAttr.isAttributeMapAttribute())
 		{
-			typedef std::map<CK_ATTRIBUTE_TYPE,OSAttribute> array_type;
+			typedef std::map<CK_ATTRIBUTE_TYPE,OSAttribute> attrmap_type;
 
-			const array_type& array = unwrapAttr.getArrayValue();
+			const attrmap_type& map = unwrapAttr.getAttributeMapValue();
 
-			for (array_type::const_iterator it = array.begin(); it != array.end(); ++it)
+			for (attrmap_type::const_iterator it = map.begin(); it != map.end(); ++it)
 			{
 				CK_ATTRIBUTE* attr = NULL;
 				for (CK_ULONG i = 0; i < secretAttribsCount; ++i)

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -430,5 +430,7 @@ private:
 	);
 
 	CK_RV MechParamCheckRSAPKCSOAEP(CK_MECHANISM_PTR pMechanism);
+
+	static bool isMechanismPermitted(OSObject* key, CK_MECHANISM_PTR pMechanism);
 };
 

--- a/src/lib/object_store/DBObject.cpp
+++ b/src/lib/object_store/DBObject.cpp
@@ -654,6 +654,7 @@ static bool decodeAttributeMap(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& map, con
 
 				map.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (attrType, value));
 			}
+			break;
 
 			default:
 			ERROR_MSG("unsupported attribute kind in attribute map");

--- a/src/lib/object_store/DBObject.cpp
+++ b/src/lib/object_store/DBObject.cpp
@@ -396,7 +396,8 @@ enum AttributeKind {
 	akBoolean,
 	akInteger,
 	akBinary,
-	akAttrMap
+	akAttrMap,
+	akMechSet
 };
 
 static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
@@ -508,7 +509,7 @@ static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
 	case CKA_WRAP_TEMPLATE: return akAttrMap;
 	case CKA_UNWRAP_TEMPLATE: return akAttrMap;
 	case CKA_DERIVE_TEMPLATE: return akAttrMap;
-	case CKA_ALLOWED_MECHANISMS: return akUnknown; // TODO: add CKA_ALLOWED_MECHANISMS support
+	case CKA_ALLOWED_MECHANISMS: return akMechSet;
 
 	case CKA_OS_TOKENLABEL: return akBinary;
 	case CKA_OS_TOKENSERIAL: return akBinary;
@@ -517,6 +518,38 @@ static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
 	case CKA_OS_USERPIN: return akBinary;
 
 	default: return akUnknown;
+	}
+}
+
+static bool decodeMechanismTypeSet(std::set<CK_MECHANISM_TYPE>& set, const unsigned char *binary, size_t size)
+{
+	for (size_t pos = 0; pos < size; )
+	{
+		// finished?
+		if (pos == size) break;
+
+		CK_MECHANISM_TYPE mechType;
+		if (pos + sizeof(mechType) > size)
+		{
+			ERROR_MSG("mechanism type set overrun");
+			return false;
+		}
+
+		memcpy(&mechType, binary + pos, sizeof(mechType));
+		pos += sizeof(mechType);
+
+		set.insert(mechType);
+    }
+
+	return true;
+}
+
+static void encodeMechanismTypeSet(ByteString& value, const std::set<CK_MECHANISM_TYPE>& set)
+{
+	for (std::set<CK_MECHANISM_TYPE>::const_iterator i = set.begin(); i != set.end(); ++i)
+	{
+		CK_MECHANISM_TYPE mechType = *i;
+		value += ByteString((unsigned char *) &mechType, sizeof(mechType));
 	}
 }
 
@@ -598,6 +631,30 @@ static bool decodeAttributeMap(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& map, con
 			}
 			break;
 
+			case akMechSet:
+			{
+				unsigned long len;
+				if (pos + sizeof(len) > size)
+				{
+					goto overrun;
+				}
+				memcpy(&len, binary + pos, sizeof(len));
+				pos += sizeof(len);
+
+				if (pos + len > size)
+				{
+					goto overrun;
+				}
+
+				std::set<CK_MECHANISM_TYPE> value;
+				if (!decodeMechanismTypeSet(value, binary + pos, len)) {
+					return false;
+				}
+				pos += len;
+
+				map.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (attrType, value));
+			}
+
 			default:
 			ERROR_MSG("unsupported attribute kind in attribute map");
 
@@ -643,6 +700,18 @@ static bool encodeAttributeMap(ByteString& value, const std::map<CK_ATTRIBUTE_TY
 			value += ByteString((unsigned char*) &attrKind, sizeof(attrKind));
 
 			ByteString val = attr.getByteStringValue();
+			unsigned long len = val.size();
+			value += ByteString((unsigned char*) &len, sizeof(len));
+			value += val;
+		}
+		else if (attr.isMechanismTypeSetAttribute())
+		{
+			AttributeKind attrKind = akMechSet;
+			value += ByteString((unsigned char*) &attrKind, sizeof(attrKind));
+
+			ByteString val;
+			encodeMechanismTypeSet(val, attr.getMechanismTypeSetValue());
+
 			unsigned long len = val.size();
 			value += ByteString((unsigned char*) &len, sizeof(len));
 			value += val;
@@ -784,6 +853,56 @@ OSAttribute *DBObject::accessAttribute(CK_ATTRIBUTE_TYPE type)
 			else
 			{
 				attr = new OSAttribute(ByteString(value,size));
+				(*attrs)[type] = attr;
+				return attr;
+			}
+			return attr;
+		}
+		case akMechSet:
+		{
+			// try to find the attribute in the binary attribute table
+			DB::Statement statement = _connection->prepare(
+					"select value from attribute_binary where type=%lu and object_id=%lld",
+					type,
+					_objectId);
+			if (!statement.isValid())
+			{
+				return NULL;
+			}
+			DB::Result result = _connection->perform(statement);
+			if (!result.isValid())
+			{
+				return NULL;
+			}
+			// Store the attribute in the transaction when it is active.
+			std::map<CK_ATTRIBUTE_TYPE,OSAttribute*> *attrs = &_attributes;
+			if (_transaction)
+				attrs = _transaction;
+
+			const unsigned char *value = result.getBinary(1);
+			size_t size = result.getFieldLength(1);
+
+			std::set<CK_MECHANISM_TYPE> set;
+			if (!decodeMechanismTypeSet(set, value, size))
+			{
+				return NULL;
+			}
+
+			OSAttribute *attr;
+			std::map<CK_ATTRIBUTE_TYPE,OSAttribute*>::iterator it =	 attrs->find(type);
+			if (it != attrs->end())
+			{
+				if (it->second != NULL)
+				{
+					delete it->second;
+				}
+
+				it->second = new OSAttribute(set);
+				attr = it->second;
+			}
+			else
+			{
+				attr = new OSAttribute(set);
 				(*attrs)[type] = attr;
 				return attr;
 			}
@@ -1002,7 +1121,6 @@ bool DBObject::setAttribute(CK_ATTRIBUTE_TYPE type, const OSAttribute& attribute
 	if (attr)
 	{
 		DB::Statement statement;
-		bool bindByteString = true;
 		if (attr->isBooleanAttribute())
 		{
 			// update boolean attribute
@@ -1011,7 +1129,6 @@ bool DBObject::setAttribute(CK_ATTRIBUTE_TYPE type, const OSAttribute& attribute
 					attribute.getBooleanValue() ? 1 : 0,
 					type,
 					_objectId);
-			bindByteString = false;
 		}
 		else if (attr->isUnsignedLongAttribute())
 		{
@@ -1021,7 +1138,6 @@ bool DBObject::setAttribute(CK_ATTRIBUTE_TYPE type, const OSAttribute& attribute
 					static_cast<long long>(attribute.getUnsignedLongValue()),
 					type,
 					_objectId);
-			bindByteString = false;
 		}
 		else if (attr->isByteStringAttribute())
 		{
@@ -1030,7 +1146,19 @@ bool DBObject::setAttribute(CK_ATTRIBUTE_TYPE type, const OSAttribute& attribute
 					"update attribute_binary set value=? where type=%lu and object_id=%lld",
 					type,
 					_objectId);
-			//bindByteString = true;
+			DB::Bindings(statement).bindBlob(1, attribute.getByteStringValue().const_byte_str(), attribute.getByteStringValue().size(), SQLITE_STATIC);
+		}
+		else if (attr->isMechanismTypeSetAttribute())
+		{
+			// update binary attribute
+			ByteString value;
+			encodeMechanismTypeSet(value, attribute.getMechanismTypeSetValue());
+
+			statement = _connection->prepare(
+					"update attribute_binary set value=? where type=%lu and object_id=%lld",
+					type,
+					_objectId);
+			DB::Bindings(statement).bindBlob(1, value.const_byte_str(), value.size(), SQLITE_TRANSIENT);
 		}
 		else if (attr->isAttributeMapAttribute())
 		{
@@ -1046,12 +1174,6 @@ bool DBObject::setAttribute(CK_ATTRIBUTE_TYPE type, const OSAttribute& attribute
 					type,
 					_objectId);
 			DB::Bindings(statement).bindBlob(1, value.const_byte_str(), value.size(), SQLITE_TRANSIENT);
-			bindByteString = false;
-		}
-
-		if (bindByteString)
-		{
-			DB::Bindings(statement).bindBlob(1, attribute.getByteStringValue().const_byte_str(), attribute.getByteStringValue().size(), SQLITE_STATIC);
 		}
 
 		// Statement is valid when a prepared statement has been attached to it.
@@ -1107,6 +1229,18 @@ bool DBObject::setAttribute(CK_ATTRIBUTE_TYPE type, const OSAttribute& attribute
 					_objectId);
 
 		DB::Bindings(statement).bindBlob(1, attribute.getByteStringValue().const_byte_str(), attribute.getByteStringValue().size(), SQLITE_STATIC);
+	}
+	else if (attribute.isMechanismTypeSetAttribute())
+	{
+		// Could not update it, so we need to insert it.
+		ByteString value;
+		encodeMechanismTypeSet(value, attribute.getMechanismTypeSetValue());
+
+		statement = _connection->prepare(
+				"insert into attribute_binary (value,type,object_id) values (?,%lu,%lld)",
+				type,
+				_objectId);
+		DB::Bindings(statement).bindBlob(1, value.const_byte_str(), value.size(), SQLITE_TRANSIENT);
 	}
 	else if (attribute.isAttributeMapAttribute())
 	{
@@ -1184,7 +1318,7 @@ bool DBObject::deleteAttribute(CK_ATTRIBUTE_TYPE type)
 				type,
 				_objectId);
 	}
-	else if (attr->isByteStringAttribute())
+	else if (attr->isByteStringAttribute() || attr -> isMechanismTypeSetAttribute())
 	{
 		// delete binary attribute
 		statement = _connection->prepare(

--- a/src/lib/object_store/File.cpp
+++ b/src/lib/object_store/File.cpp
@@ -372,6 +372,23 @@ bool File::readAttributeMap(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
 			}
 			break;
 
+			case akMechSet:
+			{
+				std::set<CK_MECHANISM_TYPE> val;
+				if (!readMechanismTypeSet(val))
+				{
+					return false;
+				}
+				if (8 + val.size() * 8 > len)
+				{
+					return false;
+				}
+				len -= 8 + val.size() * 8;
+
+				value.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (attrType, val));
+			}
+			break;
+
 			default:
 				return false;
 		}
@@ -498,6 +515,11 @@ bool File::writeAttributeMap(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& valu
 		{
 			ByteString val = attr.getByteStringValue();
 			len += 8 + val.size();
+		}
+		else if (attr.isMechanismTypeSetAttribute())
+		{
+			std::set<CK_MECHANISM_TYPE> val = attr.getMechanismTypeSetValue();
+			len += 8 + val.size() * 8;
 		}
 		else
 		{

--- a/src/lib/object_store/File.cpp
+++ b/src/lib/object_store/File.cpp
@@ -56,7 +56,7 @@ enum AttributeKind {
 	akBoolean,
 	akInteger,
 	akBinary,
-	akArray
+	akAttrMap
 };
 
 // Constructor
@@ -259,8 +259,8 @@ bool File::readBool(bool& value)
 	return true;
 }
 
-// Read an array value; warning: not thread safe without locking!
-bool File::readArray(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
+// Read an attribute map value; warning: not thread safe without locking!
+bool File::readAttributeMap(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
 {
 	if (!valid) return false;
 
@@ -430,8 +430,8 @@ bool File::writeString(const std::string& value)
 	return true;
 }
 
-// Write an array value; warning: not thread safe without locking!
-bool File::writeArray(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
+// Write an attribute map value; warning: not thread safe without locking!
+bool File::writeAttributeMap(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
 {
 	if (!valid) return false;
 

--- a/src/lib/object_store/File.h
+++ b/src/lib/object_store/File.h
@@ -74,6 +74,9 @@ public:
 	// Read a boolean value; warning: not thread safe without locking!
 	bool readBool(bool& value);
 
+	// Read a mechanism type set value; warning: not thread safe without locking!
+	bool readMechanismTypeSet(std::set<CK_MECHANISM_TYPE>& value);
+
 	// Read an array value; warning: not thread safe without locking!
 	bool readAttributeMap(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
 
@@ -88,6 +91,9 @@ public:
 
 	// Write a boolean value; warning: not thread safe without locking!
 	bool writeBool(const bool value);
+
+	// Write a mechanism type set value; warning: not thread safe without locking!
+	bool writeMechanismTypeSet(const std::set<CK_MECHANISM_TYPE>& value);
 
 	// Write an attribute map value; warning: not thread safe without locking!
 	bool writeAttributeMap(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);

--- a/src/lib/object_store/File.h
+++ b/src/lib/object_store/File.h
@@ -75,7 +75,7 @@ public:
 	bool readBool(bool& value);
 
 	// Read an array value; warning: not thread safe without locking!
-	bool readArray(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
+	bool readAttributeMap(std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
 
 	// Write an unsigned long value; warning: not thread safe without locking!
 	bool writeULong(const unsigned long value);
@@ -89,8 +89,8 @@ public:
 	// Write a boolean value; warning: not thread safe without locking!
 	bool writeBool(const bool value);
 
-	// Write an array value; warning: not thread safe without locking!
-	bool writeArray(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
+	// Write an attribute map value; warning: not thread safe without locking!
+	bool writeAttributeMap(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
 
 	// Rewind the file
 	bool rewind();

--- a/src/lib/object_store/OSAttribute.cpp
+++ b/src/lib/object_store/OSAttribute.cpp
@@ -40,7 +40,7 @@ OSAttribute::OSAttribute(const OSAttribute& in)
 	boolValue = in.boolValue;
 	ulongValue = in.ulongValue;
 	byteStrValue = in.byteStrValue;
-	arrayValue = in.arrayValue;
+	attrMapValue = in.attrMapValue;
 }
 
 // Constructor for a boolean type attribute
@@ -71,11 +71,11 @@ OSAttribute::OSAttribute(const ByteString& value)
 	ulongValue = 0;
 }
 
-// Constructor for an array type attribute
+// Constructor for an attribute map type attribute
 OSAttribute::OSAttribute(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
 {
-	arrayValue = value;
-	attributeType = ARRAY;
+	attrMapValue = value;
+	attributeType = ATTRMAP;
 
 	boolValue = false;
 	ulongValue = 0;
@@ -97,9 +97,9 @@ bool OSAttribute::isByteStringAttribute() const
 	return (attributeType == BYTESTR);
 }
 
-bool OSAttribute::isArrayAttribute() const
+bool OSAttribute::isAttributeMapAttribute() const
 {
-	return (attributeType == ARRAY);
+	return (attributeType == ATTRMAP);
 }
 
 // Retrieve the attribute value
@@ -118,9 +118,9 @@ const ByteString& OSAttribute::getByteStringValue() const
 	return byteStrValue;
 }
 
-const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& OSAttribute::getArrayValue() const
+const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& OSAttribute::getAttributeMapValue() const
 {
-	return arrayValue;
+	return attrMapValue;
 }
 
 // Helper for template (aka array) matching

--- a/src/lib/object_store/OSAttribute.cpp
+++ b/src/lib/object_store/OSAttribute.cpp
@@ -148,6 +148,9 @@ const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& OSAttribute::getAttributeMapValue
 
 bool OSAttribute::peekValue(ByteString& value) const
 {
+	size_t counter = 0;
+	CK_MECHANISM_TYPE mech;
+
 	switch (attributeType)
 	{
 		case BOOL:
@@ -164,6 +167,19 @@ bool OSAttribute::peekValue(ByteString& value) const
 			value.resize(byteStrValue.size());
 			memcpy(&value[0], byteStrValue.const_byte_str(), value.size());
 			return true;
+
+		case MECHSET:
+			value.resize(mechSetValue.size() * sizeof(mech));
+			for (std::set<CK_MECHANISM_TYPE>::const_iterator i = mechSetValue.begin(); i != mechSetValue.end(); ++i)
+			{
+				mech = *i;
+				memcpy(&value[0] + counter * sizeof(mech), &mech, sizeof(mech));
+				counter++;
+			}
+			return true;
+
+		case ATTRMAP:
+			return false;
 
 		default:
 			return false;

--- a/src/lib/object_store/OSAttribute.cpp
+++ b/src/lib/object_store/OSAttribute.cpp
@@ -40,6 +40,7 @@ OSAttribute::OSAttribute(const OSAttribute& in)
 	boolValue = in.boolValue;
 	ulongValue = in.ulongValue;
 	byteStrValue = in.byteStrValue;
+	mechSetValue = in.mechSetValue;
 	attrMapValue = in.attrMapValue;
 }
 
@@ -71,6 +72,16 @@ OSAttribute::OSAttribute(const ByteString& value)
 	ulongValue = 0;
 }
 
+// Constructor for a mechanism type set attribute
+OSAttribute::OSAttribute(const std::set<CK_MECHANISM_TYPE>& value)
+{
+	mechSetValue = value;
+	attributeType = MECHSET;
+
+	boolValue = false;
+	ulongValue = 0;
+}
+
 // Constructor for an attribute map type attribute
 OSAttribute::OSAttribute(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value)
 {
@@ -97,6 +108,11 @@ bool OSAttribute::isByteStringAttribute() const
 	return (attributeType == BYTESTR);
 }
 
+bool OSAttribute::isMechanismTypeSetAttribute() const
+{
+	return (attributeType == MECHSET);
+}
+
 bool OSAttribute::isAttributeMapAttribute() const
 {
 	return (attributeType == ATTRMAP);
@@ -116,6 +132,11 @@ unsigned long OSAttribute::getUnsignedLongValue() const
 const ByteString& OSAttribute::getByteStringValue() const
 {
 	return byteStrValue;
+}
+
+const std::set<CK_MECHANISM_TYPE>& OSAttribute::getMechanismTypeSetValue() const
+{
+	return mechSetValue;
 }
 
 const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& OSAttribute::getAttributeMapValue() const

--- a/src/lib/object_store/OSAttribute.h
+++ b/src/lib/object_store/OSAttribute.h
@@ -52,7 +52,7 @@ public:
 	// Constructor for a byte string type attribute
 	OSAttribute(const ByteString& value);
 
-	// Constructor for an array type attribute
+	// Constructor for an attribute map type attribute
 	OSAttribute(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
 
 	// Destructor
@@ -62,13 +62,13 @@ public:
 	bool isBooleanAttribute() const;
 	bool isUnsignedLongAttribute() const;
 	bool isByteStringAttribute() const;
-	bool isArrayAttribute() const;
+	bool isAttributeMapAttribute() const;
 
 	// Retrieve the attribute value
 	bool getBooleanValue() const;
 	unsigned long getUnsignedLongValue() const;
 	const ByteString& getByteStringValue() const;
-	const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& getArrayValue() const;
+	const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& getAttributeMapValue() const;
 
 	// Helper for template (aka array) matching
 	bool peekValue(ByteString& value) const;
@@ -80,7 +80,7 @@ private:
 		BOOL,
 		ULONG,
 		BYTESTR,
-		ARRAY
+		ATTRMAP
 	}
 	attributeType;
 
@@ -88,7 +88,7 @@ private:
 	bool boolValue;
 	unsigned long ulongValue;
 	ByteString byteStrValue;
-	std::map<CK_ATTRIBUTE_TYPE,OSAttribute> arrayValue;
+	std::map<CK_ATTRIBUTE_TYPE,OSAttribute> attrMapValue;
 };
 
 #endif // !_SOFTHSM_V2_OSATTRIBUTE_H

--- a/src/lib/object_store/OSAttribute.h
+++ b/src/lib/object_store/OSAttribute.h
@@ -36,6 +36,7 @@
 #include "config.h"
 #include "ByteString.h"
 #include <map>
+#include <set>
 
 class OSAttribute
 {
@@ -52,6 +53,9 @@ public:
 	// Constructor for a byte string type attribute
 	OSAttribute(const ByteString& value);
 
+	// Constructor for a mechanism type set type attribute
+	OSAttribute(const std::set<CK_MECHANISM_TYPE>& value);
+
 	// Constructor for an attribute map type attribute
 	OSAttribute(const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value);
 
@@ -62,12 +66,14 @@ public:
 	bool isBooleanAttribute() const;
 	bool isUnsignedLongAttribute() const;
 	bool isByteStringAttribute() const;
+	bool isMechanismTypeSetAttribute() const;
 	bool isAttributeMapAttribute() const;
 
 	// Retrieve the attribute value
 	bool getBooleanValue() const;
 	unsigned long getUnsignedLongValue() const;
 	const ByteString& getByteStringValue() const;
+	const std::set<CK_MECHANISM_TYPE>& getMechanismTypeSetValue() const;
 	const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& getAttributeMapValue() const;
 
 	// Helper for template (aka array) matching
@@ -80,6 +86,7 @@ private:
 		BOOL,
 		ULONG,
 		BYTESTR,
+		MECHSET,
 		ATTRMAP
 	}
 	attributeType;
@@ -88,6 +95,7 @@ private:
 	bool boolValue;
 	unsigned long ulongValue;
 	ByteString byteStrValue;
+	std::set<CK_MECHANISM_TYPE> mechSetValue;
 	std::map<CK_ATTRIBUTE_TYPE,OSAttribute> attrMapValue;
 };
 

--- a/src/lib/object_store/ObjectFile.cpp
+++ b/src/lib/object_store/ObjectFile.cpp
@@ -44,7 +44,7 @@
 #define BOOLEAN_ATTR			0x1
 #define ULONG_ATTR			0x2
 #define BYTESTR_ATTR			0x3
-#define ARRAY_ATTR			0x4
+#define ATTRMAP_ATTR			0x4
 
 // Constructor
 ObjectFile::ObjectFile(OSToken* parent, std::string inPath, std::string inLockpath, bool isNew /* = false */)
@@ -430,11 +430,11 @@ void ObjectFile::refresh(bool isFirstTime /* = false */)
 
 			attributes[p11AttrType] = new OSAttribute(value);
 		}
-		else if (osAttrType == ARRAY_ATTR)
+		else if (osAttrType == ATTRMAP_ATTR)
 		{
 			std::map<CK_ATTRIBUTE_TYPE,OSAttribute> value;
 
-			if (!objectFile.readArray(value))
+			if (!objectFile.readAttributeMap(value))
 			{
 				DEBUG_MSG("Corrupt object file %s", path.c_str());
 
@@ -563,12 +563,12 @@ bool ObjectFile::writeAttributes(File &objectFile)
 				return false;
 			}
 		}
-		else if (i->second->isArrayAttribute())
+		else if (i->second->isAttributeMapAttribute())
 		{
-			unsigned long osAttrType = ARRAY_ATTR;
-			const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value = i->second->getArrayValue();
+			unsigned long osAttrType = ATTRMAP_ATTR;
+			const std::map<CK_ATTRIBUTE_TYPE,OSAttribute>& value = i->second->getAttributeMapValue();
 
-			if (!objectFile.writeULong(osAttrType) || !objectFile.writeArray(value))
+			if (!objectFile.writeULong(osAttrType) || !objectFile.writeAttributeMap(value))
 			{
 				DEBUG_MSG("Failed to write attribute to object %s", path.c_str());
 

--- a/src/lib/object_store/test/DBObjectTests.cpp
+++ b/src/lib/object_store/test/DBObjectTests.cpp
@@ -289,7 +289,7 @@ void test_a_dbobject_with_an_object::should_store_binary_attributes()
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_MODULUS).getByteStringValue() == value1);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_COEFFICIENT).getByteStringValue() == value2);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3); 
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PUBLIC_EXPONENT).getByteStringValue() == value4);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).getByteStringValue() == value5);
 
@@ -343,6 +343,9 @@ void test_a_dbobject_with_an_object::should_store_attrmap_attributes()
 	bool value1 = true;
 	unsigned long value2 = 0x87654321;
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -353,11 +356,13 @@ void test_a_dbobject_with_an_object::should_store_attrmap_attributes()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3);
+		OSAttribute attr4(value4);
 
 		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattr;
 		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_TOKEN, attr1));
 		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_PRIME_BITS, attr2));
-		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_VALUE_BITS, attr3));
+		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_VALUE, attr3));
+		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_ALLOWED_MECHANISMS, attr4));
 		OSAttribute attra(mattr);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_WRAP_TEMPLATE, attra));
@@ -374,16 +379,19 @@ void test_a_dbobject_with_an_object::should_store_attrmap_attributes()
 
 		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb =
 				testObject.getAttribute(CKA_WRAP_TEMPLATE).getAttributeMapValue();
-		CPPUNIT_ASSERT(mattrb.size() == 3);
+		CPPUNIT_ASSERT(mattrb.size() == 4);
 		CPPUNIT_ASSERT(mattrb.find(CKA_TOKEN) != mattrb.end());
 		CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).getBooleanValue() == true);
 		CPPUNIT_ASSERT(mattrb.find(CKA_PRIME_BITS) != mattrb.end());
 		CPPUNIT_ASSERT(mattrb.at(CKA_PRIME_BITS).isUnsignedLongAttribute());
 		CPPUNIT_ASSERT(mattrb.at(CKA_PRIME_BITS).getUnsignedLongValue() == 0x87654321);
-		CPPUNIT_ASSERT(mattrb.find(CKA_VALUE_BITS) != mattrb.end());
-		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE_BITS).isByteStringAttribute());
-		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE_BITS).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(mattrb.find(CKA_VALUE) != mattrb.end());
+		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(mattrb.find(CKA_ALLOWED_MECHANISMS) != mattrb.end());
+		CPPUNIT_ASSERT(mattrb.at(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
+		CPPUNIT_ASSERT(mattrb.at(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 	}
 }
 
@@ -392,6 +400,9 @@ void test_a_dbobject_with_an_object::should_store_mixed_attributes()
 	bool value1 = true;
 	unsigned long value2 = 0x87654321;
 	unsigned long value3 = 0xBDEBDBED;
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -402,10 +413,12 @@ void test_a_dbobject_with_an_object::should_store_mixed_attributes()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3);
+		OSAttribute attr4(value4);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 	}
 
 	// Now read back the object
@@ -417,15 +430,18 @@ void test_a_dbobject_with_an_object::should_store_mixed_attributes()
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_TOKEN));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_PRIME_BITS));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE_BITS));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue());
 		CPPUNIT_ASSERT_EQUAL(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue(), value2);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 	}
 }
 
@@ -493,6 +509,12 @@ void test_a_dbobject_with_an_object::can_refresh_attributes()
 	ByteString value2 = "BDEBDBEDBBDBEBDEBE792759537328";
 	ByteString value2a = "466487346943785684957634";
 	ByteString value3 = "0102010201020102010201020102010201020102";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
+	std::set<CK_MECHANISM_TYPE> value4a;
+	value4a.insert(CKM_SHA384);
+	value4a.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -502,9 +524,11 @@ void test_a_dbobject_with_an_object::can_refresh_attributes()
 
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
+		OSAttribute attr4(value4);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_SIGN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_SUBJECT, attr2));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 	}
 
 	// Now read back the object
@@ -515,29 +539,36 @@ void test_a_dbobject_with_an_object::can_refresh_attributes()
 
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_SIGN));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_SUBJECT));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SIGN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SIGN).getBooleanValue());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).getByteStringValue() == value2);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 
 		OSAttribute attr1(value1a);
 		OSAttribute attr2(value2a);
+		OSAttribute attr4(value4a);
 
 		// Change the attributes
 		CPPUNIT_ASSERT(testObject.isValid());
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_SIGN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_SUBJECT, attr2));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 
 		// Check the attributes
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SIGN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SIGN).getBooleanValue() == value1a);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).getByteStringValue() == value2a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 		// Open the object a second time
 		DBObject testObject2(connection);
@@ -547,9 +578,11 @@ void test_a_dbobject_with_an_object::can_refresh_attributes()
 		// Check the attributes on the second instance
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_SIGN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_SUBJECT).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_SIGN).getBooleanValue() == value1a);
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_SUBJECT).getByteStringValue() == value2a);
+		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 		// Add an attribute on the second object
 		OSAttribute attr3(value3);
@@ -589,16 +622,21 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	unsigned long value2 = 0x87654321;
 	unsigned long value3 = 0xBDEBDBED;
 	ByteString value4 = "AAAAAAAAAAAAAAAFFFFFFFFFFFFFFF";
+	std::set<CK_MECHANISM_TYPE> value5;
+	value5.insert(CKM_SHA256);
+	value5.insert(CKM_SHA512);
 
 	OSAttribute attr1(value1);
 	OSAttribute attr2(value2);
 	OSAttribute attr3(value3);
 	OSAttribute attr4(value4);
+	OSAttribute attr5(value5);
 
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ID, attr4));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr5));
 
 	// Create secondary instance for the same object.
 	// This needs to have a different connection to the database to simulate
@@ -612,23 +650,29 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	// Check that the attributes have the same values as set on testObject.
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).getByteStringValue() == value4);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5);
 
 	// New values
 	bool value1a = false;
 	unsigned long value2a = 0x12345678;
 	unsigned long value3a = 0xABABABAB;
 	ByteString value4a = "EDEDEDEDEDEDEDEDEDEDEDEDEDEDED";
+	std::set<CK_MECHANISM_TYPE> value5a;
+	value5a.insert(CKM_SHA384);
+	value5a.insert(CKM_SHA512);
 
 	OSAttribute attr1a(value1a);
 	OSAttribute attr2a(value2a);
 	OSAttribute attr3a(value3a);
 	OSAttribute attr4a(value4a);
+	OSAttribute attr5a(value5a);
 
 	// Start transaction on object
 	CPPUNIT_ASSERT(testObject.startTransaction(DBObject::ReadWrite));
@@ -638,28 +682,33 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2a));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3a));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ID, attr4a));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr5a));
 
 	// Verify that the attributes were set
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ID).getByteStringValue() == value4a);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5a);
 
 	// Verify that they are unchanged on the other instance
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).getByteStringValue() == value4);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5);
 
 	// Commit the transaction
 	CPPUNIT_ASSERT(testObject.commitTransaction());
@@ -670,11 +719,13 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	// NOTE: 3 attributes below cannot be modified after creation and therefore are not required to propagate.
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() != value1a);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() != value2a);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() != value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() != value5a);
 
 	// CKA_ID attribute can be modified after creation and therefore should have propagated.
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).getByteStringValue() == value4a);
@@ -687,17 +738,20 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ID, attr4));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr5));
 
 	// Verify that the attributes were set
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ID).getByteStringValue() == value4);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5);
 
 	// Create a fresh third instance for the same object to force the data to be retrieved from the database.
 	DBObject testObject3(connection2);
@@ -709,12 +763,14 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	// Verify that the attributes from the database are still hodling the same value as when the transaction started.
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3a);
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ID).getByteStringValue() == value4a);
+	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5a);
 
 	// Abort the transaction
 	CPPUNIT_ASSERT(testObject.abortTransaction());
@@ -725,24 +781,28 @@ void test_a_dbobject_with_an_object::should_use_transactions()
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	// After aborting a transaction the testObject should be back to pre transaction state.
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ID).getByteStringValue() == value4a);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5a);
 
 	// Verify that testObject3 still has the original values.
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_VALUE_BITS).isUnsignedLongAttribute());
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ID).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	// Verify that testObject3 still has the original values.
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_VALUE_BITS).getUnsignedLongValue() == value3a);
 	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ID).getByteStringValue() == value4a);
+	CPPUNIT_ASSERT(testObject3.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value5a);
 }
 
 void test_a_dbobject_with_an_object::should_fail_to_delete()

--- a/src/lib/object_store/test/DBObjectTests.cpp
+++ b/src/lib/object_store/test/DBObjectTests.cpp
@@ -302,7 +302,7 @@ void test_a_dbobject_with_an_object::should_store_binary_attributes()
 	}
 }
 
-void test_a_dbobject_with_an_object::should_store_array_attributes()
+void test_a_dbobject_with_an_object::should_store_attrmap_attributes()
 {
 	bool value1 = true;
 	unsigned long value2 = 0x87654321;
@@ -336,7 +336,8 @@ void test_a_dbobject_with_an_object::should_store_array_attributes()
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_WRAP_TEMPLATE));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_UNWRAP_TEMPLATE));
 
-		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb = testObject.getAttribute(CKA_WRAP_TEMPLATE).getArrayValue();
+		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb =
+				testObject.getAttribute(CKA_WRAP_TEMPLATE).getAttributeMapValue();
 		CPPUNIT_ASSERT(mattrb.size() == 3);
 		CPPUNIT_ASSERT(mattrb.find(CKA_TOKEN) != mattrb.end());
 		CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).isBooleanAttribute());

--- a/src/lib/object_store/test/DBObjectTests.cpp
+++ b/src/lib/object_store/test/DBObjectTests.cpp
@@ -302,6 +302,42 @@ void test_a_dbobject_with_an_object::should_store_binary_attributes()
 	}
 }
 
+void test_a_dbobject_with_an_object::should_store_mechtypeset_attributes()
+{
+
+	// Create the test object
+	{
+		DBObject testObject(connection);
+		CPPUNIT_ASSERT(testObject.find(1));
+		CPPUNIT_ASSERT(testObject.isValid());
+
+		std::set<CK_MECHANISM_TYPE> set;
+		set.insert(CKM_SHA256);
+		set.insert(CKM_SHA512);
+		OSAttribute attr(set);
+
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr));
+	}
+
+	// Now read back the object
+	{
+		DBObject testObject(connection);
+		CPPUNIT_ASSERT(testObject.find(1));
+		CPPUNIT_ASSERT(testObject.isValid());
+
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
+
+		std::set<CK_MECHANISM_TYPE> retrieved =
+				testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue();
+
+		CPPUNIT_ASSERT(retrieved.size() == 2);
+		CPPUNIT_ASSERT(retrieved.find(CKM_SHA256) != retrieved.end());
+		CPPUNIT_ASSERT(retrieved.find(CKM_SHA384) == retrieved.end());
+		CPPUNIT_ASSERT(retrieved.find(CKM_SHA512) != retrieved.end());
+	}
+}
+
 void test_a_dbobject_with_an_object::should_store_attrmap_attributes()
 {
 	bool value1 = true;

--- a/src/lib/object_store/test/DBObjectTests.h
+++ b/src/lib/object_store/test/DBObjectTests.h
@@ -63,7 +63,7 @@ class test_a_dbobject_with_an_object : public test_a_dbobject
 	CPPUNIT_TEST(should_store_boolean_attributes);
 	CPPUNIT_TEST(should_store_unsigned_long_attributes);
 	CPPUNIT_TEST(should_store_binary_attributes);
-	CPPUNIT_TEST(should_store_array_attributes);
+	CPPUNIT_TEST(should_store_attrmap_attributes);
 	CPPUNIT_TEST(should_store_mixed_attributes);
 	CPPUNIT_TEST(should_store_double_attributes);
 	CPPUNIT_TEST(can_refresh_attributes);
@@ -79,7 +79,7 @@ public:
 	void should_store_boolean_attributes();
 	void should_store_unsigned_long_attributes();
 	void should_store_binary_attributes();
-	void should_store_array_attributes();
+	void should_store_attrmap_attributes();
 	void should_store_mixed_attributes();
 	void should_store_double_attributes();
 	void can_refresh_attributes();

--- a/src/lib/object_store/test/DBObjectTests.h
+++ b/src/lib/object_store/test/DBObjectTests.h
@@ -63,6 +63,7 @@ class test_a_dbobject_with_an_object : public test_a_dbobject
 	CPPUNIT_TEST(should_store_boolean_attributes);
 	CPPUNIT_TEST(should_store_unsigned_long_attributes);
 	CPPUNIT_TEST(should_store_binary_attributes);
+	CPPUNIT_TEST(should_store_mechtypeset_attributes);
 	CPPUNIT_TEST(should_store_attrmap_attributes);
 	CPPUNIT_TEST(should_store_mixed_attributes);
 	CPPUNIT_TEST(should_store_double_attributes);
@@ -79,6 +80,7 @@ public:
 	void should_store_boolean_attributes();
 	void should_store_unsigned_long_attributes();
 	void should_store_binary_attributes();
+    void should_store_mechtypeset_attributes();
 	void should_store_attrmap_attributes();
 	void should_store_mixed_attributes();
 	void should_store_double_attributes();

--- a/src/lib/object_store/test/FileTests.cpp
+++ b/src/lib/object_store/test/FileTests.cpp
@@ -100,7 +100,7 @@ void FileTests::testCreateNotCreate()
 	// Test pre-condition
 	CPPUNIT_ASSERT(!exists("nonExistentFile"));
 	CPPUNIT_ASSERT(!exists("nonExistentFile2"));
-	
+
 	// Attempt to open a file known not to exist
 #ifndef _WIN32
 	File doesntExist("testdir/nonExistentFile", true, true, false);
@@ -162,6 +162,9 @@ void FileTests::testWriteRead()
 
 	// More test data
 	std::string testString = "This is a test of the File class";
+	std::set<CK_MECHANISM_TYPE> testSet;
+	testSet.insert(CKM_RSA_PKCS);
+	testSet.insert(CKM_SHA256_RSA_PKCS);
 
 	// Create a file for writing
 	{
@@ -185,6 +188,9 @@ void FileTests::testWriteRead()
 
 		// Write a string into the file
 		CPPUNIT_ASSERT(newFile.writeString(testString));
+
+		// Write a set into the file
+		CPPUNIT_ASSERT(newFile.writeMechanismTypeSet(testSet));
 	}
 
 	CPPUNIT_ASSERT(exists("newFile"));
@@ -222,6 +228,12 @@ void FileTests::testWriteRead()
 
 		CPPUNIT_ASSERT(newFile.readString(stringVal));
 		CPPUNIT_ASSERT(!testString.compare(stringVal));
+
+		// Read back the set value
+		std::set<CK_MECHANISM_TYPE> setVal;
+
+		CPPUNIT_ASSERT(newFile.readMechanismTypeSet(setVal));
+		CPPUNIT_ASSERT(setVal == testSet);
 
 		// Check for EOF
 		CPPUNIT_ASSERT(!newFile.readBool(b1));
@@ -284,7 +296,7 @@ void FileTests::testSeek()
 
 	// Seek to the start of second byte string
 	CPPUNIT_ASSERT(testFile.seek(8+9));
-	
+
 	// Read it
 	ByteString trr2;
 

--- a/src/lib/object_store/test/ObjectFileTests.cpp
+++ b/src/lib/object_store/test/ObjectFileTests.cpp
@@ -270,6 +270,50 @@ void ObjectFileTests::testByteStrAttr()
 	}
 }
 
+void ObjectFileTests::testMechTypeSetAttr()
+{
+	// Create the test object
+	{
+#ifndef _WIN32
+		ObjectFile testObject(NULL, "testdir/test.object", "testdir/test.lock", true);
+#else
+		ObjectFile testObject(NULL, "testdir\\test.object", "testdir\\test.lock", true);
+#endif
+
+		CPPUNIT_ASSERT(testObject.isValid());
+
+		std::set<CK_MECHANISM_TYPE> set;
+		set.insert(CKM_SHA256);
+		set.insert(CKM_SHA512);
+		OSAttribute attr(set);
+
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr));
+	}
+
+	// Now read back the object
+	{
+#ifndef _WIN32
+		ObjectFile testObject(NULL, "testdir/test.object", "testdir/test.lock");
+#else
+		ObjectFile testObject(NULL, "testdir\\test.object", "testdir\\test.lock");
+#endif
+
+		CPPUNIT_ASSERT(testObject.isValid());
+
+
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
+
+		std::set<CK_MECHANISM_TYPE> retrieved =
+				testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue();
+
+		CPPUNIT_ASSERT(retrieved.size() == 2);
+		CPPUNIT_ASSERT(retrieved.find(CKM_SHA256) != retrieved.end());
+		CPPUNIT_ASSERT(retrieved.find(CKM_SHA384) == retrieved.end());
+		CPPUNIT_ASSERT(retrieved.find(CKM_SHA512) != retrieved.end());
+	}
+}
+
 void ObjectFileTests::testAttrMapAttr()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";

--- a/src/lib/object_store/test/ObjectFileTests.cpp
+++ b/src/lib/object_store/test/ObjectFileTests.cpp
@@ -227,7 +227,7 @@ void ObjectFileTests::testByteStrAttr()
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_MODULUS, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_COEFFICIENT, attr2));
-		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PUBLIC_EXPONENT, attr4));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_SUBJECT, attr5));
 	}
@@ -244,20 +244,20 @@ void ObjectFileTests::testByteStrAttr()
 
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_MODULUS));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_COEFFICIENT));
-		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE_BITS));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_PUBLIC_EXPONENT));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_SUBJECT));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_MODULUS).isByteStringAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_COEFFICIENT).isByteStringAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PUBLIC_EXPONENT).isByteStringAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).isByteStringAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_MODULUS).getByteStringValue() == value1);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_COEFFICIENT).getByteStringValue() == value2);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PUBLIC_EXPONENT).getByteStringValue() == value4);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_SUBJECT).getByteStringValue() == value5);
 
@@ -317,6 +317,9 @@ void ObjectFileTests::testMechTypeSetAttr()
 void ObjectFileTests::testAttrMapAttr()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -334,11 +337,13 @@ void ObjectFileTests::testAttrMapAttr()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3);
+		OSAttribute attr4(value4);
 
 		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattr;
 		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_TOKEN, attr1));
 		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_PRIME_BITS, attr2));
-		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_VALUE_BITS, attr3));
+		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_VALUE, attr3));
+		mattr.insert(std::pair<CK_ATTRIBUTE_TYPE,OSAttribute> (CKA_ALLOWED_MECHANISMS, attr4));
 		OSAttribute attra(mattr);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_WRAP_TEMPLATE, attra));
@@ -359,22 +364,28 @@ void ObjectFileTests::testAttrMapAttr()
 
 		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb =
 				testObject.getAttribute(CKA_WRAP_TEMPLATE).getAttributeMapValue();
-		CPPUNIT_ASSERT(mattrb.size() == 3);
+		CPPUNIT_ASSERT(mattrb.size() == 4);
 		CPPUNIT_ASSERT(mattrb.find(CKA_TOKEN) != mattrb.end());
 		CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).getBooleanValue() == true);
 		CPPUNIT_ASSERT(mattrb.find(CKA_PRIME_BITS) != mattrb.end());
 		CPPUNIT_ASSERT(mattrb.at(CKA_PRIME_BITS).isUnsignedLongAttribute());
 		CPPUNIT_ASSERT(mattrb.at(CKA_PRIME_BITS).getUnsignedLongValue() == 0x87654321);
-		CPPUNIT_ASSERT(mattrb.find(CKA_VALUE_BITS) != mattrb.end());
-		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE_BITS).isByteStringAttribute());
-		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE_BITS).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(mattrb.find(CKA_VALUE) != mattrb.end());
+		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(mattrb.at(CKA_VALUE).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(mattrb.find(CKA_ALLOWED_MECHANISMS) != mattrb.end());
+		CPPUNIT_ASSERT(mattrb.at(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
+		CPPUNIT_ASSERT(mattrb.at(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 	}
 }
 
 void ObjectFileTests::testMixedAttr()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -392,10 +403,12 @@ void ObjectFileTests::testMixedAttr()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3);
+		OSAttribute attr4(value4);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 	}
 
 	// Now read back the object
@@ -410,16 +423,19 @@ void ObjectFileTests::testMixedAttr()
 
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_TOKEN));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_PRIME_BITS));
-		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE_BITS));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == true);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == 0x87654321);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 	}
 }
 
@@ -427,6 +443,12 @@ void ObjectFileTests::testDoubleAttr()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
 	ByteString value3a = "466487346943785684957634";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
+	std::set<CK_MECHANISM_TYPE> value4a;
+	value4a.insert(CKM_SHA384);
+	value4a.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -444,10 +466,12 @@ void ObjectFileTests::testDoubleAttr()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3);
+		OSAttribute attr4(value4);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 	}
 
 	// Now read back the object
@@ -462,16 +486,19 @@ void ObjectFileTests::testDoubleAttr()
 
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_TOKEN));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_PRIME_BITS));
-		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE_BITS));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == true);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == 0x87654321);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 
 		bool value1 = false;
 		unsigned long value2 = 0x76767676;
@@ -479,22 +506,26 @@ void ObjectFileTests::testDoubleAttr()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3a);
+		OSAttribute attr4(value4a);
 
 		// Change the attributes
 		CPPUNIT_ASSERT(testObject.isValid());
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 
 		// Check the attributes
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 	}
 
 	// Now re-read back the object
@@ -509,19 +540,22 @@ void ObjectFileTests::testDoubleAttr()
 
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_TOKEN));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_PRIME_BITS));
-		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE_BITS));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		bool value1 = false;
 		unsigned long value2 = 0x76767676;
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 	}
 }
 
@@ -529,6 +563,12 @@ void ObjectFileTests::testRefresh()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
 	ByteString value3a = "466487346943785684957634";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
+	std::set<CK_MECHANISM_TYPE> value4a;
+	value4a.insert(CKM_SHA384);
+	value4a.insert(CKM_SHA512);
 
 	// Create the test object
 	{
@@ -546,10 +586,12 @@ void ObjectFileTests::testRefresh()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3);
+		OSAttribute attr4(value4);
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 	}
 
 	// Now read back the object
@@ -564,16 +606,19 @@ void ObjectFileTests::testRefresh()
 
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_TOKEN));
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_PRIME_BITS));
-		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE_BITS));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_VALUE));
+		CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_ID));
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == true);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == 0x87654321);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 
 		bool value1 = false;
 		unsigned long value2 = 0x76767676;
@@ -581,22 +626,26 @@ void ObjectFileTests::testRefresh()
 		OSAttribute attr1(value1);
 		OSAttribute attr2(value2);
 		OSAttribute attr3(value3a);
+		OSAttribute attr4(value4a);
 
 		// Change the attributes
 		CPPUNIT_ASSERT(testObject.isValid());
 
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 		CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+		CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 
 		// Check the attributes
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 		CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 		// Open the object a second time
 #ifndef _WIN32
@@ -610,19 +659,21 @@ void ObjectFileTests::testRefresh()
 		// Check the attributes on the second instance
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).isByteStringAttribute());
+		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 		// Add an attribute on the second object
 		ByteString id = "0102010201020102010201020102010201020102";
 
-		OSAttribute attr4(id);
+		OSAttribute attr5(id);
 
-		CPPUNIT_ASSERT(testObject2.setAttribute(CKA_ID, attr4));
-		
+		CPPUNIT_ASSERT(testObject2.setAttribute(CKA_ID, attr5));
+
 		// Check the attribute
 		CPPUNIT_ASSERT(testObject2.attributeExists(CKA_ID));
 		CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ID).isByteStringAttribute());
@@ -690,14 +741,19 @@ void ObjectFileTests::testTransactions()
 	bool value1 = true;
 	unsigned long value2 = 0x87654321;
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
+	std::set<CK_MECHANISM_TYPE> value4;
+	value4.insert(CKM_SHA256);
+	value4.insert(CKM_SHA512);
 
 	OSAttribute attr1(value1);
 	OSAttribute attr2(value2);
 	OSAttribute attr3(value3);
+	OSAttribute attr4(value4);
 
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 
 	// Create secondary instance for the same object
 #ifndef _WIN32
@@ -711,20 +767,26 @@ void ObjectFileTests::testTransactions()
 	// Check that it has the same attributes
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).getByteStringValue() == value3);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 
 	// New values
 	bool value1a = false;
 	unsigned long value2a = 0x12345678;
 	ByteString value3a = "ABABABABABABABABABABABABABABAB";
+	std::set<CK_MECHANISM_TYPE> value4a;
+	value4a.insert(CKM_SHA384);
+	value4a.insert(CKM_SHA512);
 
 	OSAttribute attr1a(value1a);
 	OSAttribute attr2a(value2a);
 	OSAttribute attr3a(value3a);
+	OSAttribute attr4a(value4a);
 
 	// Start transaction on object
 	CPPUNIT_ASSERT(testObject.startTransaction(ObjectFile::ReadWrite));
@@ -732,26 +794,31 @@ void ObjectFileTests::testTransactions()
 	// Change the attributes
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1a));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2a));
-	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3a));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3a));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4a));
 
 	// Verify that the attributes were set
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 	// Verify that they are unchanged on the other instance
 	CPPUNIT_ASSERT(testObject2.isValid());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).getByteStringValue() == value3);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 
 	// Commit the transaction
 	CPPUNIT_ASSERT(testObject.commitTransaction());
@@ -760,11 +827,13 @@ void ObjectFileTests::testTransactions()
 	CPPUNIT_ASSERT(testObject2.isValid());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 	// Start transaction on object
 	CPPUNIT_ASSERT(testObject.startTransaction(ObjectFile::ReadWrite));
@@ -772,26 +841,31 @@ void ObjectFileTests::testTransactions()
 	// Change the attributes
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_TOKEN, attr1));
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_PRIME_BITS, attr2));
-	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE_BITS, attr3));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_VALUE, attr3));
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr4));
 
 	// Verify that the attributes were set
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2);
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4);
 
 	// Verify that they are unchanged on the other instance
 	CPPUNIT_ASSERT(testObject2.isValid());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 	// Abort the transaction
 	CPPUNIT_ASSERT(testObject.abortTransaction());
@@ -799,20 +873,24 @@ void ObjectFileTests::testTransactions()
 	// Verify that they are unchanged on both instances
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 
 	CPPUNIT_ASSERT(testObject2.isValid());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).isBooleanAttribute());
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).isUnsignedLongAttribute());
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).isByteStringAttribute());
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
 
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_TOKEN).getBooleanValue() == value1a);
 	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_PRIME_BITS).getUnsignedLongValue() == value2a);
-	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_VALUE).getByteStringValue() == value3a);
+	CPPUNIT_ASSERT(testObject2.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue() == value4a);
 }
 
 void ObjectFileTests::testDestroyObjectFails()

--- a/src/lib/object_store/test/ObjectFileTests.cpp
+++ b/src/lib/object_store/test/ObjectFileTests.cpp
@@ -270,7 +270,7 @@ void ObjectFileTests::testByteStrAttr()
 	}
 }
 
-void ObjectFileTests::testArrayAttr()
+void ObjectFileTests::testAttrMapAttr()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
 
@@ -313,7 +313,8 @@ void ObjectFileTests::testArrayAttr()
 		CPPUNIT_ASSERT(testObject.attributeExists(CKA_WRAP_TEMPLATE));
 		CPPUNIT_ASSERT(!testObject.attributeExists(CKA_UNWRAP_TEMPLATE));
 
-		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb = testObject.getAttribute(CKA_WRAP_TEMPLATE).getArrayValue();
+		std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb =
+				testObject.getAttribute(CKA_WRAP_TEMPLATE).getAttributeMapValue();
 		CPPUNIT_ASSERT(mattrb.size() == 3);
 		CPPUNIT_ASSERT(mattrb.find(CKA_TOKEN) != mattrb.end());
 		CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).isBooleanAttribute());

--- a/src/lib/object_store/test/ObjectFileTests.h
+++ b/src/lib/object_store/test/ObjectFileTests.h
@@ -41,6 +41,7 @@ class ObjectFileTests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testBoolAttr);
 	CPPUNIT_TEST(testULongAttr);
 	CPPUNIT_TEST(testByteStrAttr);
+	CPPUNIT_TEST(testMechTypeSetAttr);
 	CPPUNIT_TEST(testAttrMapAttr);
 	CPPUNIT_TEST(testMixedAttr);
 	CPPUNIT_TEST(testDoubleAttr);
@@ -54,6 +55,7 @@ public:
 	void testBoolAttr();
 	void testULongAttr();
 	void testByteStrAttr();
+	void testMechTypeSetAttr();
 	void testAttrMapAttr();
 	void testMixedAttr();
 	void testDoubleAttr();

--- a/src/lib/object_store/test/ObjectFileTests.h
+++ b/src/lib/object_store/test/ObjectFileTests.h
@@ -41,7 +41,7 @@ class ObjectFileTests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testBoolAttr);
 	CPPUNIT_TEST(testULongAttr);
 	CPPUNIT_TEST(testByteStrAttr);
-	CPPUNIT_TEST(testArrayAttr);
+	CPPUNIT_TEST(testAttrMapAttr);
 	CPPUNIT_TEST(testMixedAttr);
 	CPPUNIT_TEST(testDoubleAttr);
 	CPPUNIT_TEST(testRefresh);
@@ -54,7 +54,7 @@ public:
 	void testBoolAttr();
 	void testULongAttr();
 	void testByteStrAttr();
-	void testArrayAttr();
+	void testAttrMapAttr();
 	void testMixedAttr();
 	void testDoubleAttr();
 	void testRefresh();

--- a/src/lib/object_store/test/SessionObjectTests.cpp
+++ b/src/lib/object_store/test/SessionObjectTests.cpp
@@ -52,7 +52,7 @@ void SessionObjectTests::tearDown()
 
 void SessionObjectTests::testBoolAttr()
 {
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -106,7 +106,7 @@ void SessionObjectTests::testBoolAttr()
 
 void SessionObjectTests::testULongAttr()
 {
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -166,7 +166,7 @@ void SessionObjectTests::testByteStrAttr()
 	ByteString value4 = "98A7E5D798A7E5D798A7E5D798A7E5D798A7E5D798A7E5D7";
 	ByteString value5 = "ABCDABCDABCDABCDABCDABCDABCDABCD";
 
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -209,6 +209,34 @@ void SessionObjectTests::testByteStrAttr()
 	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ISSUER, attr6));
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ISSUER).isByteStringAttribute());
 	CPPUNIT_ASSERT(testObject.getByteStringValue(CKA_ISSUER) == value6);
+}
+
+void SessionObjectTests::testMechTypeSetAttr()
+{
+	SessionObject testObject(NULL, 1, 1);
+
+	CPPUNIT_ASSERT(testObject.isValid());
+
+	std::set<CK_MECHANISM_TYPE> set;
+	set.insert(CKM_SHA256);
+	set.insert(CKM_SHA512);
+
+	OSAttribute attr(set);
+
+	CPPUNIT_ASSERT(testObject.setAttribute(CKA_ALLOWED_MECHANISMS, attr));
+	CPPUNIT_ASSERT(testObject.isValid());
+
+	CPPUNIT_ASSERT(testObject.attributeExists(CKA_ALLOWED_MECHANISMS));
+
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_ALLOWED_MECHANISMS).isMechanismTypeSetAttribute());
+
+	std::set<CK_MECHANISM_TYPE> retrieved =
+			testObject.getAttribute(CKA_ALLOWED_MECHANISMS).getMechanismTypeSetValue();
+
+	CPPUNIT_ASSERT(retrieved.size() == 2);
+	CPPUNIT_ASSERT(retrieved.find(CKM_SHA256) != retrieved.end());
+	CPPUNIT_ASSERT(retrieved.find(CKM_SHA384) == retrieved.end());
+	CPPUNIT_ASSERT(retrieved.find(CKM_SHA512) != retrieved.end());
 }
 
 void SessionObjectTests::testAttrMapAttr()
@@ -259,7 +287,7 @@ void SessionObjectTests::testMixedAttr()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
 
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -295,7 +323,7 @@ void SessionObjectTests::testDoubleAttr()
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
 	ByteString value3a = "466487346943785684957634";
 
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -355,7 +383,7 @@ void SessionObjectTests::testCloseSession()
 {
 	ByteString value3 = "BDEBDBEDBBDBEBDEBE792759537328";
 
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 
@@ -386,7 +414,7 @@ void SessionObjectTests::testCloseSession()
 	CPPUNIT_ASSERT(testObject.getAttribute(CKA_VALUE_BITS).getByteStringValue() == value3);
 
 	// Now close the session
-    testObject.removeOnSessionClose(1);
+	testObject.removeOnSessionClose(1);
 
 	CPPUNIT_ASSERT(!testObject.isValid());
 	CPPUNIT_ASSERT(!testObject.attributeExists(CKA_TOKEN));
@@ -397,7 +425,7 @@ void SessionObjectTests::testCloseSession()
 void SessionObjectTests::testDestroyObjectFails()
 {
 	// Create test object instance
-    SessionObject testObject(NULL, 1, 1);
+	SessionObject testObject(NULL, 1, 1);
 
 	CPPUNIT_ASSERT(testObject.isValid());
 

--- a/src/lib/object_store/test/SessionObjectTests.cpp
+++ b/src/lib/object_store/test/SessionObjectTests.cpp
@@ -211,7 +211,7 @@ void SessionObjectTests::testByteStrAttr()
 	CPPUNIT_ASSERT(testObject.getByteStringValue(CKA_ISSUER) == value6);
 }
 
-void SessionObjectTests::testArrayAttr()
+void SessionObjectTests::testAttrMapAttr()
 {
 	SessionObject testObject(NULL, 1, 1);
 
@@ -238,9 +238,10 @@ void SessionObjectTests::testArrayAttr()
 	CPPUNIT_ASSERT(testObject.attributeExists(CKA_WRAP_TEMPLATE));
 	CPPUNIT_ASSERT(!testObject.attributeExists(CKA_UNWRAP_TEMPLATE));
 
-	CPPUNIT_ASSERT(testObject.getAttribute(CKA_WRAP_TEMPLATE).isArrayAttribute());
+	CPPUNIT_ASSERT(testObject.getAttribute(CKA_WRAP_TEMPLATE).isAttributeMapAttribute());
 
-	std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb = testObject.getAttribute(CKA_WRAP_TEMPLATE).getArrayValue();
+	std::map<CK_ATTRIBUTE_TYPE,OSAttribute> mattrb =
+			testObject.getAttribute(CKA_WRAP_TEMPLATE).getAttributeMapValue();
 	CPPUNIT_ASSERT(mattrb.size() == 3);
 	CPPUNIT_ASSERT(mattrb.find(CKA_TOKEN) != mattrb.end());
 	CPPUNIT_ASSERT(mattrb.at(CKA_TOKEN).isBooleanAttribute());

--- a/src/lib/object_store/test/SessionObjectTests.h
+++ b/src/lib/object_store/test/SessionObjectTests.h
@@ -41,6 +41,7 @@ class SessionObjectTests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testBoolAttr);
 	CPPUNIT_TEST(testULongAttr);
 	CPPUNIT_TEST(testByteStrAttr);
+	CPPUNIT_TEST(testMechTypeSetAttr);
 	CPPUNIT_TEST(testAttrMapAttr);
 	CPPUNIT_TEST(testMixedAttr);
 	CPPUNIT_TEST(testDoubleAttr);
@@ -52,6 +53,7 @@ public:
 	void testBoolAttr();
 	void testULongAttr();
 	void testByteStrAttr();
+	void testMechTypeSetAttr();
 	void testAttrMapAttr();
 	void testMixedAttr();
 	void testDoubleAttr();

--- a/src/lib/object_store/test/SessionObjectTests.h
+++ b/src/lib/object_store/test/SessionObjectTests.h
@@ -41,7 +41,7 @@ class SessionObjectTests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testBoolAttr);
 	CPPUNIT_TEST(testULongAttr);
 	CPPUNIT_TEST(testByteStrAttr);
-	CPPUNIT_TEST(testArrayAttr);
+	CPPUNIT_TEST(testAttrMapAttr);
 	CPPUNIT_TEST(testMixedAttr);
 	CPPUNIT_TEST(testDoubleAttr);
 	CPPUNIT_TEST(testCloseSession);
@@ -52,7 +52,7 @@ public:
 	void testBoolAttr();
 	void testULongAttr();
 	void testByteStrAttr();
-	void testArrayAttr();
+	void testAttrMapAttr();
 	void testMixedAttr();
 	void testDoubleAttr();
 	void testCloseSession();

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -298,7 +298,7 @@ void ObjectTests::checkX509CertificateObjectAttributes(CK_SESSION_HANDLE hSessio
 	free(attribs[7].pValue);
 }
 
-void ObjectTests::checkCommonKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_KEY_TYPE keyType, CK_BYTE_PTR pId, CK_ULONG ulIdLen, CK_DATE startDate, CK_ULONG ulStartDateLen, CK_DATE endDate, CK_ULONG ulEndDateLen, CK_BBOOL bDerive, CK_BBOOL bLocal, CK_MECHANISM_TYPE keyMechanismType, CK_MECHANISM_TYPE_PTR /*pAllowedMechanisms*/, CK_ULONG /*ulAllowedMechanismsLen*/)
+void ObjectTests::checkCommonKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_KEY_TYPE keyType, CK_BYTE_PTR pId, CK_ULONG ulIdLen, CK_DATE startDate, CK_ULONG ulStartDateLen, CK_DATE endDate, CK_ULONG ulEndDateLen, CK_BBOOL bDerive, CK_BBOOL bLocal, CK_MECHANISM_TYPE keyMechanismType, CK_MECHANISM_TYPE_PTR pAllowedMechanisms, CK_ULONG ulAllowedMechanismsLen)
 {
 	CK_RV rv;
 
@@ -310,14 +310,13 @@ void ObjectTests::checkCommonKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT
 	CK_MECHANISM_TYPE obj_mech = CKM_VENDOR_DEFINED;
 	CK_ATTRIBUTE attribs[] = {
 		{ CKA_ID, NULL_PTR, 0 },
-		/* Not supported
-		{ CKA_ALLOWED_MECHANISMS, NULL_PTR, 0 }, */
 		{ CKA_KEY_TYPE, &obj_type, sizeof(obj_type) },
 		{ CKA_START_DATE, &obj_start, sizeof(obj_start) },
 		{ CKA_END_DATE, &obj_end, sizeof(obj_end) },
 		{ CKA_DERIVE, &obj_derive, sizeof(obj_derive) },
 		{ CKA_LOCAL, &obj_local, sizeof(obj_local) },
-		{ CKA_KEY_GEN_MECHANISM, &obj_mech, sizeof(obj_mech) }
+		{ CKA_KEY_GEN_MECHANISM, &obj_mech, sizeof(obj_mech) },
+		{ CKA_ALLOWED_MECHANISMS, NULL_PTR, 0 }
 	};
 
 	// Get length
@@ -326,7 +325,7 @@ void ObjectTests::checkCommonKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT
 	attribs[0].pValue = (CK_VOID_PTR)malloc(attribs[0].ulValueLen);
 
 	// Check values
-	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 7) );
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, &attribs[0], 8) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(attribs[0].ulValueLen == ulIdLen);
 	CPPUNIT_ASSERT(obj_type == keyType);
@@ -335,12 +334,16 @@ void ObjectTests::checkCommonKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT
 	CPPUNIT_ASSERT(obj_derive == bDerive);
 	CPPUNIT_ASSERT(obj_local == bLocal);
 	CPPUNIT_ASSERT(obj_mech == keyMechanismType);
+	CPPUNIT_ASSERT(attribs[7].ulValueLen == ulAllowedMechanismsLen);
+
 	if (ulIdLen > 0)
 		CPPUNIT_ASSERT(memcmp(attribs[0].pValue, pId, ulIdLen) == 0);
 	if (ulStartDateLen > 0)
-		CPPUNIT_ASSERT(memcmp(attribs[3].pValue, &startDate, ulStartDateLen) == 0);
+		CPPUNIT_ASSERT(memcmp(attribs[2].pValue, &startDate, ulStartDateLen) == 0);
 	if (ulEndDateLen > 0)
-		CPPUNIT_ASSERT(memcmp(attribs[4].pValue, &endDate, ulEndDateLen) == 0);
+		CPPUNIT_ASSERT(memcmp(attribs[3].pValue, &endDate, ulEndDateLen) == 0);
+	if (ulAllowedMechanismsLen > 0)
+		CPPUNIT_ASSERT(memcmp(attribs[7].pValue, pAllowedMechanisms, ulAllowedMechanismsLen) == 0);
 
 	free(attribs[0].pValue);
 }
@@ -1948,6 +1951,77 @@ void ObjectTests::testGetInvalidAttribute()
 	// Check value
 	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hObject, getTemplate, 1) );
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_TYPE_INVALID);
+}
+
+void ObjectTests::testAllowedMechanisms()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession;
+
+	// Just make sure that we finalize any previous tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	// Initialize the library and start the test.
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Open read-write session
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Login USER into the sessions so we can create a private objects
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
+	CPPUNIT_ASSERT(rv==CKR_OK);
+
+	CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+	CK_OBJECT_CLASS secretClass = CKO_SECRET_KEY;
+	CK_BYTE key[64];
+	CK_MECHANISM_TYPE allowedMechs[] = { CKM_SHA256_HMAC, CKM_SHA512_HMAC };
+	CK_ATTRIBUTE attribs[] = {
+			{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
+			{ CKA_CLASS, &secretClass, sizeof(secretClass) },
+			{ CKA_VALUE, &key, sizeof(key) },
+			{ CKA_ALLOWED_MECHANISMS, &allowedMechs, sizeof(allowedMechs) }
+	};
+
+	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, attribs, sizeof(attribs)/sizeof(CK_ATTRIBUTE), &hKey) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	CK_BYTE data[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+	CK_BYTE signature[256];
+	CK_ULONG ulSignatureLen = (CK_ULONG) 256;
+
+	// SHA_1_HMAC is not an allowed mechanism
+	CK_MECHANISM mechanism = { CKM_SHA_1_HMAC, NULL_PTR, 0 };
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession, &mechanism, hKey) );
+	CPPUNIT_ASSERT(rv == CKR_MECHANISM_INVALID);
+
+	// SHA256_HMAC is an allowed mechanism
+	mechanism.mechanism = CKM_SHA256_HMAC;
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession, &mechanism, hKey) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	CK_BYTE signature256[256];
+	CK_ULONG signature256Len = sizeof(signature256);
+	rv = CRYPTOKI_F_PTR( C_Sign(hSession, data, sizeof(data), signature256, &signature256Len) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// SHA384_HMAC is not an allowed mechanism
+	mechanism.mechanism = CKM_SHA384_HMAC;
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession, &mechanism, hKey) );
+	CPPUNIT_ASSERT(rv == CKR_MECHANISM_INVALID);
+
+	// SHA512_HMAC is an allowed mechanism
+	mechanism.mechanism = CKM_SHA512_HMAC;
+	rv = CRYPTOKI_F_PTR( C_SignInit(hSession, &mechanism, hKey) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	CK_BYTE signature512[512];
+	CK_ULONG signature512Len = sizeof(signature512);
+	rv = CRYPTOKI_F_PTR( C_Sign(hSession, data, sizeof(data), signature512, &signature512Len) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 
 void ObjectTests::testTemplateAttribute()

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -1950,7 +1950,7 @@ void ObjectTests::testGetInvalidAttribute()
 	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_TYPE_INVALID);
 }
 
-void ObjectTests::testArrayAttribute()
+void ObjectTests::testTemplateAttribute()
 {
 	CK_RV rv;
 	CK_SESSION_HANDLE hSession;

--- a/src/lib/test/ObjectTests.h
+++ b/src/lib/test/ObjectTests.h
@@ -57,7 +57,7 @@ class ObjectTests : public TestsBase
 	CPPUNIT_TEST(testAlwaysNeverAttribute);
 	CPPUNIT_TEST(testSensitiveAttributes);
 	CPPUNIT_TEST(testGetInvalidAttribute);
-	CPPUNIT_TEST(testArrayAttribute);
+	CPPUNIT_TEST(testTemplateAttribute);
 	CPPUNIT_TEST(testCreateSecretKey);
 	CPPUNIT_TEST_SUITE_END();
 
@@ -78,7 +78,7 @@ public:
 	void testAlwaysNeverAttribute();
 	void testSensitiveAttributes();
 	void testGetInvalidAttribute();
-	void testArrayAttribute();
+	void testTemplateAttribute();
 	void testCreateSecretKey();
 
 protected:

--- a/src/lib/test/ObjectTests.h
+++ b/src/lib/test/ObjectTests.h
@@ -57,6 +57,7 @@ class ObjectTests : public TestsBase
 	CPPUNIT_TEST(testAlwaysNeverAttribute);
 	CPPUNIT_TEST(testSensitiveAttributes);
 	CPPUNIT_TEST(testGetInvalidAttribute);
+	CPPUNIT_TEST(testAllowedMechanisms);
 	CPPUNIT_TEST(testTemplateAttribute);
 	CPPUNIT_TEST(testCreateSecretKey);
 	CPPUNIT_TEST_SUITE_END();
@@ -78,6 +79,7 @@ public:
 	void testAlwaysNeverAttribute();
 	void testSensitiveAttributes();
 	void testGetInvalidAttribute();
+	void testAllowedMechanisms();
 	void testTemplateAttribute();
 	void testCreateSecretKey();
 


### PR DESCRIPTION
Took a stab at closing out #140, since I'm looking for this support for a project I'm working on.  

There are a couple of corners that I cut, and welcome feedback about how I can improve:
* I didn't create a new table in sqlite to hold mechanisms; rather, overloaded the byte string table. It's not entirely clear to me why different object types need different tables. In any case, I'd be happy to do something different, but would need to understand what an appropriate migration path would look like for users who are using a released version.
* I did not add support for mechanism lists in wrap/unwrap templates.  That probably ought to be there for this feature to be considered complete.

I will openly confess that my C++ is pretty novice, so I'd suggest that you probably want to be quite thorough on review.  ~~Also, I know that there are some tab/spacing issues-- I'll fix those up on the next push.~~ (edit: fixed)