### PR TITLE
Support raw PSS with Botan

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 NEWS for SoftHSM -- History of user visible changes
 
+SoftHSM develop
+
+* Issue #335: Support for CKM_RSA_PKCS_PSS.
+  (Patch from Nikos Mavrogiannopoulos)
+
+
 SoftHSM 2.3.0 - 2017-07-03
 
 * Issue #130: Upgraded to PKCS#11 v2.40.

--- a/m4/acx_botan_rawpss.m4
+++ b/m4/acx_botan_rawpss.m4
@@ -1,0 +1,37 @@
+AC_DEFUN([ACX_BOTAN_RAWPSS],[
+	AC_MSG_CHECKING(for Botan raw PSS support)
+
+	tmp_CPPFLAGS=$CPPFLAGS
+	tmp_LIBS=$LIBS
+
+	CPPFLAGS="$CPPFLAGS $CRYPTO_INCLUDES"
+	LIBS="$CRYPTO_LIBS $LIBS"
+
+	AC_LANG_PUSH([C++])
+	AC_RUN_IFELSE([
+		AC_LANG_SOURCE([[
+			#include <botan/botan.h>
+			#include <botan/version.h>
+			int main()
+			{
+				using namespace Botan;
+
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(2,3,0)
+				return 0;
+#endif
+				return 1;
+			}
+		]])
+	],[
+		AC_MSG_RESULT([Found raw PSS])
+		AC_DEFINE([WITH_RAW_PSS], [1],
+			  [Compile with raw RSA PKCS PSS])
+	],[
+		AC_MSG_RESULT([Cannot find raw PSS support, upgrade to Botan >= v2.3.0])
+
+	])
+	AC_LANG_POP([C++])
+
+	CPPFLAGS=$tmp_CPPFLAGS
+	LIBS=$tmp_LIBS
+])

--- a/m4/acx_crypto_backend.m4
+++ b/m4/acx_crypto_backend.m4
@@ -106,6 +106,11 @@ AC_DEFUN([ACX_CRYPTO_BACKEND],[
 		fi
 
 		AC_DEFINE_UNQUOTED(
+			[WITH_RAW_PSS],
+			[1],
+			[Compile with raw RSA PKCS PSS]
+		)
+		AC_DEFINE_UNQUOTED(
 			[WITH_OPENSSL],
 			[],
 			[Compile with OpenSSL support]
@@ -136,6 +141,7 @@ AC_DEFUN([ACX_CRYPTO_BACKEND],[
 		fi
 
 		ACX_BOTAN_RFC5649
+		ACX_BOTAN_RAWPSS
 
 		AC_DEFINE_UNQUOTED(
 			[WITH_BOTAN],

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -640,7 +640,7 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 #ifdef HAVE_AES_KEY_WRAP_PAD
 	nrSupportedMechanisms += 1;
 #endif
-#ifdef WITH_OPENSSL
+#ifdef WITH_RAW_PSS
 	nrSupportedMechanisms += 1; // CKM_RSA_PKCS_PSS
 #endif
 
@@ -674,7 +674,7 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 		CKM_SHA256_RSA_PKCS,
 		CKM_SHA384_RSA_PKCS,
 		CKM_SHA512_RSA_PKCS,
-#ifdef WITH_OPENSSL
+#ifdef WITH_RAW_PSS
 		CKM_RSA_PKCS_PSS,
 #endif
 		CKM_SHA1_RSA_PKCS_PSS,
@@ -931,7 +931,7 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 		case CKM_SHA256_RSA_PKCS:
 		case CKM_SHA384_RSA_PKCS:
 		case CKM_SHA512_RSA_PKCS:
-#ifdef WITH_OPENSSL
+#ifdef WITH_RAW_PSS
 		case CKM_RSA_PKCS_PSS:
 #endif
 		case CKM_SHA1_RSA_PKCS_PSS:
@@ -3759,6 +3759,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 			bAllowMultiPartOp = true;
 			isRSA = true;
 			break;
+#ifdef WITH_RAW_PSS
 		case CKM_RSA_PKCS_PSS:
 			if (pMechanism->pParameter == NULL_PTR ||
 			    pMechanism->ulParameterLen != sizeof(CK_RSA_PKCS_PSS_PARAMS))
@@ -3811,6 +3812,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 			bAllowMultiPartOp = false;
 			isRSA = true;
 			break;
+#endif
 		case CKM_SHA1_RSA_PKCS_PSS:
 			if (pMechanism->pParameter == NULL_PTR ||
 			    pMechanism->ulParameterLen != sizeof(CK_RSA_PKCS_PSS_PARAMS) ||
@@ -4655,6 +4657,7 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 			bAllowMultiPartOp = true;
 			isRSA = true;
 			break;
+#ifdef WITH_RAW_PSS
 		case CKM_RSA_PKCS_PSS:
 			if (pMechanism->pParameter == NULL_PTR ||
 			    pMechanism->ulParameterLen != sizeof(CK_RSA_PKCS_PSS_PARAMS))
@@ -4705,6 +4708,7 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 			bAllowMultiPartOp = false;
 			isRSA = true;
 			break;
+#endif
 		case CKM_SHA1_RSA_PKCS_PSS:
 			if (pMechanism->pParameter == NULL_PTR ||
 			    pMechanism->ulParameterLen != sizeof(CK_RSA_PKCS_PSS_PARAMS) ||

--- a/src/lib/crypto/BotanRSA.h
+++ b/src/lib/crypto/BotanRSA.h
@@ -80,6 +80,10 @@ public:
 private:
 	Botan::PK_Signer* signer;
 	Botan::PK_Verifier* verifier;
+
+#ifdef WITH_RAW_PSS
+	std::string getCipherRawPss(size_t bitLength, size_t dataSize, const void* param, const size_t paramLen);
+#endif
 };
 
 #endif // !_SOFTHSM_V2_BOTANRSA_H

--- a/src/lib/crypto/SymmetricAlgorithm.cpp
+++ b/src/lib/crypto/SymmetricAlgorithm.cpp
@@ -193,6 +193,8 @@ bool SymmetricAlgorithm::isStreamCipher()
 		case SymMode::CTR:
 		case SymMode::OFB:
 			return true;
+		default:
+			break;
 	}
 
 	return false;
@@ -205,6 +207,8 @@ bool SymmetricAlgorithm::isBlockCipher()
 		case SymMode::CBC:
 		case SymMode::ECB:
 			return true;
+		default:
+			break;
 	}
 
 	return false;

--- a/src/lib/crypto/test/RSATests.cpp
+++ b/src/lib/crypto/test/RSATests.cpp
@@ -396,6 +396,33 @@ void RSATests::testSigningVerifying()
 			// Verify the signature
 			CPPUNIT_ASSERT(rsa->verify(kp->getPublicKey(), dataToSign, signature, AsymMech::RSA));
 
+#ifdef WITH_RAW_PSS
+			// Test raw (SHA1) PKCS PSS signing
+			CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 20));
+			CPPUNIT_ASSERT(rsa->sign(kp->getPrivateKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[0], sizeof(pssParams[0])));
+			CPPUNIT_ASSERT(rsa->verify(kp->getPublicKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[0], sizeof(pssParams[0])));
+
+			// Test raw (SHA224) PKCS PSS signing
+			CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 28));
+			CPPUNIT_ASSERT(rsa->sign(kp->getPrivateKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[1], sizeof(pssParams[1])));
+			CPPUNIT_ASSERT(rsa->verify(kp->getPublicKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[1], sizeof(pssParams[1])));
+
+			// Test raw (SHA256) PKCS PSS signing
+			CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 32));
+			CPPUNIT_ASSERT(rsa->sign(kp->getPrivateKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[2], sizeof(pssParams[2])));
+			CPPUNIT_ASSERT(rsa->verify(kp->getPublicKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[2], sizeof(pssParams[2])));
+
+			// Test raw (SHA384) PKCS PSS signing
+			CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 48));
+			CPPUNIT_ASSERT(rsa->sign(kp->getPrivateKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[3], sizeof(pssParams[3])));
+			CPPUNIT_ASSERT(rsa->verify(kp->getPublicKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[3], sizeof(pssParams[3])));
+
+			// Test raw (SHA512) PKCS PSS signing
+			CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 64));
+			CPPUNIT_ASSERT(rsa->sign(kp->getPrivateKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[4], sizeof(pssParams[4])));
+			CPPUNIT_ASSERT(rsa->verify(kp->getPublicKey(), dataToSign, signature, AsymMech::RSA_PKCS_PSS, &pssParams[4], sizeof(pssParams[4])));
+#endif
+
 			rsa->recycleKeyPair(kp);
 		}
 	}

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -326,7 +326,7 @@ void SignVerifyTests::testRsaSignVerify()
 	signVerifyMulti(CKM_SHA384_RSA_PKCS, hSessionRO, hPuk,hPrk);
 	signVerifyMulti(CKM_SHA512_RSA_PKCS, hSessionRO, hPuk,hPrk);
 
-#ifdef WITH_OPENSSL
+#ifdef WITH_RAW_PSS
 	signVerifySingleData(20, CKM_RSA_PKCS_PSS, hSessionRO, hPuk,hPrk, &params[0], sizeof(params[0]));
 	signVerifySingleData(28, CKM_RSA_PKCS_PSS, hSessionRO, hPuk,hPrk, &params[1], sizeof(params[1]));
 	signVerifySingleData(32, CKM_RSA_PKCS_PSS, hSessionRO, hPuk,hPrk, &params[2], sizeof(params[2]));

--- a/win32/Configure.py
+++ b/win32/Configure.py
@@ -39,6 +39,7 @@ testlist = ["botan",
             "gost",
             "ossl",
             "osslv",
+            "rawpss",
             "rfc3394",
             "rfc5649"]
 
@@ -69,6 +70,7 @@ condnames = ["BOTAN",
              "GOST",
              "NONPAGE",
              "OPENSSL",
+             "RAWPSS",
              "RFC3394",
              "RFC5649",
              "TESTS"]
@@ -682,6 +684,33 @@ int main() {\n\
                 if verbose:
                     print("Botan GNU MP is not supported")
 
+        # Botan raw PSS support
+        if verbose:
+            print("checking Botan raw PSS support")
+        testfile = open("testrawpss.cpp", "w")
+        print('\
+#include <botan/botan.h>\n\
+#include <botan/version.h>\n\
+int main() {\n\
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(2,3,0)\n\
+ return 0;\n\
+#endif\n\
+ return 1;\n\
+}', file=testfile)
+            testfile.close()
+            command = ["cl", "/nologo", "/MD", "/I", inc, "testrawpss.cpp", lib]
+            command.extend(system_libs)
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
+            if not os.path.exists(".\\testrawpss.exe"):
+                if verbose:
+                    print("can't create .\\testrawpss.exe", file=sys.stderr)
+            else:
+                if subprocess.call(".\\testrawpss.exe") != 0:
+                    if verbose:
+                        print("can't find raw PSS: upgrade to Botan >= 2.3.0", file=sys.stderr)
+                else:
+                    condvals["RAWPSS"] = True
+
     else:
 
         condvals["OPENSSL"] = True
@@ -908,6 +937,9 @@ int main() {\n\
         else:
             if verbose:
                 print("can't compile OpenSSL RFC 5649")
+
+        # no check for OpenSSL raw PSS support
+        condvals["RAWPSS"] = True
 
     # configure CppUnit
     if want_tests:

--- a/win32/Configure.py
+++ b/win32/Configure.py
@@ -697,19 +697,19 @@ int main() {\n\
 #endif\n\
  return 1;\n\
 }', file=testfile)
-            testfile.close()
-            command = ["cl", "/nologo", "/MD", "/I", inc, "testrawpss.cpp", lib]
-            command.extend(system_libs)
-            subprocess.check_output(command, stderr=subprocess.STDOUT)
-            if not os.path.exists(".\\testrawpss.exe"):
+        testfile.close()
+        command = ["cl", "/nologo", "/MD", "/I", inc, "testrawpss.cpp", lib]
+        command.extend(system_libs)
+        subprocess.check_output(command, stderr=subprocess.STDOUT)
+        if not os.path.exists(".\\testrawpss.exe"):
+            if verbose:
+                print("can't create .\\testrawpss.exe", file=sys.stderr)
+        else:
+            if subprocess.call(".\\testrawpss.exe") != 0:
                 if verbose:
-                    print("can't create .\\testrawpss.exe", file=sys.stderr)
+                    print("can't find raw PSS: upgrade to Botan >= 2.3.0", file=sys.stderr)
             else:
-                if subprocess.call(".\\testrawpss.exe") != 0:
-                    if verbose:
-                        print("can't find raw PSS: upgrade to Botan >= 2.3.0", file=sys.stderr)
-                else:
-                    condvals["RAWPSS"] = True
+                condvals["RAWPSS"] = True
 
     else:
 

--- a/win32/config.h.in
+++ b/win32/config.h.in
@@ -124,6 +124,13 @@
 #undef WITH_OPENSSL
 @END OPENSSL
 
+/* Compile with raw PSS support */
+@IF RAWPSS
+#define WITH_RAW_PSS 1
+@ELSE RAWPSS
+#undef WITH_RAW_PSS
+@END RAWPSS
+
 /* Define to 1 if you have getpassphrase(). */
 #define HAVE_GETPASSPHRASE
 


### PR DESCRIPTION
CKM_RSA_PKCS_PSS was added in #335, but only for OpenSSL. This also add support for Botan.