### PR TITLE
Add CKM_GENERIC_SECRET_KEY_GEN Support

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -668,6 +668,7 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 		CKM_RSA_PKCS_KEY_PAIR_GEN,
 		CKM_RSA_PKCS,
 		CKM_RSA_X_509,
+        CKM_GENERIC_SECRET_KEY_GEN,
 #ifndef WITH_FIPS
 		CKM_MD5_RSA_PKCS,
 #endif
@@ -916,6 +917,11 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 			pInfo->ulMaxKeySize = 512;
 			pInfo->flags = CKF_SIGN | CKF_VERIFY;
 			break;
+        case CKM_GENERIC_SECRET_KEY_GEN:
+            pInfo->ulMinKeySize = 0;
+			pInfo->ulMaxKeySize = 0;
+			pInfo->flags = CKF_GENERATE;
+            break;
 		case CKM_RSA_PKCS_KEY_PAIR_GEN:
 			pInfo->ulMinKeySize = rsaMinSize;
 			pInfo->ulMaxKeySize = rsaMaxSize;
@@ -5546,6 +5552,10 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 			objClass = CKO_SECRET_KEY;
 			keyType = CKK_AES;
 			break;
+        case CKM_GENERIC_SECRET_KEY_GEN:
+			objClass = CKO_SECRET_KEY;
+			keyType = CKK_SHA256_HMAC;
+			break;
 		default:
 			return CKR_MECHANISM_INVALID;
 	}
@@ -5626,6 +5636,111 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 	{
 		return this->generateAES(hSession, pTemplate, ulCount, phKey, isOnToken, isPrivate);
 	}
+
+    if (pMechanism->mechanism == CKM_GENERIC_SECRET_KEY_GEN)
+    {
+        const CK_ULONG maxAttribs = 32;
+        CK_ATTRIBUTE keyAttribs[maxAttribs] = {
+            { CKA_CLASS, &objClass, sizeof(objClass) },
+            { CKA_TOKEN, &isOnToken, sizeof(isOnToken) },
+            { CKA_PRIVATE, &isPrivate, sizeof(isPrivate) },
+            { CKA_KEY_TYPE, &keyType, sizeof(keyType) },
+        };
+        CK_ULONG keyAttribsCount = 4;
+        CK_ULONG gen_key_len = 0;
+        // Add the additional
+        if (ulCount > (maxAttribs - keyAttribsCount))
+            rv = CKR_TEMPLATE_INCONSISTENT;
+        for (CK_ULONG i=0; i < ulCount && rv == CKR_OK; ++i)
+        {
+            switch (pTemplate[i].type)
+            {
+                case CKA_CLASS:
+                case CKA_TOKEN:
+                case CKA_PRIVATE:
+                case CKA_KEY_TYPE:
+                case CKA_CHECK_VALUE:
+                    continue;
+
+                case CKA_VALUE_LEN:
+				if (pTemplate[i].ulValueLen != sizeof(CK_ULONG))
+				{
+					INFO_MSG("CKA_VALUE_LEN does not have the size of CK_ULONG");
+					return CKR_ATTRIBUTE_VALUE_INVALID;
+				}
+				gen_key_len = *(CK_ULONG*)pTemplate[i].pValue;
+                keyAttribs[keyAttribsCount++] = pTemplate[i];
+				break;
+            default:
+                keyAttribs[keyAttribsCount++] = pTemplate[i];
+            }
+        }
+        CK_RV rv = CKR_OK;
+
+        CK_BYTE val[gen_key_len];
+        rv = C_GenerateRandom(hSession, val, gen_key_len);
+
+        if (keyType == CKK_GOST28147)
+        {
+            rv = CreateObject(hSession, keyAttribs, keyAttribsCount, phKey, OBJECT_OP_GENERATE);
+        }
+        else
+        {
+            rv = CreateObject(hSession, keyAttribs, keyAttribsCount, phKey, OBJECT_OP_GENERATE);
+        }
+
+        Session* session = (Session*)handleManager->getSession(hSession);
+        if (session == NULL)
+            return CKR_SESSION_HANDLE_INVALID;
+
+        // Get the token
+        Token* token = session->getToken();
+        if (token == NULL)
+            return CKR_GENERAL_ERROR;
+
+        // Store the attributes that are being supplied
+        if (rv == CKR_OK)
+        {
+            OSObject* osobject = (OSObject*)handleManager->getObject(*phKey);
+            if (osobject == NULL_PTR || !osobject->isValid()) {
+                rv = CKR_FUNCTION_FAILED;
+            } else if (osobject->startTransaction()) {
+                bool bOK = true;
+
+                // Common Attributes
+                bOK = bOK && osobject->setAttribute(CKA_LOCAL,true);
+                CK_ULONG ulKeyGenMechanism = (CK_ULONG)CKM_GENERIC_SECRET_KEY_GEN;
+                bOK = bOK && osobject->setAttribute(CKA_KEY_GEN_MECHANISM,ulKeyGenMechanism);
+
+                // Common Secret Key Attributes
+                bool bAlwaysSensitive = osobject->getBooleanValue(CKA_SENSITIVE, false);
+                bOK = bOK && osobject->setAttribute(CKA_ALWAYS_SENSITIVE,bAlwaysSensitive);
+                bool bNeverExtractable = osobject->getBooleanValue(CKA_EXTRACTABLE, false) == false;
+                bOK = bOK && osobject->setAttribute(CKA_NEVER_EXTRACTABLE, bNeverExtractable);
+
+                ByteString rawval = ByteString(val, gen_key_len);
+                ByteString value;
+                if (isPrivate)
+                {
+                    token->encrypt(rawval, value);
+                }
+                else
+                {
+                    value = rawval;
+                }
+                bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+                if (bOK)
+                    bOK = osobject->commitTransaction();
+                else
+                    osobject->abortTransaction();
+
+                if (!bOK)
+                    rv = CKR_FUNCTION_FAILED;
+            } else
+                rv = CKR_FUNCTION_FAILED;
+        }
+        return rv;
+    }
 
 	return CKR_GENERAL_ERROR;
 }

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -627,7 +627,7 @@ CK_RV SoftHSM::C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMechanismList, CK_ULONG_PTR pulCount)
 {
 	// A list with the supported mechanisms
-	CK_ULONG nrSupportedMechanisms = 61;
+	CK_ULONG nrSupportedMechanisms = 62;
 #ifdef WITH_ECC
 	nrSupportedMechanisms += 3;
 #endif
@@ -668,7 +668,6 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 		CKM_RSA_PKCS_KEY_PAIR_GEN,
 		CKM_RSA_PKCS,
 		CKM_RSA_X_509,
-        CKM_GENERIC_SECRET_KEY_GEN,
 #ifndef WITH_FIPS
 		CKM_MD5_RSA_PKCS,
 #endif
@@ -686,6 +685,7 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 		CKM_SHA256_RSA_PKCS_PSS,
 		CKM_SHA384_RSA_PKCS_PSS,
 		CKM_SHA512_RSA_PKCS_PSS,
+		CKM_GENERIC_SECRET_KEY_GEN,
 #ifndef WITH_FIPS
 		CKM_DES_KEY_GEN,
 #endif
@@ -917,11 +917,6 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 			pInfo->ulMaxKeySize = 512;
 			pInfo->flags = CKF_SIGN | CKF_VERIFY;
 			break;
-        case CKM_GENERIC_SECRET_KEY_GEN:
-            pInfo->ulMinKeySize = 0;
-			pInfo->ulMaxKeySize = 0;
-			pInfo->flags = CKF_GENERATE;
-            break;
 		case CKM_RSA_PKCS_KEY_PAIR_GEN:
 			pInfo->ulMinKeySize = rsaMinSize;
 			pInfo->ulMaxKeySize = rsaMaxSize;
@@ -961,6 +956,11 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 			pInfo->ulMinKeySize = rsaMinSize;
 			pInfo->ulMaxKeySize = rsaMaxSize;
 			pInfo->flags = CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP;
+			break;
+		case CKM_GENERIC_SECRET_KEY_GEN:
+			pInfo->ulMinKeySize = 1;
+			pInfo->ulMaxKeySize = 0x80000000;
+			pInfo->flags = CKF_GENERATE;
 			break;
 #ifndef WITH_FIPS
 		case CKM_DES_KEY_GEN:
@@ -5552,9 +5552,9 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 			objClass = CKO_SECRET_KEY;
 			keyType = CKK_AES;
 			break;
-        case CKM_GENERIC_SECRET_KEY_GEN:
+		case CKM_GENERIC_SECRET_KEY_GEN:
 			objClass = CKO_SECRET_KEY;
-			keyType = CKK_SHA256_HMAC;
+			keyType = CKK_GENERIC_SECRET;
 			break;
 		default:
 			return CKR_MECHANISM_INVALID;
@@ -5587,6 +5587,9 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 		return CKR_TEMPLATE_INCONSISTENT;
 	if (pMechanism->mechanism == CKM_AES_KEY_GEN &&
 	    (objClass != CKO_SECRET_KEY || keyType != CKK_AES))
+		return CKR_TEMPLATE_INCONSISTENT;
+	if (pMechanism->mechanism == CKM_GENERIC_SECRET_KEY_GEN &&
+	    (objClass != CKO_SECRET_KEY || keyType != CKK_GENERIC_SECRET))
 		return CKR_TEMPLATE_INCONSISTENT;
 
 	// Check authorization
@@ -5637,10 +5640,11 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 		return this->generateAES(hSession, pTemplate, ulCount, phKey, isOnToken, isPrivate);
 	}
 
-    if (pMechanism->mechanism == CKM_GENERIC_SECRET_KEY_GEN)
-    {
-        return this->generateGeneric(hSession, pTemplate, ulCount, phKey, isOnToken, isPrivate, objClass, keyType);
-    }
+	// Generate generic secret key
+	if (pMechanism->mechanism == CKM_GENERIC_SECRET_KEY_GEN)
+	{
+		return this->generateGeneric(hSession, pTemplate, ulCount, phKey, isOnToken, isPrivate);
+	}
 
 	return CKR_GENERAL_ERROR;
 }
@@ -6892,113 +6896,169 @@ CK_RV SoftHSM::generateGeneric
 	CK_ULONG ulCount,
 	CK_OBJECT_HANDLE_PTR phKey,
 	CK_BBOOL isOnToken,
-	CK_BBOOL isPrivate,
-    CK_OBJECT_CLASS objClass,
-	CK_KEY_TYPE keyType)
+	CK_BBOOL isPrivate)
 {
-    const CK_ULONG maxAttribs = 32;
-    CK_ATTRIBUTE keyAttribs[maxAttribs] = {
-        { CKA_CLASS, &objClass, sizeof(objClass) },
-        { CKA_TOKEN, &isOnToken, sizeof(isOnToken) },
-        { CKA_PRIVATE, &isPrivate, sizeof(isPrivate) },
-        { CKA_KEY_TYPE, &keyType, sizeof(keyType) },
-    };
-    CK_ULONG keyAttribsCount = 4;
-    CK_ULONG gen_key_len = 0;
-    CK_RV rv = CKR_OK;
-    // Add the additional
-    if (ulCount > (maxAttribs - keyAttribsCount))
-        rv = CKR_TEMPLATE_INCONSISTENT;
-    for (CK_ULONG i=0; i < ulCount && rv == CKR_OK; ++i)
-    {
-        switch (pTemplate[i].type)
-        {
-            case CKA_CLASS:
-            case CKA_TOKEN:
-            case CKA_PRIVATE:
-            case CKA_KEY_TYPE:
-            case CKA_CHECK_VALUE:
-                continue;
+	*phKey = CK_INVALID_HANDLE;
 
-            case CKA_VALUE_LEN:
-            if (pTemplate[i].ulValueLen != sizeof(CK_ULONG))
-            {
-                INFO_MSG("CKA_VALUE_LEN does not have the size of CK_ULONG");
-                return CKR_ATTRIBUTE_VALUE_INVALID;
-            }
-            gen_key_len = *(CK_ULONG*)pTemplate[i].pValue;
-            keyAttribs[keyAttribsCount++] = pTemplate[i];
-            break;
-        default:
-            keyAttribs[keyAttribsCount++] = pTemplate[i];
-        }
-    }
+	// Get the session
+	Session* session = (Session*)handleManager->getSession(hSession);
+	if (session == NULL)
+		return CKR_SESSION_HANDLE_INVALID;
 
-    CK_BYTE val[gen_key_len];
-    rv = C_GenerateRandom(hSession, val, gen_key_len);
-    if (rv == CKR_OK)
-    {
-        if (keyType == CKK_GOST28147)
-        {
-            rv = CreateObject(hSession, keyAttribs, keyAttribsCount, phKey, OBJECT_OP_GENERATE);
-        }
-        else
-        {
-            rv = CreateObject(hSession, keyAttribs, keyAttribsCount, phKey, OBJECT_OP_GENERATE);
-        }
-    }
+	// Get the token
+	Token* token = session->getToken();
+	if (token == NULL)
+		return CKR_GENERAL_ERROR;
 
-    Session* session = (Session*)handleManager->getSession(hSession);
-    if (session == NULL)
-        return CKR_SESSION_HANDLE_INVALID;
+	// Extract desired parameter information
+	size_t keyLen = 0;
+	bool checkValue = true;
+	for (CK_ULONG i = 0; i < ulCount; i++)
+	{
+		switch (pTemplate[i].type)
+		{
+			case CKA_VALUE_LEN:
+				if (pTemplate[i].ulValueLen != sizeof(CK_ULONG))
+				{
+					INFO_MSG("CKA_VALUE_LEN does not have the size of CK_ULONG");
+					return CKR_ATTRIBUTE_VALUE_INVALID;
+				}
+				keyLen = *(CK_ULONG*)pTemplate[i].pValue;
+				break;
+			case CKA_CHECK_VALUE:
+				if (pTemplate[i].ulValueLen > 0)
+				{
+					INFO_MSG("CKA_CHECK_VALUE must be a no-value (0 length) entry");
+					return CKR_ATTRIBUTE_VALUE_INVALID;
+				}
+				checkValue = false;
+				break;
+			default:
+				break;
+		}
+	}
 
-    // Get the token
-    Token* token = session->getToken();
-    if (token == NULL)
-        return CKR_GENERAL_ERROR;
+	// CKA_VALUE_LEN must be specified
+	if (keyLen == 0)
+	{
+		INFO_MSG("Missing CKA_VALUE_LEN in pTemplate");
+		return CKR_TEMPLATE_INCOMPLETE;
+	}
 
-    // Store the attributes that are being supplied
-    if (rv == CKR_OK)
-    {
-        OSObject* osobject = (OSObject*)handleManager->getObject(*phKey);
-        if (osobject == NULL_PTR || !osobject->isValid()) {
-            rv = CKR_FUNCTION_FAILED;
-        } else if (osobject->startTransaction()) {
-            bool bOK = true;
+	// Check keyLen
+	if (keyLen < 1 || keyLen > 0x8000000)
+	{
+		INFO_MSG("bad generic key length");
+		return CKR_ATTRIBUTE_VALUE_INVALID;
+	}
 
-            // Common Attributes
-            bOK = bOK && osobject->setAttribute(CKA_LOCAL,true);
-            CK_ULONG ulKeyGenMechanism = (CK_ULONG)CKM_GENERIC_SECRET_KEY_GEN;
-            bOK = bOK && osobject->setAttribute(CKA_KEY_GEN_MECHANISM,ulKeyGenMechanism);
+	// Generate the secret key
+	RNG* rng = CryptoFactory::i()->getRNG();
+	if (rng == NULL) return CKR_GENERAL_ERROR;
+	ByteString key;
+	if (!rng->generateRandom(key, keyLen)) return CKR_GENERAL_ERROR;
 
-            // Common Secret Key Attributes
-            bool bAlwaysSensitive = osobject->getBooleanValue(CKA_SENSITIVE, false);
-            bOK = bOK && osobject->setAttribute(CKA_ALWAYS_SENSITIVE,bAlwaysSensitive);
-            bool bNeverExtractable = osobject->getBooleanValue(CKA_EXTRACTABLE, false) == false;
-            bOK = bOK && osobject->setAttribute(CKA_NEVER_EXTRACTABLE, bNeverExtractable);
+        CK_RV rv = CKR_OK;
 
-            ByteString rawval = ByteString(val, gen_key_len);
-            ByteString value;
-            if (isPrivate)
-            {
-                token->encrypt(rawval, value);
-            }
-            else
-            {
-                value = rawval;
-            }
-            bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
-            if (bOK)
-                bOK = osobject->commitTransaction();
-            else
-                osobject->abortTransaction();
+	// Create the secret key object using C_CreateObject
+	const CK_ULONG maxAttribs = 32;
+	CK_OBJECT_CLASS objClass = CKO_SECRET_KEY;
+	CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+	CK_ATTRIBUTE keyAttribs[maxAttribs] = {
+		{ CKA_CLASS, &objClass, sizeof(objClass) },
+		{ CKA_TOKEN, &isOnToken, sizeof(isOnToken) },
+		{ CKA_PRIVATE, &isPrivate, sizeof(isPrivate) },
+		{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
+	};
+	CK_ULONG keyAttribsCount = 4;
 
-            if (!bOK)
-                rv = CKR_FUNCTION_FAILED;
-        } else
-            rv = CKR_FUNCTION_FAILED;
-    }
-    return rv;
+	// Add the additional
+	if (ulCount > (maxAttribs - keyAttribsCount))
+		rv = CKR_TEMPLATE_INCONSISTENT;
+	for (CK_ULONG i=0; i < ulCount && rv == CKR_OK; ++i)
+	{
+		switch (pTemplate[i].type)
+		{
+			case CKA_CLASS:
+			case CKA_TOKEN:
+			case CKA_PRIVATE:
+			case CKA_KEY_TYPE:
+			case CKA_CHECK_VALUE:
+				continue;
+			default:
+				keyAttribs[keyAttribsCount++] = pTemplate[i];
+				break;
+		}
+	}
+
+	if (rv == CKR_OK)
+		rv = CreateObject(hSession, keyAttribs, keyAttribsCount, phKey, OBJECT_OP_GENERATE);
+
+	// Store the attributes that are being supplied
+	if (rv == CKR_OK)
+	{
+		OSObject* osobject = (OSObject*)handleManager->getObject(*phKey);
+		if (osobject == NULL_PTR || !osobject->isValid()) {
+			rv = CKR_FUNCTION_FAILED;
+		} else if (osobject->startTransaction()) {
+			bool bOK = true;
+
+			// Common Attributes
+			bOK = bOK && osobject->setAttribute(CKA_LOCAL,true);
+			CK_ULONG ulKeyGenMechanism = (CK_ULONG)CKM_GENERIC_SECRET_KEY_GEN;
+			bOK = bOK && osobject->setAttribute(CKA_KEY_GEN_MECHANISM,ulKeyGenMechanism);
+
+			// Common Secret Key Attributes
+			bool bAlwaysSensitive = osobject->getBooleanValue(CKA_SENSITIVE, false);
+			bOK = bOK && osobject->setAttribute(CKA_ALWAYS_SENSITIVE,bAlwaysSensitive);
+			bool bNeverExtractable = osobject->getBooleanValue(CKA_EXTRACTABLE, false) == false;
+			bOK = bOK && osobject->setAttribute(CKA_NEVER_EXTRACTABLE, bNeverExtractable);
+
+			// Generic Secret Key Attributes
+			ByteString value;
+			ByteString kcv;
+			SymmetricKey symKey;
+			symKey.setKeyBits(key);
+			symKey.setBitLen(keyLen);
+			if (isPrivate)
+			{
+				token->encrypt(symKey.getKeyBits(), value);
+				token->encrypt(symKey.getKeyCheckValue(), kcv);
+			}
+			else
+			{
+				value = symKey.getKeyBits();
+				kcv = symKey.getKeyCheckValue();
+			}
+			bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+			if (checkValue)
+				bOK = bOK && osobject->setAttribute(CKA_CHECK_VALUE, kcv);
+
+			if (bOK)
+				bOK = osobject->commitTransaction();
+			else
+				osobject->abortTransaction();
+
+			if (!bOK)
+				rv = CKR_FUNCTION_FAILED;
+		} else
+			rv = CKR_FUNCTION_FAILED;
+	}
+
+	// Clean up
+	// Remove the key that may have been created already when the function fails.
+	if (rv != CKR_OK)
+	{
+		if (*phKey != CK_INVALID_HANDLE)
+		{
+			OSObject* oskey = (OSObject*)handleManager->getObject(*phKey);
+			handleManager->destroyObject(*phKey);
+			if (oskey) oskey->destroyObject();
+			*phKey = CK_INVALID_HANDLE;
+		}
+	}
+
+	return rv;
 }
 
 // Generate an AES secret key

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -327,17 +327,15 @@ private:
 		CK_BBOOL isPrivateKeyOnToken,
 		CK_BBOOL isPrivateKeyPrivate
 	);
-    CK_RV generateGeneric
-    (
-        CK_SESSION_HANDLE hSession,
-        CK_ATTRIBUTE_PTR pTemplate,
-        CK_ULONG ulCount,
-        CK_OBJECT_HANDLE_PTR phKey,
-        CK_BBOOL isOnToken,
-        CK_BBOOL isPrivate,
-        CK_OBJECT_CLASS objClass,
-        CK_KEY_TYPE keyType
-    );
+	CK_RV generateGeneric
+	(
+		CK_SESSION_HANDLE hSession,
+		CK_ATTRIBUTE_PTR pTemplate,
+		CK_ULONG ulCount,
+		CK_OBJECT_HANDLE_PTR phKey,
+		CK_BBOOL isOnToken,
+		CK_BBOOL isPrivate
+	);
 	CK_RV deriveDH
 	(
 		CK_SESSION_HANDLE hSession,

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -327,6 +327,17 @@ private:
 		CK_BBOOL isPrivateKeyOnToken,
 		CK_BBOOL isPrivateKeyPrivate
 	);
+    CK_RV generateGeneric
+    (
+        CK_SESSION_HANDLE hSession,
+        CK_ATTRIBUTE_PTR pTemplate,
+        CK_ULONG ulCount,
+        CK_OBJECT_HANDLE_PTR phKey,
+        CK_BBOOL isOnToken,
+        CK_BBOOL isPrivate,
+        CK_OBJECT_CLASS objClass,
+        CK_KEY_TYPE keyType
+    );
 	CK_RV deriveDH
 	(
 		CK_SESSION_HANDLE hSession,

--- a/src/lib/test/SymmetricAlgorithmTests.h
+++ b/src/lib/test/SymmetricAlgorithmTests.h
@@ -48,6 +48,7 @@ class SymmetricAlgorithmTests : public TestsBase
 	CPPUNIT_TEST(testNonModifiableDesKeyGeneration);
 	CPPUNIT_TEST(testCheckValue);
 	CPPUNIT_TEST(testAesCtrOverflow);
+	CPPUNIT_TEST(testGenericKey);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -58,8 +59,10 @@ public:
 	void testNonModifiableDesKeyGeneration();
 	void testCheckValue();
 	void testAesCtrOverflow();
+	void testGenericKey();
 
 protected:
+	CK_RV generateGenericKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);
 	CK_RV generateAesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);
 #ifndef WITH_FIPS
 	CK_RV generateDesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);


### PR DESCRIPTION
Add support for CKM_GENERIC_SECRET_KEY_GEN which is required for HMAC operations in PKCS11 2.4.0.

Resolves #375 