### PR TITLE
Add VS2017 detection to Configure.py

### DIFF
--- a/win32/Configure.py
+++ b/win32/Configure.py
@@ -176,6 +176,8 @@ def dodetectplatform(visualstudio):
         toolset="v120"
     elif "Microsoft Visual Studio 14.0" in visualstudio:
         toolset="v140"
+    elif "Microsoft Visual Studio\\2017" in visualstudio:
+        toolset="v141"
     else:
         print("PlatformToolset for \""+visualstudio+"\" not supported")
         toolset=""


### PR DESCRIPTION
Hi, I've successfully [built SoftHSM 2.4.0 with Visual Studio 2017 Community](https://github.com/disig/SoftHSM2-for-Windows/blob/2.4.0/BUILDING.md) but I had to pass `with-toolset=v141` parameter to `Configure.py` script. This micropatch adds VS2017 detection to `Configure.py` script.