### PR TITLE
Update DBTests.cpp to fix x86 test failure

### DIFF
--- a/src/lib/object_store/test/DBTests.cpp
+++ b/src/lib/object_store/test/DBTests.cpp
@@ -348,7 +348,7 @@ void test_a_db_with_a_connection_with_tables::can_update_integer_attribute_bound
 
 	// insert integer attribute
 	statement = connection->prepare(
-				"insert into attribute_integer (value,type,object_id) values (%lld,%d,%lld)",
+				"insert into attribute_integer (value,type,object_id) values (%d,%d,%lld)",
 				1111,
 				1235,
 				object_id);


### PR DESCRIPTION
I don't know why this wasn't a problem on `x86_64` builds, but this test failed on `x86` alpinelinux.

See: https://github.com/tcely/aports/blob/a6fdb70c45eb7ce9eff1dff0993eeb93a012bfb6/testing/softhsm/fix-objstoretest.patch
http://build.alpinelinux.org/buildlogs/build-edge-x86/testing/softhsm/softhsm-2.4.0-r0.log