### PR TITLE
Issue #401 wrong key and keyserver mentioned in installation documentation

### DIFF
--- a/WIN32-NOTES.md
+++ b/WIN32-NOTES.md
@@ -212,7 +212,7 @@ Copy the results into `C:\build\bin\cppunit-1.13.2-x64` directory:
 Download the latest version of [SoftHSMv2](https://dist.opendnssec.org/source/) with its signature into `C:\build\src\` directory and verify signature of the downloaded archive:
 
     cd C:\build\src\
-    gpg --keyserver pgp.mit.edu --recv-keys 4EE17CD2
+    gpg --keyserver pgp.surfnet.nl --recv-keys 4FCB0B94
     gpg --verify softhsm-2.x.y.tar.gz.sig softhsm-2.x.y.tar.gz
     "C:\Program Files\7-Zip\7z" x softhsm-2.x.y.tar.gz
     "C:\Program Files\7-Zip\7z" x softhsm-2.x.y.tar


### PR DESCRIPTION
Issue #401
Out key isn't located at pgp.mit.edu but on the keyserver pgp.surfnet.nl.
At the moment it isn't easy to upload to all keyservers.
But also they key id is actually an old key, the new key in use for some
time is 4FCB0B94.