### PR TITLE
Correct the default config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Install the library using the follow command:
 
 ### Configure
 
-The default location of the config file is /etc/softhsm2.conf. This location
+The default location of the config file is /etc/softhsm/softhsm2.conf. This location
 can be change by setting the environment variable.
 
 	export SOFTHSM2_CONF=/home/user/config.file


### PR DESCRIPTION
According to `man softhsm2.conf` and experimentation on my system, the default config path is `/etc/softhsm/softhsm2.conf`.