### PR TITLE
Reset mutex callbacks to the default version when finished

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -321,6 +321,15 @@ static CK_ATTRIBUTE bsAttribute(CK_ATTRIBUTE_TYPE type, const ByteString &value)
 /*****************************************************************************
  Implementation of SoftHSM class specific functions
  *****************************************************************************/
+static void resetMutexFactoryCallbacks()
+{
+	// Reset MutexFactory callbacks to our versions
+	MutexFactory::i()->setCreateMutex(OSCreateMutex);
+	MutexFactory::i()->setDestroyMutex(OSDestroyMutex);
+	MutexFactory::i()->setLockMutex(OSLockMutex);
+	MutexFactory::i()->setUnlockMutex(OSUnlockMutex);
+}
+
 
 // Return the one-and-only instance
 SoftHSM* SoftHSM::i()
@@ -349,6 +358,7 @@ SoftHSM::SoftHSM()
 	slotManager = NULL;
 	sessionManager = NULL;
 	handleManager = NULL;
+	resetMutexFactoryCallbacks();
 }
 
 // Destructor
@@ -359,6 +369,7 @@ SoftHSM::~SoftHSM()
 	if (slotManager != NULL) delete slotManager;
 	if (objectStore != NULL) delete objectStore;
 	if (sessionObjectStore != NULL) delete sessionObjectStore;
+	resetMutexFactoryCallbacks();
 }
 
 /*****************************************************************************
@@ -409,10 +420,7 @@ CK_RV SoftHSM::C_Initialize(CK_VOID_PTR pInitArgs)
 			if (args->flags & CKF_OS_LOCKING_OK)
 			{
 				// Use our own mutex functions.
-				MutexFactory::i()->setCreateMutex(OSCreateMutex);
-				MutexFactory::i()->setDestroyMutex(OSDestroyMutex);
-				MutexFactory::i()->setLockMutex(OSLockMutex);
-				MutexFactory::i()->setUnlockMutex(OSUnlockMutex);
+				resetMutexFactoryCallbacks();
 				MutexFactory::i()->enable();
 			}
 			else


### PR DESCRIPTION
If a PKCS11 API caller provided own mutex handling callbacks,
we need to ensure they aren't used after C_Finalize is called
and SoftHSM instance is recycled.

Inability to do so may lead to a situation where callbacks might
be provided by a different dynamically loaded object which is removed
after C_Finalize() call. Thus, callback pointers become invalid and
calling them leads to crashes.

Fixes: https://github.com/opendnssec/SoftHSMv2/issues/408

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>