### PR TITLE
Set fields to NULL to avoid double free

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -365,10 +365,16 @@ SoftHSM::SoftHSM()
 SoftHSM::~SoftHSM()
 {
 	if (handleManager != NULL) delete handleManager;
+	handleManager = NULL;
 	if (sessionManager != NULL) delete sessionManager;
+	sessionManager = NULL;
 	if (slotManager != NULL) delete slotManager;
+	slotManager = NULL;
 	if (objectStore != NULL) delete objectStore;
+	objectStore = NULL;
 	if (sessionObjectStore != NULL) delete sessionObjectStore;
+	sessionObjectStore = NULL;
+
 	resetMutexFactoryCallbacks();
 }
 


### PR DESCRIPTION
I encountered this issue while attempting to diagnose the root cause of #417. I followed the procedures described by @parasssh, but I made two changes
1. I used a PKCS11 URL for which there was no matching object
2. I used the newly added `-check` flag in `openssl pkey`

I was using the latest master branches of SoftHSMv2 and lbp11. For OpenSSL, I used v1.1.1.

I then ran the command, resulting in a segfault
```
#pkey -engine pkcs11 -inform engine -in 'token=slot_111111-id=%11%11'   -check
engine "pkcs11" set.
Format not recognized!
The key ID is not a valid PKCS#11 URI
The PKCS#11 URI format is defined by RFC7512
The legacy ENGINE_pkcs11 ID format is also still accepted for now
Format not recognized!
The key ID is not a valid PKCS#11 URI
The PKCS#11 URI format is defined by RFC7512
The legacy ENGINE_pkcs11 ID format is also still accepted for now
PKCS11_get_private_key returned NULL
cannot load key from engine
140737353732544:error:80065064:pkcs11 engine:ctx_load_key:invalid id:eng_back.c:659:
140737353732544:error:26096080:engine routines:ENGINE_load_private_key:failed loading private key:crypto/engine/eng_pkey.c:78:
unable to load key
Segmentation fault
```
I attached GDB and obtained a stacktrace:
```Program received signal SIGSEGV, Segmentation fault.
0x0000000000000101 in ?? ()
>>>>where
#0  0x0000000000000101 in ?? ()
#1  0x00007ffff69dc136 in SoftHSM::C_Finalize (this=0x6d80a0, pReserved=<optimized out>) at SoftHSM.cpp:547
#2  0x00007ffff69c3611 in C_Finalize (pReserved=0x0) at main.cpp:148
#3  0x00007ffff6c6dcb3 in pkcs11_CTX_unload (ctx=0x6d5cd0) at p11_load.c:149
#4  0x00007ffff6c71d3a in PKCS11_CTX_unload (ctx=0x6d5cd0) at p11_front.c:53
#5  0x00007ffff6c67114 in ctx_finish (ctx=0x6d28a0) at eng_back.c:359
#6  0x00007ffff6c6643a in engine_finish (engine=0x6d1ad0) at eng_front.c:159
#7  0x00007ffff7798ae9 in engine_unlocked_finish (e=0x6d1ad0, unlock_for_handlers=0) at crypto/engine/eng_init.c:61
#8  0x00007ffff779b51e in int_cleanup_cb_doall (p=0x6d1760) at crypto/engine/eng_table.c:176
#9  0x00007ffff77c29cf in doall_util_fn (lh=0x6d16a0, use_arg=0, func=0x7ffff779b4d9 <int_cleanup_cb_doall>, func_arg=0x0, arg=0x0)
    at crypto/lhash/lhash.c:198
#10 0x00007ffff77c2a1d in OPENSSL_LH_doall (lh=0x6d16a0, func=0x7ffff779b4d9 <int_cleanup_cb_doall>) at crypto/lhash/lhash.c:206
#11 0x00007ffff779b078 in lh_ENGINE_PILE_doall (lh=0x6d16a0, doall=0x7ffff779b4d9 <int_cleanup_cb_doall>)
    at crypto/engine/eng_int.h:169
#12 0x00007ffff779b57b in engine_table_cleanup (table=0x7ffff7b23758 <rsa_table>) at crypto/engine/eng_table.c:184
#13 0x00007ffff779ca2b in engine_unregister_all_RSA () at crypto/engine/tb_rsa.c:22
#14 0x00007ffff7799245 in engine_cleanup_cb_free (item=0x6d30b0) at crypto/engine/eng_lib.c:162
#15 0x00007ffff78221e6 in OPENSSL_sk_pop_free (st=0x6b9820, func=0x7ffff7799230 <engine_cleanup_cb_free>) at crypto/stack/stack.c:368
#16 0x00007ffff7798d5b in sk_ENGINE_CLEANUP_ITEM_pop_free (sk=0x6b9820, freefunc=0x7ffff7799230 <engine_cleanup_cb_free>)
    at crypto/engine/eng_int.h:54
#17 0x00007ffff7799288 in engine_cleanup_int () at crypto/engine/eng_lib.c:169
#18 0x00007ffff77c47fc in OPENSSL_cleanup () at crypto/init.c:562
#19 0x00007ffff6eb15ec in __run_exit_handlers (status=1, listp=0x7ffff7231718 <__exit_funcs>, 
    run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#20 0x00007ffff6eb171c in __GI_exit (status=<optimized out>) at exit.c:139
#21 0x0000000000435c54 in main (argc=8, argv=0x7fffffffcb60) at apps/openssl.c:269
``` 

GDB showed that  `SoftHSM::C_Finalize()` was being called after  `SoftHSM::~SoftHSM()`. Since `SoftHSM::~SoftHSM()`  does not set fields to `NULL` after free, `SoftHSM::~SoftHSM()` attempted to free the same fields again.

I'm still investigating why `SoftHSM::C_Finalize()` is being called after `SoftHSM::~SoftHSM()`. As @ueno noted in #413, it appears both functions are called when the `exit()` function is invoked by `openssl pkey`.