### PR TITLE
Updated prerequisite to build from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ the source file name and line number.
 If the code is downloaded directly from the code repository, you have to
 prepare the configuration scripts before continuing with the real README.
 
-1. You need to install automake, autoconf, libtool, libtool-ltdl-devel, pkg-config.
+1. You need to install automake, autoconf, libtool, libtool-ltdl-devel (RHEL/CentOS), pkg-config.
 2. Run the command 'sh autogen.sh'
 3. Continue reading this README.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ the source file name and line number.
 If the code is downloaded directly from the code repository, you have to
 prepare the configuration scripts before continuing with the real README.
 
-1. You need to install automake, autoconf, libtool, pkg-config.
+1. You need to install automake, autoconf, libtool, libtool-ltdl-devel, pkg-config.
 2. Run the command 'sh autogen.sh'
 3. Continue reading this README.


### PR DESCRIPTION
Faced [issue ](https://github.com/opendnssec/SoftHSMv2/issues/429) while building from the repository because `libtool-ltdl-devel` was not installed.
Updated readme to reflect that.