### PR TITLE
Issue #435: Fix botan build without EDDSA

### DIFF
--- a/src/lib/crypto/BotanEDKeyPair.cpp
+++ b/src/lib/crypto/BotanEDKeyPair.cpp
@@ -31,6 +31,7 @@
  *****************************************************************************/
 
 #include "config.h"
+#ifdef WITH_EDDSA
 #include "log.h"
 #include "BotanEDKeyPair.h"
 
@@ -67,3 +68,4 @@ const PrivateKey* BotanEDKeyPair::getConstPrivateKey() const
 {
 	return &privKey;
 }
+#endif

--- a/src/lib/crypto/BotanEDKeyPair.h
+++ b/src/lib/crypto/BotanEDKeyPair.h
@@ -34,6 +34,7 @@
 #define _SOFTHSM_V2_BOTANEDKEYPAIR_H
 
 #include "config.h"
+#ifdef WITH_EDDSA
 #include "AsymmetricKeyPair.h"
 #include "BotanEDPublicKey.h"
 #include "BotanEDPrivateKey.h"
@@ -62,5 +63,6 @@ private:
 	// The private key
 	BotanEDPrivateKey privKey;
 };
+#endif
 #endif // !_SOFTHSM_V2_BOTANEDKEYPAIR_H
 

--- a/src/lib/crypto/BotanEDPrivateKey.h
+++ b/src/lib/crypto/BotanEDPrivateKey.h
@@ -34,6 +34,7 @@
 #define _SOFTHSM_V2_BOTANEDPRIVATEKEY_H
 
 #include "config.h"
+#ifdef WITH_EDDSA
 #include "EDPrivateKey.h"
 #include <botan/pk_keys.h>
 
@@ -82,4 +83,5 @@ private:
 	// Create the Botan representation of the key
 	void createBotanKey();
 };
+#endif
 #endif // !_SOFTHSM_V2_BOTANEDPRIVATEKEY_H

--- a/src/lib/crypto/BotanEDPublicKey.h
+++ b/src/lib/crypto/BotanEDPublicKey.h
@@ -34,6 +34,7 @@
 #define _SOFTHSM_V2_BOTANEDPUBLICKEY_H
 
 #include "config.h"
+#ifdef WITH_EDDSA
 #include "EDPublicKey.h"
 #include <botan/pk_keys.h>
 
@@ -74,4 +75,5 @@ private:
 	// Create the Botan representation of the key
 	void createBotanKey();
 };
+#endif
 #endif // !_SOFTHSM_V2_BOTANEDPUBLICKEY_H


### PR DESCRIPTION
Loading libsofthsm2.so (built on Ubuntu 14.04 with botan) failed with:

    ERROR: Could not load the PKCS#11 library/module: src/lib/libsofthsm2.so: undefined symbol: _ZN17BotanEDPrivateKeyD1Ev

Fixes #435 (a regression in 2.5.0 due to commit 2751555).
___
(verified this patch on Ubuntu 14.04, the library can load again, softhsm2-util init and import works.)