### PR TITLE
build: detect crypto algorithms by default

### DIFF
--- a/m4/acx_botan_ecc.m4
+++ b/m4/acx_botan_ecc.m4
@@ -41,11 +41,7 @@ AC_DEFUN([ACX_BOTAN_ECC],[
 			acx_cv_lib_botan_ecc_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find P256])
-			AC_MSG_ERROR([
-Botan library has no valid ECC support. Please upgrade to a later version
-of Botan, above or including version 1.10.6 or 1.11.5.
-Alternatively disable ECC support in SoftHSM with --disable-ecc
-])
+			acx_cv_lib_botan_ecc_support=no
 		],[
 			AC_MSG_WARN([Cannot test, assuming P256])
 			acx_cv_lib_botan_ecc_support=yes
@@ -55,4 +51,5 @@ Alternatively disable ECC support in SoftHSM with --disable-ecc
 
 	CPPFLAGS=$tmp_CPPFLAGS
 	LIBS=$tmp_LIBS
+	have_lib_botan_ecc_support="${acx_cv_lib_botan_ecc_support}"
 ])

--- a/m4/acx_botan_eddsa.m4
+++ b/m4/acx_botan_eddsa.m4
@@ -32,11 +32,7 @@ AC_DEFUN([ACX_BOTAN_EDDSA],[
 			acx_cv_lib_botan_eddsa_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find Ed25519])
-			AC_MSG_ERROR([
-Botan library has no valid EDDSA support. Please upgrade to a later version
-of Botan with EDDSA support.
-Alternatively disable EDDSA support in SoftHSM with --disable-eddsa
-])
+			acx_cv_lib_botan_eddsa_support=no
 		],[
 			AC_MSG_WARN([Cannot test, assuming EDDSA])
 			acx_cv_lib_botan_eddsa_support=yes
@@ -46,4 +42,5 @@ Alternatively disable EDDSA support in SoftHSM with --disable-eddsa
 
 	CPPFLAGS=$tmp_CPPFLAGS
 	LIBS=$tmp_LIBS
+	have_lib_botan_eddsa_support="${acx_cv_lib_botan_eddsa_support}"
 ])

--- a/m4/acx_botan_gost.m4
+++ b/m4/acx_botan_gost.m4
@@ -42,11 +42,7 @@ AC_DEFUN([ACX_BOTAN_GOST],[
 			acx_cv_lib_botan_gost_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find GOST])
-			AC_MSG_ERROR([
-Botan library has no valid GOST support. Please upgrade to a later version
-of Botan, above or including version 1.10.6 or 1.11.5.
-Alternatively disable GOST support in SoftHSM with --disable-gost
-])
+			acx_cv_lib_botan_gost_support=no
 		],[
 			AC_MSG_WARN([Cannot test, assuming GOST])
 			acx_cv_lib_botan_gost_support=yes
@@ -56,4 +52,5 @@ Alternatively disable GOST support in SoftHSM with --disable-gost
 
 	CPPFLAGS=$tmp_CPPFLAGS
 	LIBS=$tmp_LIBS
+	have_lib_botan_gost_support="${acx_cv_lib_botan_gost_support}"
 ])

--- a/m4/acx_openssl_ecc.m4
+++ b/m4/acx_openssl_ecc.m4
@@ -31,7 +31,7 @@ AC_DEFUN([ACX_OPENSSL_ECC],[
 			acx_cv_lib_openssl_ecc_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find P256, P384, or P521])
-			AC_MSG_ERROR([OpenSSL library has no ECC support])
+			acx_cv_lib_openssl_ecc_support=no
 		],[
 			AC_MSG_WARN([Cannot test, assuming P256, P384, and P521])
 			acx_cv_lib_openssl_ecc_support=yes
@@ -41,4 +41,5 @@ AC_DEFUN([ACX_OPENSSL_ECC],[
 
 	CPPFLAGS=$tmp_CPPFLAGS
 	LIBS=$tmp_LIBS
+	have_lib_openssl_ecc_support="${acx_cv_lib_openssl_ecc_support}"
 ])

--- a/m4/acx_openssl_eddsa.m4
+++ b/m4/acx_openssl_eddsa.m4
@@ -1,5 +1,5 @@
 AC_DEFUN([ACX_OPENSSL_EDDSA],[
-	AC_MSG_CHECKING(for OpenSSL EDDSA support)
+	AC_MSG_CHECKING(for OpenSSL EDDSA ED25519 support)
 
 	tmp_CPPFLAGS=$CPPFLAGS
 	tmp_LIBS=$LIBS
@@ -29,12 +29,14 @@ AC_DEFUN([ACX_OPENSSL_EDDSA],[
 			acx_cv_lib_openssl_ed25519_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find ED25519])
-			AC_MSG_ERROR([OpenSSL library has no EDDSA support])
+			acx_cv_lib_openssl_ed25519_support=no
 		],[
 			AC_MSG_WARN([Cannot test, ED25519])
 			acx_cv_lib_openssl_ed25519_support=yes
 		])
 	])
+
+	AC_MSG_CHECKING(for OpenSSL EDDSA ED448 support)
 	AC_CACHE_VAL([acx_cv_lib_openssl_ed448_support],[
 		acx_cv_lib_openssl_ed448_support=no
 		AC_RUN_IFELSE([
@@ -56,6 +58,7 @@ AC_DEFUN([ACX_OPENSSL_EDDSA],[
 			acx_cv_lib_openssl_ed448_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find ED448])
+			acx_cv_lib_openssl_ed448_support=no
 		],[
 			AC_MSG_WARN([Cannot test, ED448])
 			acx_cv_lib_openssl_ed448_support=yes
@@ -65,4 +68,6 @@ AC_DEFUN([ACX_OPENSSL_EDDSA],[
 
 	CPPFLAGS=$tmp_CPPFLAGS
 	LIBS=$tmp_LIBS
+	have_lib_openssl_ed25519_support="${acx_cv_lib_openssl_ed25519_support}"
+	have_lib_openssl_ed448_support="${acx_cv_lib_openssl_ed448_support}"
 ])

--- a/m4/acx_openssl_gost.m4
+++ b/m4/acx_openssl_gost.m4
@@ -59,7 +59,7 @@ AC_DEFUN([ACX_OPENSSL_GOST],[
 			acx_cv_lib_openssl_gost_support=yes
 		],[
 			AC_MSG_RESULT([Cannot find GOST engine])
-			AC_MSG_ERROR([OpenSSL library has no GOST support])
+			acx_cv_lib_openssl_gost_support=no
 		],[
 			AC_MSG_WARN([Cannot test, assuming GOST engine])
 			acx_cv_lib_openssl_gost_support=yes
@@ -69,4 +69,5 @@ AC_DEFUN([ACX_OPENSSL_GOST],[
 
 	CPPFLAGS=$tmp_CPPFLAGS
 	LIBS=$tmp_LIBS
+	have_lib_openssl_gost_support="${acx_cv_lib_openssl_gost_support}"
 ])


### PR DESCRIPTION
Currently the crypto algorithm settings are either enabled or disabled, this
makes it difficult to support permutations openssl, libressl, botan versions,
as these differ in capabilities.

In most cases, the library should use the crypto library capabilities unless
explicitly required otherwise by the users.

This change handles tree state value for the --enable-<algo>:
 * detect [default] - set to yes/no based on supported detection.
 * yes - must be supported and used.
 * no - should not be used.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>