### PR TITLE
Perform copy only if value has size > 0.

### DIFF
--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -340,8 +340,10 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 					ERROR_MSG("Internal error: failed to decrypt private attribute value");
 					return CKR_GENERAL_ERROR;
 				}
-				const unsigned char* attrPtr = value.const_byte_str();
-				memcpy(pValue,attrPtr,attrSize);
+				if (value.size() !=  0) {
+					const unsigned char* attrPtr = value.const_byte_str();
+					memcpy(pValue,attrPtr,attrSize);
+				}
 			}
 			else if (attr.getByteStringValue().size() != 0)
 			{

--- a/src/lib/data_mgr/ByteString.cpp
+++ b/src/lib/data_mgr/ByteString.cpp
@@ -37,6 +37,14 @@
 #include "log.h"
 #include "ByteString.h"
 
+/**
+ * Backward compatible fix: byte_str()/const_byte_str() to
+ * return a non-NULL pointer, even if size() == 0, and yet
+ * be compatible with -Wp,-D_GLIBCXX_ASSERTIONS stricter
+ * bounds checking
+ */
+static unsigned char sentinel[1];
+
 // Constructors
 ByteString::ByteString()
 {
@@ -187,13 +195,21 @@ unsigned char& ByteString::operator[](size_t pos)
 // Return the byte string data
 unsigned char* ByteString::byte_str()
 {
-	return &byteString[0];
+	if (byteString.size() != 0) {
+		return &byteString[0];
+	} else {
+		return (unsigned char*) sentinel;
+	}
 }
 
 // Return the const byte string
 const unsigned char* ByteString::const_byte_str() const
 {
-	return (const unsigned char*) &byteString[0];
+	if (byteString.size() != 0) {
+		return (const unsigned char*) &byteString[0];
+	} else {
+		return (const unsigned char*) sentinel;
+	}
 }
 
 // Return a hexadecimal character representation of the string


### PR DESCRIPTION
Addresses #449.

When `value` has size 0, the invalid reference  `&byteString[0]` in `ByteString::const_byte_str` will cause an assertion when built with the flag `-Wp,-D_GLIBCXX_ASSERTIONS` (used by default in distros like Fedora)