### PR TITLE
Provide a new configuration option to allow enabling and disabling various mechanisms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ src/lib/session_mgr/test/sessionmgrtest
 src/lib/slot_mgr/test/slotmgrtest
 src/lib/test/p11test
 src/lib/test/softhsm2-alt.conf
+src/lib/test/softhsm2-mech.conf
 src/lib/test/softhsm2.conf
 src/lib/test/tokens/64d6c3fe-1575-1736-1d26-5ccb28440ea7/
 src/lib/test/tokens/dummy

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,7 @@ AC_CONFIG_FILES([
 	src/lib/test/Makefile
 	src/lib/test/softhsm2.conf
 	src/lib/test/softhsm2-alt.conf
+	src/lib/test/softhsm2-mech.conf
 	src/lib/test/tokens/dummy
 	src/bin/Makefile
 	src/bin/common/Makefile

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -77,6 +77,7 @@
 #endif
 
 #include <stdlib.h>
+#include <algorithm>
 
 // Initialise the one-and-only instance
 
@@ -378,6 +379,11 @@ SoftHSM::~SoftHSM()
 	resetMutexFactoryCallbacks();
 }
 
+// A list with the supported mechanisms
+std::map<std::string, CK_MECHANISM_TYPE> mechanisms_table;
+std::list<CK_MECHANISM_TYPE> supportedMechanisms;
+CK_ULONG nrSupportedMechanisms;
+
 /*****************************************************************************
  Implementation of PKCS #11 functions
  *****************************************************************************/
@@ -525,6 +531,9 @@ CK_RV SoftHSM::C_Initialize(CK_VOID_PTR pInitArgs)
 		return CKR_GENERAL_ERROR;
 	}
 
+	// Load the enabled list of algorithms
+	prepareSupportedMecahnisms(mechanisms_table);
+
 	isRemovable = Configuration::i()->getBool("slots.removable", false);
 
 	// Load the slot manager
@@ -644,115 +653,154 @@ CK_RV SoftHSM::C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 	return token->getTokenInfo(pInfo);
 }
 
+void SoftHSM::prepareSupportedMecahnisms(std::map<std::string, CK_MECHANISM_TYPE> &t)
+{
+#ifndef WITH_FIPS
+	t["CKM_MD5"]			= CKM_MD5;
+#endif
+	t["CKM_SHA_1"]			= CKM_SHA_1;
+	t["CKM_SHA224"]			= CKM_SHA224;
+	t["CKM_SHA256"]			= CKM_SHA256;
+	t["CKM_SHA384"]			= CKM_SHA384;
+	t["CKM_SHA512"]			= CKM_SHA512;
+#ifndef WITH_FIPS
+	t["CKM_MD5_HMAC"]		= CKM_MD5_HMAC;
+#endif
+	t["CKM_SHA_1_HMAC"]		= CKM_SHA_1_HMAC;
+	t["CKM_SHA224_HMAC"]		= CKM_SHA224_HMAC;
+	t["CKM_SHA256_HMAC"]		= CKM_SHA256_HMAC;
+	t["CKM_SHA384_HMAC"]		= CKM_SHA384_HMAC;
+	t["CKM_SHA512_HMAC"]		= CKM_SHA512_HMAC;
+	t["CKM_RSA_PKCS_KEY_PAIR_GEN"]	= CKM_RSA_PKCS_KEY_PAIR_GEN;
+	t["CKM_RSA_PKCS"]		= CKM_RSA_PKCS;
+	t["CKM_RSA_X_509"]		= CKM_RSA_X_509;
+#ifndef WITH_FIPS
+	t["CKM_MD5_RSA_PKCS"]		= CKM_MD5_RSA_PKCS;
+#endif
+	t["CKM_SHA1_RSA_PKCS"]		= CKM_SHA1_RSA_PKCS;
+	t["CKM_RSA_PKCS_OAEP"]		= CKM_RSA_PKCS_OAEP;
+	t["CKM_SHA224_RSA_PKCS"]	= CKM_SHA224_RSA_PKCS;
+	t["CKM_SHA256_RSA_PKCS"]	= CKM_SHA256_RSA_PKCS;
+	t["CKM_SHA384_RSA_PKCS"]	= CKM_SHA384_RSA_PKCS;
+	t["CKM_SHA512_RSA_PKCS"]	= CKM_SHA512_RSA_PKCS;
+#ifdef WITH_RAW_PSS
+	t["CKM_RSA_PKCS_PSS"]		= CKM_RSA_PKCS_PSS;
+#endif
+	t["CKM_SHA1_RSA_PKCS_PSS"]	= CKM_SHA1_RSA_PKCS_PSS;
+	t["CKM_SHA224_RSA_PKCS_PSS"]	= CKM_SHA224_RSA_PKCS_PSS;
+	t["CKM_SHA256_RSA_PKCS_PSS"]	= CKM_SHA256_RSA_PKCS_PSS;
+	t["CKM_SHA384_RSA_PKCS_PSS"]	= CKM_SHA384_RSA_PKCS_PSS;
+	t["CKM_SHA512_RSA_PKCS_PSS"]	= CKM_SHA512_RSA_PKCS_PSS;
+	t["CKM_GENERIC_SECRET_KEY_GEN"]	= CKM_GENERIC_SECRET_KEY_GEN;
+#ifndef WITH_FIPS
+	t["CKM_DES_KEY_GEN"]		= CKM_DES_KEY_GEN;
+#endif
+	t["CKM_DES2_KEY_GEN"]		= CKM_DES2_KEY_GEN;
+	t["CKM_DES3_KEY_GEN"]		= CKM_DES3_KEY_GEN;
+#ifndef WITH_FIPS
+	t["CKM_DES_ECB"]		= CKM_DES_ECB;
+	t["CKM_DES_CBC"]		= CKM_DES_CBC;
+	t["CKM_DES_CBC_PAD"]		= CKM_DES_CBC_PAD;
+	t["CKM_DES_ECB_ENCRYPT_DATA"]	= CKM_DES_ECB_ENCRYPT_DATA;
+	t["CKM_DES_CBC_ENCRYPT_DATA"]	= CKM_DES_CBC_ENCRYPT_DATA;
+#endif
+	t["CKM_DES3_ECB"]		= CKM_DES3_ECB;
+	t["CKM_DES3_CBC"]		= CKM_DES3_CBC;
+	t["CKM_DES3_CBC_PAD"]		= CKM_DES3_CBC_PAD;
+	t["CKM_DES3_ECB_ENCRYPT_DATA"]	= CKM_DES3_ECB_ENCRYPT_DATA;
+	t["CKM_DES3_CBC_ENCRYPT_DATA"]	= CKM_DES3_CBC_ENCRYPT_DATA;
+	t["CKM_DES3_CMAC"]		= CKM_DES3_CMAC;
+	t["CKM_AES_KEY_GEN"]		= CKM_AES_KEY_GEN;
+	t["CKM_AES_ECB"]		= CKM_AES_ECB;
+	t["CKM_AES_CBC"]		= CKM_AES_CBC;
+	t["CKM_AES_CBC_PAD"]		= CKM_AES_CBC_PAD;
+	t["CKM_AES_CTR"]		= CKM_AES_CTR;
+#ifdef WITH_AES_GCM
+	t["CKM_AES_GCM"]		= CKM_AES_GCM;
+#endif
+	t["CKM_AES_KEY_WRAP"]		= CKM_AES_KEY_WRAP;
+#ifdef HAVE_AES_KEY_WRAP_PAD
+	t["CKM_AES_KEY_WRAP_PAD"]	= CKM_AES_KEY_WRAP_PAD;
+#endif
+	t["CKM_AES_ECB_ENCRYPT_DATA"]	= CKM_AES_ECB_ENCRYPT_DATA;
+	t["CKM_AES_CBC_ENCRYPT_DATA"]	= CKM_AES_CBC_ENCRYPT_DATA;
+	t["CKM_AES_CMAC"]		= CKM_AES_CMAC;
+	t["CKM_DSA_PARAMETER_GEN"]	= CKM_DSA_PARAMETER_GEN;
+	t["CKM_DSA_KEY_PAIR_GEN"]	= CKM_DSA_KEY_PAIR_GEN;
+	t["CKM_DSA"]			= CKM_DSA;
+	t["CKM_DSA_SHA1"]		= CKM_DSA_SHA1;
+	t["CKM_DSA_SHA224"]		= CKM_DSA_SHA224;
+	t["CKM_DSA_SHA256"]		= CKM_DSA_SHA256;
+	t["CKM_DSA_SHA384"]		= CKM_DSA_SHA384;
+	t["CKM_DSA_SHA512"]		= CKM_DSA_SHA512;
+	t["CKM_DH_PKCS_KEY_PAIR_GEN"]	= CKM_DH_PKCS_KEY_PAIR_GEN;
+	t["CKM_DH_PKCS_PARAMETER_GEN"]	= CKM_DH_PKCS_PARAMETER_GEN;
+	t["CKM_DH_PKCS_DERIVE"]		= CKM_DH_PKCS_DERIVE;
+#ifdef WITH_ECC
+	t["CKM_EC_KEY_PAIR_GEN"]	= CKM_EC_KEY_PAIR_GEN;
+	t["CKM_ECDSA"]			= CKM_ECDSA;
+#endif
+#if defined(WITH_ECC) || defined(WITH_EDDSA)
+	t["CKM_ECDH1_DERIVE"]		= CKM_ECDH1_DERIVE;
+#endif
+#ifdef WITH_GOST
+	t["CKM_GOSTR3411"]		= CKM_GOSTR3411;
+	t["CKM_GOSTR3411_HMAC"]		= CKM_GOSTR3411_HMAC;
+	t["CKM_GOSTR3410_KEY_PAIR_GEN"]	= CKM_GOSTR3410_KEY_PAIR_GEN;
+	t["CKM_GOSTR3410"]		= CKM_GOSTR3410;
+	t["CKM_GOSTR3410_WITH_GOSTR3411"] = CKM_GOSTR3410_WITH_GOSTR3411;
+#endif
+#ifdef WITH_EDDSA
+	t["CKM_EC_EDWARDS_KEY_PAIR_GEN"] = CKM_EC_EDWARDS_KEY_PAIR_GEN;
+	t["CKM_EDDSA"]			= CKM_EDDSA;
+#endif
+
+	for (auto it = t.begin(); it != t.end(); ++it)
+	{
+		supportedMechanisms.push_back(it->second);
+	}
+
+	/* Check configuration for supported algorithms */
+	std::string mechs = Configuration::i()->getString("token.mechanisms", "ALL");
+	if (mechs != "ALL")
+	{
+		bool negative = (mechs[0] == '-');
+		if (!negative)
+		{
+			/* For positive list, we remove everything */
+			supportedMechanisms.clear();
+		}
+		size_t pos = 0, prev = 0;
+		std::string token;
+		do
+		{
+			pos = mechs.find(",", prev);
+			if (pos == std::string::npos) pos = mechs.length();
+			token = mechs.substr(prev, pos - prev);
+			CK_MECHANISM_TYPE mechanism;
+			try
+			{
+				mechanism = t.at(token);
+				if (!negative)
+					supportedMechanisms.push_back(mechanism);
+				else
+					supportedMechanisms.remove(mechanism);
+			}
+			catch (const std::out_of_range& e)
+			{
+				WARNING_MSG("Unknown mechanism provided: %s", token.c_str());
+			}
+			prev = pos + 1;
+		}
+		while (pos < mechs.length() && prev < mechs.length());
+	}
+
+	nrSupportedMechanisms = supportedMechanisms.size();
+}
+
 // Return the list of supported mechanisms for a given slot
 CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMechanismList, CK_ULONG_PTR pulCount)
 {
-	// A list with the supported mechanisms
-	std::list<CK_MECHANISM_TYPE> supportedMechanisms =
-	{
-#ifndef WITH_FIPS
-		CKM_MD5,
-#endif
-		CKM_SHA_1,
-		CKM_SHA224,
-		CKM_SHA256,
-		CKM_SHA384,
-		CKM_SHA512,
-#ifndef WITH_FIPS
-		CKM_MD5_HMAC,
-#endif
-		CKM_SHA_1_HMAC,
-		CKM_SHA224_HMAC,
-		CKM_SHA256_HMAC,
-		CKM_SHA384_HMAC,
-		CKM_SHA512_HMAC,
-		CKM_RSA_PKCS_KEY_PAIR_GEN,
-		CKM_RSA_PKCS,
-		CKM_RSA_X_509,
-#ifndef WITH_FIPS
-		CKM_MD5_RSA_PKCS,
-#endif
-		CKM_SHA1_RSA_PKCS,
-		CKM_RSA_PKCS_OAEP,
-		CKM_SHA224_RSA_PKCS,
-		CKM_SHA256_RSA_PKCS,
-		CKM_SHA384_RSA_PKCS,
-		CKM_SHA512_RSA_PKCS,
-#ifdef WITH_RAW_PSS
-		CKM_RSA_PKCS_PSS,
-#endif
-		CKM_SHA1_RSA_PKCS_PSS,
-		CKM_SHA224_RSA_PKCS_PSS,
-		CKM_SHA256_RSA_PKCS_PSS,
-		CKM_SHA384_RSA_PKCS_PSS,
-		CKM_SHA512_RSA_PKCS_PSS,
-		CKM_GENERIC_SECRET_KEY_GEN,
-#ifndef WITH_FIPS
-		CKM_DES_KEY_GEN,
-#endif
-		CKM_DES2_KEY_GEN,
-		CKM_DES3_KEY_GEN,
-#ifndef WITH_FIPS
-		CKM_DES_ECB,
-		CKM_DES_CBC,
-		CKM_DES_CBC_PAD,
-		CKM_DES_ECB_ENCRYPT_DATA,
-		CKM_DES_CBC_ENCRYPT_DATA,
-#endif
-		CKM_DES3_ECB,
-		CKM_DES3_CBC,
-		CKM_DES3_CBC_PAD,
-		CKM_DES3_ECB_ENCRYPT_DATA,
-		CKM_DES3_CBC_ENCRYPT_DATA,
-		CKM_DES3_CMAC,
-		CKM_AES_KEY_GEN,
-		CKM_AES_ECB,
-		CKM_AES_CBC,
-		CKM_AES_CBC_PAD,
-		CKM_AES_CTR,
-#ifdef WITH_AES_GCM
-		CKM_AES_GCM,
-#endif
-		CKM_AES_KEY_WRAP,
-#ifdef HAVE_AES_KEY_WRAP_PAD
-		CKM_AES_KEY_WRAP_PAD,
-#endif
-		CKM_AES_ECB_ENCRYPT_DATA,
-		CKM_AES_CBC_ENCRYPT_DATA,
-		CKM_AES_CMAC,
-		CKM_DSA_PARAMETER_GEN,
-		CKM_DSA_KEY_PAIR_GEN,
-		CKM_DSA,
-		CKM_DSA_SHA1,
-		CKM_DSA_SHA224,
-		CKM_DSA_SHA256,
-		CKM_DSA_SHA384,
-		CKM_DSA_SHA512,
-		CKM_DH_PKCS_KEY_PAIR_GEN,
-		CKM_DH_PKCS_PARAMETER_GEN,
-		CKM_DH_PKCS_DERIVE,
-#ifdef WITH_ECC
-		CKM_EC_KEY_PAIR_GEN,
-		CKM_ECDSA,
-#endif
-#if defined(WITH_ECC) || defined(WITH_EDDSA)
-		CKM_ECDH1_DERIVE,
-#endif
-#ifdef WITH_GOST
-		CKM_GOSTR3411,
-		CKM_GOSTR3411_HMAC,
-		CKM_GOSTR3410_KEY_PAIR_GEN,
-		CKM_GOSTR3410,
-		CKM_GOSTR3410_WITH_GOSTR3411,
-#endif
-#ifdef WITH_EDDSA
-		CKM_EC_EDWARDS_KEY_PAIR_GEN,
-		CKM_EDDSA,
-#endif
-	};
-	CK_ULONG nrSupportedMechanisms = supportedMechanisms.size();
-
-
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 	if (pulCount == NULL_PTR) return CKR_ARGUMENTS_BAD;
 
@@ -12202,9 +12250,17 @@ CK_RV SoftHSM::MechParamCheckRSAPKCSOAEP(CK_MECHANISM_PTR pMechanism)
 	return CKR_OK;
 }
 
-bool SoftHSM::isMechanismPermitted(OSObject* key, CK_MECHANISM_PTR pMechanism) {
+bool SoftHSM::isMechanismPermitted(OSObject* key, CK_MECHANISM_PTR pMechanism)
+{
+	std::list<CK_MECHANISM_TYPE> mechs = supportedMechanisms;
+	/* First check if the algorithm is enabled in the global configuration */
+	auto it = std::find(mechs.begin(), mechs.end(), pMechanism->mechanism);
+	if (it == mechs.end())
+		return false;
+
 	OSAttribute attribute = key->getAttribute(CKA_ALLOWED_MECHANISMS);
 	std::set<CK_MECHANISM_TYPE> allowed = attribute.getMechanismTypeSetValue();
+
 	if (allowed.empty()) {
 		return true;
 	}

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -648,33 +648,7 @@ CK_RV SoftHSM::C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMechanismList, CK_ULONG_PTR pulCount)
 {
 	// A list with the supported mechanisms
-	CK_ULONG nrSupportedMechanisms = 62;
-#ifdef WITH_ECC
-	nrSupportedMechanisms += 2;
-#endif
-#if defined(WITH_ECC) || defined(WITH_EDDSA)
-	nrSupportedMechanisms += 1;
-#endif
-#ifdef WITH_FIPS
-	nrSupportedMechanisms -= 9;
-#endif
-#ifdef WITH_GOST
-	nrSupportedMechanisms += 5;
-#endif
-#ifdef HAVE_AES_KEY_WRAP_PAD
-	nrSupportedMechanisms += 1;
-#endif
-#ifdef WITH_RAW_PSS
-	nrSupportedMechanisms += 1; // CKM_RSA_PKCS_PSS
-#endif
-#ifdef WITH_AES_GCM
-	nrSupportedMechanisms += 1;
-#endif
-#ifdef WITH_EDDSA
-	nrSupportedMechanisms += 2;
-#endif
-
-	CK_MECHANISM_TYPE supportedMechanisms[] =
+	std::list<CK_MECHANISM_TYPE> supportedMechanisms =
 	{
 #ifndef WITH_FIPS
 		CKM_MD5,
@@ -776,6 +750,8 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 		CKM_EDDSA,
 #endif
 	};
+	CK_ULONG nrSupportedMechanisms = supportedMechanisms.size();
+
 
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 	if (pulCount == NULL_PTR) return CKR_ARGUMENTS_BAD;
@@ -802,9 +778,11 @@ CK_RV SoftHSM::C_GetMechanismList(CK_SLOT_ID slotID, CK_MECHANISM_TYPE_PTR pMech
 
 	*pulCount = nrSupportedMechanisms;
 
-	for (CK_ULONG i = 0; i < nrSupportedMechanisms; i ++)
+	int i = 0;
+	auto it = supportedMechanisms.cbegin();
+	for (; it != supportedMechanisms.cend(); it++, i++)
 	{
-		pMechanismList[i] = supportedMechanisms[i];
+		pMechanismList[i] = *it;
 	}
 
 	return CKR_OK;

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -477,5 +477,6 @@ private:
 	CK_RV MechParamCheckRSAPKCSOAEP(CK_MECHANISM_PTR pMechanism);
 
 	static bool isMechanismPermitted(OSObject* key, CK_MECHANISM_PTR pMechanism);
+	static void prepareSupportedMecahnisms(std::map<std::string, CK_MECHANISM_TYPE> &t);
 };
 

--- a/src/lib/common/Configuration.cpp
+++ b/src/lib/common/Configuration.cpp
@@ -48,6 +48,7 @@ const struct config Configuration::valid_config[] = {
 	{ "objectstore.backend",	CONFIG_TYPE_STRING },
 	{ "log.level",			CONFIG_TYPE_STRING },
 	{ "slots.removable",		CONFIG_TYPE_BOOL },
+	{ "token.mechanisms",		CONFIG_TYPE_STRING },
 	{ "",				CONFIG_TYPE_UNSUPPORTED }
 };
 

--- a/src/lib/common/softhsm2.conf.5.in
+++ b/src/lib/common/softhsm2.conf.5.in
@@ -64,6 +64,24 @@ slots.removable = true
 .fi
 .RE
 .LP
+.SH TOKEN.MECHANISMS
+Allows to enable and disable any of the PKCS#11 mechanisms reported in the
+C_GetMechanismList().
+The option accepts string argument containing the comma separated list of all
+algorithms that should be enabled (do not forget about the keygen mechanisms).
+The list can be prefixed with minus sign "-" to list only the disabled
+mechanisms.
+Additionally, special keyword ALL can be used to enable all the known
+mechanisms (default). Unknown mechanisms are ignored.
+This option has higher priority than the CKA_ALLOWED_MECHANISMS attribute
+on the key objects.
+.LP
+.RS
+.nf
+token.mechanisms = ALL
+.fi
+.RE
+.LP
 .SH ENVIRONMENT
 .TP
 SOFTHSM2_CONF

--- a/src/lib/common/softhsm2.conf.in
+++ b/src/lib/common/softhsm2.conf.in
@@ -8,3 +8,6 @@ log.level = ERROR
 
 # If CKF_REMOVABLE_DEVICE flag should be set
 slots.removable = false
+
+# Enable and disable PKCS#11 mechanisms using token.mechanisms.
+token.mechanisms = ALL

--- a/src/lib/test/CMakeLists.txt
+++ b/src/lib/test/CMakeLists.txt
@@ -40,4 +40,5 @@ add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME}
 set(builddir ${PROJECT_BINARY_DIR})
 configure_file(softhsm2.conf.in softhsm2.conf)
 configure_file(softhsm2-alt.conf.in softhsm2-alt.conf)
+configure_file(softhsm2-mech.conf.in softhsm2-mech.conf)
 configure_file(tokens/dummy.in tokens/dummy)

--- a/src/lib/test/InfoTests.cpp
+++ b/src/lib/test/InfoTests.cpp
@@ -260,6 +260,7 @@ void InfoTests::testGetMechanismList()
 	// Get the size of the buffer
 	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
+	CPPUNIT_ASSERT(ulMechCount > 2);
 	pMechanismList = (CK_MECHANISM_TYPE_PTR)malloc(ulMechCount * sizeof(CK_MECHANISM_TYPE_PTR));
 
 	// Check if we have a too small buffer
@@ -317,4 +318,47 @@ void InfoTests::testGetMechanismInfo()
 	free(pMechanismList);
 
 	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+}
+
+
+void InfoTests::testGetMechanismListConfig()
+{
+	CK_RV rv;
+	CK_ULONG ulMechCount = 0;
+	CK_MECHANISM_TYPE_PTR pMechanismList;
+
+#ifndef _WIN32
+    setenv("SOFTHSM2_CONF", "./softhsm2-mech.conf", 1);
+#else
+    setenv("SOFTHSM2_CONF", ".\\softhsm2-mech.conf", 1);
+#endif
+
+	// Just make sure that we finalize any previous failed tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount) );
+	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
+
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Get the size of the buffer
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, NULL_PTR, &ulMechCount) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	CPPUNIT_ASSERT_EQUAL((CK_ULONG)2, ulMechCount);
+	pMechanismList = (CK_MECHANISM_TYPE_PTR)malloc(ulMechCount * sizeof(CK_MECHANISM_TYPE_PTR));
+
+	// Get the mechanism list
+	rv = CRYPTOKI_F_PTR( C_GetMechanismList(m_initializedTokenSlotID, pMechanismList, &ulMechCount) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	CPPUNIT_ASSERT(pMechanismList[0] == CKM_RSA_X_509);
+	CPPUNIT_ASSERT(pMechanismList[1] == CKM_RSA_PKCS);
+	free(pMechanismList);
+
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+#ifndef _WIN32
+	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
 }

--- a/src/lib/test/InfoTests.h
+++ b/src/lib/test/InfoTests.h
@@ -48,6 +48,7 @@ class InfoTests : public TestsNoPINInitBase
 	CPPUNIT_TEST(testGetMechanismList);
 	CPPUNIT_TEST(testGetMechanismInfo);
 	CPPUNIT_TEST(testGetSlotInfoAlt);
+	CPPUNIT_TEST(testGetMechanismListConfig);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -59,6 +60,7 @@ public:
 	void testGetMechanismList();
 	void testGetMechanismInfo();
 	void testGetSlotInfoAlt();
+	void testGetMechanismListConfig();
 };
 
 #endif // !_SOFTHSM_V2_INFOTESTS_H

--- a/src/lib/test/Makefile.am
+++ b/src/lib/test/Makefile.am
@@ -37,5 +37,6 @@ TESTS = 			p11test
 EXTRA_DIST =			$(srcdir)/CMakeLists.txt \
 				$(srcdir)/*.h \
 				$(srcdir)/softhsm2-alt.conf.win32 \
+				$(srcdir)/softhsm2-mech.conf.win32 \
 				$(srcdir)/softhsm2.conf.win32 \
 				$(srcdir)/tokens/dummy.in

--- a/src/lib/test/softhsm2-mech.conf.in
+++ b/src/lib/test/softhsm2-mech.conf.in
@@ -1,0 +1,8 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = @builddir@/tokens
+objectstore.backend = file
+log.level = INFO
+slots.removable = false
+token.mechanisms = CKM_RSA_X_509,CKM_RSA_PKCS
+

--- a/src/lib/test/softhsm2-mech.conf.win32
+++ b/src/lib/test/softhsm2-mech.conf.win32
@@ -1,0 +1,7 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = .\tokens
+objectstore.backend = file
+log.level = INFO
+slots.removable = false
+token.mechanisms = CKM_RSA_X_509,CKM_RSA_PKCS

--- a/win32/p11test/p11test.vcxproj.in
+++ b/win32/p11test/p11test.vcxproj.in
@@ -65,6 +65,7 @@
       <Command>
 copy ..\..\src\lib\test\softhsm2.conf.win32 "$(TargetDir)\softhsm2.conf"
 copy ..\..\src\lib\test\softhsm2-alt.conf.win32 "$(TargetDir)\softhsm2-alt.conf"
+copy ..\..\src\lib\test\softhsm2-mech.conf.win32 "$(TargetDir)\softhsm2-mech.conf"
 mkdir "$(TargetDir)\tokens" 2&gt; nul
 copy ..\..\src\lib\test\tokens\dummy.in "$(TargetDir)\tokens\dummy"
       </Command>
@@ -95,6 +96,7 @@ copy ..\..\src\lib\test\tokens\dummy.in "$(TargetDir)\tokens\dummy"
       <Command>
 copy ..\..\src\lib\test\softhsm2.conf.win32 "$(TargetDir)\softhsm2.conf"
 copy ..\..\src\lib\test\softhsm2-alt.conf.win32 "$(TargetDir)\softhsm2-alt.conf"
+copy ..\..\src\lib\test\softhsm2-mech.conf.win32 "$(TargetDir)\softhsm2-mech.conf"
 mkdir "$(TargetDir)\tokens" 2&gt; nul
 copy ..\..\src\lib\test\tokens\dummy.in "$(TargetDir)\tokens\dummy"
       </Command>


### PR DESCRIPTION
This is helpful for testing applications using PKCS#11 devices,
which do not have to provide all the variety of the mechanisms
provided by SoftHSM and might need to implement some checks
and possible fallback when detecting the algorithm to be used in the
upper protocol layers.

This is an addition to the `CKA_ALLOWED_MECHANISMS` attribute,
which is unfortunately not very widely used. It should serve the same
purpose better, but most of the tokens and PKCS#11 modules do not
provide it.