### PR TITLE
Fix allowed mechanisms set directly to the objects

### DIFF
--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -356,7 +356,7 @@ CK_RV P11Attribute::retrieve(Token *token, bool isPrivate, CK_VOID_PTR pValue, C
 
 			std::set<CK_MECHANISM_TYPE> set = attr.getMechanismTypeSetValue();
 			for (std::set<CK_MECHANISM_TYPE>::const_iterator it = set.begin(); it != set.end(); ++it)
-				pTemplate[++i] = *it;
+				pTemplate[i++] = *it;
 		}
 		else
 		{


### PR DESCRIPTION
While investigating how the `CKA_ALLOWED_MECHANISMS` work, I noticed that I was getting wrong results when I read the attribute from the object. Some investigation turned out that the data is written with offset one for some reason and that this for some reason worked with the one test case (which stores the `CKA_ALLOWED_MECHANISMS` inside of `CKA_WRAP_TEMPLATE` attribute, that is currently in SoftHSM.

The attached patch set fixes the issue for me and adds a test case that verifies this work as expected (fails without the patch attached).