### PR TITLE
Fix user PIN flags manipulation in DBToken

### DIFF
--- a/src/lib/object_store/DBToken.cpp
+++ b/src/lib/object_store/DBToken.cpp
@@ -408,8 +408,9 @@ bool DBToken::setUserPIN(ByteString userPINBlob)
 	}
 
 	// Retrieve flags from the database and reset flags related to tries and expiration of the user PIN.
-	CK_ULONG flags = (tokenObject.getAttribute(CKA_OS_TOKENFLAGS).getUnsignedLongValue() | CKF_USER_PIN_INITIALIZED)
-					& ~(CKF_USER_PIN_COUNT_LOW | CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_LOCKED | CKF_USER_PIN_TO_BE_CHANGED);
+	CK_ULONG flags = tokenObject.getAttribute(CKA_OS_TOKENFLAGS).getUnsignedLongValue();
+	flags |= CKF_USER_PIN_INITIALIZED;
+	flags &= ~(CKF_USER_PIN_COUNT_LOW | CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_LOCKED | CKF_USER_PIN_TO_BE_CHANGED);
 
 	OSAttribute changedTokenFlags(flags);
 	if (!tokenObject.setAttribute(CKA_OS_TOKENFLAGS, changedTokenFlags))

--- a/src/lib/object_store/DBToken.cpp
+++ b/src/lib/object_store/DBToken.cpp
@@ -407,9 +407,9 @@ bool DBToken::setUserPIN(ByteString userPINBlob)
 		return false;
 	}
 
-	// Retrieve flags from the database and reset flags related to tries and expiration of the SOPIN.
-	CK_ULONG flags = tokenObject.getAttribute(CKA_OS_TOKENFLAGS).getUnsignedLongValue()
-					| (CKF_USER_PIN_INITIALIZED & ~(CKF_USER_PIN_COUNT_LOW | CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_LOCKED | CKF_USER_PIN_TO_BE_CHANGED));
+	// Retrieve flags from the database and reset flags related to tries and expiration of the user PIN.
+	CK_ULONG flags = (tokenObject.getAttribute(CKA_OS_TOKENFLAGS).getUnsignedLongValue() | CKF_USER_PIN_INITIALIZED)
+					& ~(CKF_USER_PIN_COUNT_LOW | CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_LOCKED | CKF_USER_PIN_TO_BE_CHANGED);
 
 	OSAttribute changedTokenFlags(flags);
 	if (!tokenObject.setAttribute(CKA_OS_TOKENFLAGS, changedTokenFlags))
@@ -841,7 +841,7 @@ bool DBToken::resetToken(const ByteString& label)
 		return false;
 	}
 
-	// Retrieve flags from the database and reset flags related to tries and expiration of the SOPIN.
+	// Retrieve flags from the database and reset flags related to tries and expiration of the user PIN.
 	CK_ULONG flags = tokenObject.getAttribute(CKA_OS_TOKENFLAGS).getUnsignedLongValue()
 					& ~(CKF_USER_PIN_INITIALIZED | CKF_USER_PIN_COUNT_LOW | CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_LOCKED | CKF_USER_PIN_TO_BE_CHANGED);
 


### PR DESCRIPTION
The parentheses in the logic expression were wrong, not clearing the flags which should be cleared when user PIN is set.

In SoftHSMv2, this has the only effect of clearing USER_PIN_COUNT_LOW when user PIN is changed/initialized, as the other flags are never set. In OSToken, these flags are manipulated correctly.