### PR TITLE
Implemented fix and testcase for missing NULL_PTR validation

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -2694,6 +2694,9 @@ CK_RV SoftHSM::C_EncryptFinal(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncrypted
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
+	// Github issue #469, check NULL_PTR on pulEncryptedDataLen
+	if (pulEncryptedDataLen == NULL) return CKR_ARGUMENTS_BAD;
+
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
@@ -3395,6 +3398,9 @@ static CK_RV SymDecryptFinal(Session* session, CK_BYTE_PTR pDecryptedData, CK_UL
 CK_RV SoftHSM::C_DecryptFinal(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG_PTR pDataLen)
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
+
+	// Github issue #469, check NULL_PTR on pDataLen
+	if (pDataLen == NULL) return CKR_ARGUMENTS_BAD;
 
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -2694,12 +2694,16 @@ CK_RV SoftHSM::C_EncryptFinal(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncrypted
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	// Github issue #469, check NULL_PTR on pulEncryptedDataLen
-	if (pulEncryptedDataLen == NULL) return CKR_ARGUMENTS_BAD;
-
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
+
+	// Github issue #469, check NULL_PTR on pulEncryptedDataLen
+	if (pulEncryptedDataLen == NULL)
+	{
+		session->resetOp();
+		return CKR_ARGUMENTS_BAD;
+	}
 
 	// Check if we are doing the correct operation
 	if (session->getOpType() != SESSION_OP_ENCRYPT) return CKR_OPERATION_NOT_INITIALIZED;
@@ -3399,12 +3403,16 @@ CK_RV SoftHSM::C_DecryptFinal(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	// Github issue #469, check NULL_PTR on pDataLen
-	if (pDataLen == NULL) return CKR_ARGUMENTS_BAD;
-
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
+
+	// Github issue #469, check NULL_PTR on pDataLen
+	if (pDataLen == NULL)
+	{
+		session->resetOp();
+		return CKR_ARGUMENTS_BAD;
+	}
 
 	// Check if we are doing the correct operation
 	if (session->getOpType() != SESSION_OP_DECRYPT) return CKR_OPERATION_NOT_INITIALIZED;

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -1194,3 +1194,105 @@ void SymmetricAlgorithmTests::testGenericKey()
 	rv = generateGenericKey(hSession,IN_SESSION,IS_PUBLIC,hKey);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
+
+void SymmetricAlgorithmTests::testEncDecFinalNULLValidation()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession;
+
+	// Just make sure that we finalize any previous tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	// Initialize the library and start the test.
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Open read-write session
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Login USER into the sessions so we can create a private objects
+	rv = CRYPTOKI_F_PTR( C_Login(hSession,CKU_USER,m_userPin1,m_userPin1Length) );
+	CPPUNIT_ASSERT(rv==CKR_OK);
+
+	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
+
+	// Generate all combinations of session/token keys.
+	rv = generateAesKey(hSession,IN_SESSION,IS_PUBLIC,hKey);
+
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	
+	CK_MECHANISM mechanism = { CKM_AES_CTR, NULL_PTR, 0 };
+	CK_AES_CTR_PARAMS ctrParams =
+	{
+		2,
+		{
+			0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+		}
+	};
+	mechanism.pParameter = &ctrParams;
+	mechanism.ulParameterLen = sizeof(ctrParams);
+	CK_BYTE plainText[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+				0x00 };
+	std::vector<CK_BYTE> vEncryptedData;
+	std::vector<CK_BYTE> vEncryptedDataParted;
+	std::vector<CK_BYTE> vDecryptedData;
+	std::vector<CK_BYTE> vDecryptedDataParted;
+	CK_ULONG ulEncryptedDataLen;
+	CK_ULONG ulEncryptedPartLen;
+	CK_ULONG ulDecryptedPartLen;
+	CK_ULONG ulDataPartLen;
+
+	// Single-part encryption
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText)-1,NULL_PTR,&ulEncryptedDataLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	vEncryptedData.resize(ulEncryptedDataLen);
+	rv = CRYPTOKI_F_PTR( C_Encrypt(hSession,plainText,sizeof(plainText)-1,&vEncryptedData.front(),&ulEncryptedDataLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	vEncryptedData.resize(ulEncryptedDataLen);
+
+	// Multi-part encryption
+	rv = CRYPTOKI_F_PTR( C_EncryptInit(hSession,&mechanism,hKey) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)-1,NULL_PTR,&ulEncryptedPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	vEncryptedDataParted.resize(ulEncryptedPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptUpdate(hSession,plainText,sizeof(plainText)-1,&vEncryptedDataParted.front(),&ulEncryptedPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+
+	// Test input validation
+	rv = CRYPTOKI_F_PTR( C_EncryptFinal(hSession, NULL_PTR, NULL_PTR) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_ARGUMENTS_BAD, rv );
+	ulEncryptedPartLen = 0;
+	rv = CRYPTOKI_F_PTR( C_EncryptFinal(hSession, NULL_PTR, &ulEncryptedPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	vEncryptedDataParted.resize(ulEncryptedPartLen);
+	rv = CRYPTOKI_F_PTR( C_EncryptFinal(hSession, &vEncryptedDataParted.front(), &ulEncryptedPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+
+	// Multi-part decryption
+	rv = CRYPTOKI_F_PTR( C_DecryptInit(hSession,&mechanism,hKey) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,&vEncryptedData.front(),vEncryptedData.size(),NULL_PTR,&ulDataPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	vDecryptedDataParted.resize(ulDataPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptUpdate(hSession,&vEncryptedData.front(),vEncryptedData.size(),&vDecryptedDataParted.front(),&ulDataPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	
+	// Test input validation
+	rv = CRYPTOKI_F_PTR( C_DecryptFinal(hSession, NULL_PTR, NULL_PTR) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_ARGUMENTS_BAD, rv );
+	ulDecryptedPartLen = 0;
+	rv = CRYPTOKI_F_PTR( C_DecryptFinal(hSession, NULL_PTR, &ulDecryptedPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+	vDecryptedDataParted.resize(ulDecryptedPartLen);
+	rv = CRYPTOKI_F_PTR( C_DecryptFinal(hSession, &vDecryptedDataParted.front(), &ulDecryptedPartLen) );
+	CPPUNIT_ASSERT_EQUAL( (CK_RV)CKR_OK, rv );
+
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+}

--- a/src/lib/test/SymmetricAlgorithmTests.h
+++ b/src/lib/test/SymmetricAlgorithmTests.h
@@ -49,6 +49,7 @@ class SymmetricAlgorithmTests : public TestsBase
 	CPPUNIT_TEST(testCheckValue);
 	CPPUNIT_TEST(testAesCtrOverflow);
 	CPPUNIT_TEST(testGenericKey);
+	CPPUNIT_TEST(testEncDecFinalNULLValidation);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -60,6 +61,7 @@ public:
 	void testCheckValue();
 	void testAesCtrOverflow();
 	void testGenericKey();
+	void testEncDecFinalNULLValidation();
 
 protected:
 	CK_RV generateGenericKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);


### PR DESCRIPTION
This PR implements a fix for issue #469 and adds a test case to check if ```C_EncryptFinal``` and ```C_DecryptFinal``` correctly return ```CKR_ARGUMENTS_BAD``` when a ```NULL_PTR``` is provided in the return length field.