### PR TITLE
Rename configuration option to "slots.mechanisms".

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -761,7 +761,7 @@ void SoftHSM::prepareSupportedMecahnisms(std::map<std::string, CK_MECHANISM_TYPE
 	}
 
 	/* Check configuration for supported algorithms */
-	std::string mechs = Configuration::i()->getString("token.mechanisms", "ALL");
+	std::string mechs = Configuration::i()->getString("slots.mechanisms", "ALL");
 	if (mechs != "ALL")
 	{
 		bool negative = (mechs[0] == '-');

--- a/src/lib/common/Configuration.cpp
+++ b/src/lib/common/Configuration.cpp
@@ -48,7 +48,7 @@ const struct config Configuration::valid_config[] = {
 	{ "objectstore.backend",	CONFIG_TYPE_STRING },
 	{ "log.level",			CONFIG_TYPE_STRING },
 	{ "slots.removable",		CONFIG_TYPE_BOOL },
-	{ "token.mechanisms",		CONFIG_TYPE_STRING },
+	{ "slots.mechanisms",		CONFIG_TYPE_STRING },
 	{ "",				CONFIG_TYPE_UNSUPPORTED }
 };
 

--- a/src/lib/common/softhsm2.conf.5.in
+++ b/src/lib/common/softhsm2.conf.5.in
@@ -78,7 +78,7 @@ on the key objects.
 .LP
 .RS
 .nf
-token.mechanisms = ALL
+slots.mechanisms = ALL
 .fi
 .RE
 .LP

--- a/src/lib/common/softhsm2.conf.in
+++ b/src/lib/common/softhsm2.conf.in
@@ -9,5 +9,5 @@ log.level = ERROR
 # If CKF_REMOVABLE_DEVICE flag should be set
 slots.removable = false
 
-# Enable and disable PKCS#11 mechanisms using token.mechanisms.
-token.mechanisms = ALL
+# Enable and disable PKCS#11 mechanisms using slots.mechanisms.
+slots.mechanisms = ALL

--- a/src/lib/test/softhsm2-mech.conf.in
+++ b/src/lib/test/softhsm2-mech.conf.in
@@ -4,5 +4,5 @@ directories.tokendir = @builddir@/tokens
 objectstore.backend = file
 log.level = INFO
 slots.removable = false
-token.mechanisms = CKM_RSA_X_509,CKM_RSA_PKCS
+slots.mechanisms = CKM_RSA_X_509,CKM_RSA_PKCS
 

--- a/src/lib/test/softhsm2-mech.conf.win32
+++ b/src/lib/test/softhsm2-mech.conf.win32
@@ -4,4 +4,4 @@ directories.tokendir = .\tokens
 objectstore.backend = file
 log.level = INFO
 slots.removable = false
-token.mechanisms = CKM_RSA_X_509,CKM_RSA_PKCS
+slots.mechanisms = CKM_RSA_X_509,CKM_RSA_PKCS


### PR DESCRIPTION
My rationale is that the configuration parameter overrides whatever
mechanisms are reported by the token itself, which is reported by the
"slot" object in SoftHSM.