### PR TITLE
Increase sqlite busy timeout from 15 seconds to 3 minutes

### DIFF
--- a/src/lib/object_store/DB.cpp
+++ b/src/lib/object_store/DB.cpp
@@ -848,7 +848,7 @@ bool DB::Connection::connect(const char *
 		return false;
 	}
 
-	rv = sqlite3_busy_timeout(_db, 15000); // 15 seconds
+	rv = sqlite3_busy_timeout(_db, 180000); // 3 minutes
 	if (rv != SQLITE_OK) {
 		reportErrorDB(_db);
 		return false;


### PR DESCRIPTION
When many parallel accesses happen on a network-backed storage (like a
busy Ceph RBD), the DB can be busy for longer than 15 seconds, leading
to failed token accesses. Increase the timeout to 3 minutes (a factor of
12).