### PR TITLE
Remove extra field iv_bits from CK_GCM_PARAMS

### DIFF
--- a/src/lib/pkcs11/pkcs11.h
+++ b/src/lib/pkcs11/pkcs11.h
@@ -982,7 +982,6 @@ struct ck_aes_ctr_params {
 struct ck_gcm_params {
   unsigned char *iv_ptr;
   unsigned long iv_len;
-  unsigned long iv_bits;
   unsigned char *aad_ptr;
   unsigned long aad_len;
   unsigned long tag_bits;


### PR DESCRIPTION
The PKCS#11 specification defines CK_GCM_PARAMS as:
```
typedef struct CK_GCM_PARAMS {
     CK_BYTE_PTR pIv;
     CK_ULONG ulIvLen;
     CK_BYTE_PTR pAAD;
     CK_ULONG ulAADLen;
     CK_ULONG ulTagBits;
   } CK_GCM_PARAMS;
```