### PR TITLE
Remove direct use of Exception class to work with modern Botan.

### DIFF
--- a/src/lib/crypto/Botan_ecb.cpp
+++ b/src/lib/crypto/Botan_ecb.cpp
@@ -108,7 +108,7 @@ void ECB_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
    padding().add_padding(buffer, bytes_in_final_block, BS);
 
    if(buffer.size() % BS)
-      throw Exception("Did not pad to full block size in " + name());
+      throw Encoding_Error("Did not pad to full block size in " + name());
 
    update(buffer, offset);
    }


### PR DESCRIPTION
Commit b909778 made this constructor protected.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).