### PR TITLE
memory leak in OSSLCryptoFactory destructor

### DIFF
--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -234,6 +234,15 @@ OSSLCryptoFactory::~OSSLCryptoFactory()
 	}
 #endif
 
+	// free RDRAND engine
+	if (rdrand_engine != NULL)
+	{
+		ENGINE_finish(rdrand_engine);
+		ENGINE_free(rdrand_engine);
+	}
+
+	ENGINE_cleanup();
+
 	// Destroy the one-and-only RNG
 	delete rng;
 


### PR DESCRIPTION
in OSSLCryptoFactory destructor resources created by ENGINE_load_rdrand are not freed