### PR TITLE
Check CK_ATTRIBUTE_PTR arguments for NULL_PTR

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1842,6 +1842,7 @@ CK_RV SoftHSM::C_SetAttributeValue(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE 
 CK_RV SoftHSM::C_FindObjectsInit(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (pTemplate == NULL_PTR && ulCount != 0) return CKR_ARGUMENTS_BAD;
 
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
@@ -5669,6 +5670,7 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
 	if (pMechanism == NULL_PTR) return CKR_ARGUMENTS_BAD;
+	if (pTemplate == NULL_PTR && ulCount != 0) return CKR_ARGUMENTS_BAD;
 	if (phKey == NULL_PTR) return CKR_ARGUMENTS_BAD;
 
 	// Get the session
@@ -5820,6 +5822,8 @@ CK_RV SoftHSM::C_GenerateKeyPair
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
 	if (pMechanism == NULL_PTR) return CKR_ARGUMENTS_BAD;
+	if (pPublicKeyTemplate == NULL_PTR && ulPublicKeyAttributeCount != 0) return CKR_ARGUMENTS_BAD;
+	if (pPrivateKeyTemplate == NULL_PTR && ulPrivateKeyAttributeCount != 0) return CKR_ARGUMENTS_BAD;
 	if (phPublicKey == NULL_PTR) return CKR_ARGUMENTS_BAD;
 	if (phPrivateKey == NULL_PTR) return CKR_ARGUMENTS_BAD;
 

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -904,6 +904,9 @@ void SymmetricAlgorithmTests::testNullTemplate()
 	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism1, NULL_PTR, 0, &hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
+	rv = CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism1, NULL_PTR, 1, &hKey) );
+	CPPUNIT_ASSERT(rv == CKR_ARGUMENTS_BAD);
+
 	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hKey) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 


### PR DESCRIPTION
Add NULL_PTR checks for number of PKCS#11 functions that take CK_ATTRIBUTE_PTR as input arguments. Since NULL_PTR is allowed when `ulCount` is 0, the conditionals also check the `ulCount` (or similar) argument.

