### PR TITLE
Add support for C_WaitForSlotEvent

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -7069,9 +7069,17 @@ CK_RV SoftHSM::C_CancelFunction(CK_SESSION_HANDLE hSession)
 }
 
 // Wait or poll for a slot event on the specified slot
-CK_RV SoftHSM::C_WaitForSlotEvent(CK_FLAGS /*flags*/, CK_SLOT_ID_PTR /*pSlot*/, CK_VOID_PTR /*pReserved*/)
+CK_RV SoftHSM::C_WaitForSlotEvent(CK_FLAGS flags, CK_SLOT_ID_PTR /*pSlot*/, CK_VOID_PTR /*pReserved*/)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	if (!(flags & CKF_DONT_BLOCK)) return CKR_FUNCTION_NOT_SUPPORTED;
+
+	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
+
+	// SoftHSM slots don't change after it's initialised. With the
+	// exception of when a slot is initialised and then getSlotList() is
+	// called. However, at this point the caller has been updated with the
+	// new slot list already so no event needs to be triggered.
+	return CKR_NO_EVENT;
 }
 
 CK_RV SoftHSM::generateGeneric

--- a/src/lib/test/InfoTests.cpp
+++ b/src/lib/test/InfoTests.cpp
@@ -362,3 +362,27 @@ void InfoTests::testGetMechanismListConfig()
 	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
 #endif
 }
+
+void InfoTests::testWaitForSlotEvent()
+{
+	CK_RV rv;
+
+	// Just make sure that we finalize any previous failed tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	rv = CRYPTOKI_F_PTR( C_WaitForSlotEvent(CKF_DONT_BLOCK, NULL_PTR, NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_NOT_INITIALIZED);
+
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Blocking version should fail
+	rv = CRYPTOKI_F_PTR( C_WaitForSlotEvent(0, NULL_PTR, NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_FUNCTION_NOT_SUPPORTED);
+
+	// Should always return CKR_NO_EVENT
+	rv = CRYPTOKI_F_PTR( C_WaitForSlotEvent(CKF_DONT_BLOCK, NULL_PTR, NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_NO_EVENT);
+
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+}

--- a/src/lib/test/InfoTests.h
+++ b/src/lib/test/InfoTests.h
@@ -49,6 +49,7 @@ class InfoTests : public TestsNoPINInitBase
 	CPPUNIT_TEST(testGetMechanismInfo);
 	CPPUNIT_TEST(testGetSlotInfoAlt);
 	CPPUNIT_TEST(testGetMechanismListConfig);
+	CPPUNIT_TEST(testWaitForSlotEvent);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -61,6 +62,7 @@ public:
 	void testGetMechanismInfo();
 	void testGetSlotInfoAlt();
 	void testGetMechanismListConfig();
+	void testWaitForSlotEvent();
 };
 
 #endif // !_SOFTHSM_V2_INFOTESTS_H


### PR DESCRIPTION
C_WaitForSlotEvent is expected to be supplied as a pkcs11 function by
libraries and applications, such as nss. Since the slots are never
updated it's quite easy to implement.

Would you like me to create an issue and add an entry into NEWS?