### PR TITLE
Mark as not initialized in destructor

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -403,6 +403,8 @@ SoftHSM::~SoftHSM()
 	mechanisms_table.clear();
 	supportedMechanisms.clear();
 
+	isInitialised = false;
+
 	resetMutexFactoryCallbacks();
 }
 


### PR DESCRIPTION
This is a follow-up on #418 

I was investigating a crash similar to #417 which happened if a wrong PIN was provided when using the openssl + engine_pkcs11 + SoftHSM combination. The root of the problem is that the destructor for SoftHSM can be executed before the ``atexit()`` handlers installed by other libraries holding references to SoftHSM.

In one particular case, the engine_pkcs11 would call ``SoftHSM::C_CloseSession()`` when exiting, which would end in a crash in ``HandleManager::getSession()`` because the ``handleManager`` had been destroyed earlier.

The bug was reported as part of https://github.com/OpenSC/libp11/issues/273