### PR TITLE
Add a configuration option to reset SoftHSM state on fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ src/lib/session_mgr/test/sessionmgrtest
 src/lib/slot_mgr/test/slotmgrtest
 src/lib/test/p11test
 src/lib/test/softhsm2-alt.conf
+src/lib/test/softhsm2-reset-on-fork.conf
 src/lib/test/softhsm2-mech.conf
 src/lib/test/softhsm2.conf
 src/lib/test/tokens/64d6c3fe-1575-1736-1d26-5ccb28440ea7/

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,7 @@ AC_CONFIG_FILES([
 	src/lib/test/Makefile
 	src/lib/test/softhsm2.conf
 	src/lib/test/softhsm2-alt.conf
+	src/lib/test/softhsm2-reset-on-fork.conf
 	src/lib/test/softhsm2-mech.conf
 	src/lib/test/tokens/dummy
 	src/bin/Makefile

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -193,6 +193,8 @@ private:
 	SessionManager* sessionManager;
 	HandleManager* handleManager;
 
+	int forkID;
+
 	// Encrypt/Decrypt variants
 	CK_RV SymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey);
 	CK_RV AsymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey);
@@ -478,5 +480,7 @@ private:
 
 	static bool isMechanismPermitted(OSObject* key, CK_MECHANISM_PTR pMechanism);
 	static void prepareSupportedMecahnisms(std::map<std::string, CK_MECHANISM_TYPE> &t);
+
+	bool detectFork(void);
 };
 

--- a/src/lib/common/Configuration.cpp
+++ b/src/lib/common/Configuration.cpp
@@ -49,6 +49,7 @@ const struct config Configuration::valid_config[] = {
 	{ "log.level",			CONFIG_TYPE_STRING },
 	{ "slots.removable",		CONFIG_TYPE_BOOL },
 	{ "slots.mechanisms",		CONFIG_TYPE_STRING },
+	{ "library.reset_on_fork",	CONFIG_TYPE_BOOL },
 	{ "",				CONFIG_TYPE_UNSUPPORTED }
 };
 

--- a/src/lib/common/softhsm2.conf.5.in
+++ b/src/lib/common/softhsm2.conf.5.in
@@ -82,6 +82,16 @@ slots.mechanisms = ALL
 .fi
 .RE
 .LP
+.SH LIBRARY.RESET_ON_FORK
+If set to true, the library will reset the state on fork.
+Default is false.
+.LP
+.RS
+.nf
+library.reset_on_fork = true
+.fi
+.RE
+.LP
 .SH ENVIRONMENT
 .TP
 SOFTHSM2_CONF

--- a/src/lib/common/softhsm2.conf.in
+++ b/src/lib/common/softhsm2.conf.in
@@ -11,3 +11,6 @@ slots.removable = false
 
 # Enable and disable PKCS#11 mechanisms using slots.mechanisms.
 slots.mechanisms = ALL
+
+# If the library should reset the state on fork
+library.reset_on_fork = false

--- a/src/lib/test/CMakeLists.txt
+++ b/src/lib/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES p11test.cpp
             AsymWrapUnwrapTests.cpp
             TestsBase.cpp
             TestsNoPINInitBase.cpp
+            ForkTests.cpp
             ../common/log.cpp
             ../common/osmutex.cpp
             )
@@ -40,5 +41,6 @@ add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME}
 set(builddir ${PROJECT_BINARY_DIR})
 configure_file(softhsm2.conf.in softhsm2.conf)
 configure_file(softhsm2-alt.conf.in softhsm2-alt.conf)
+configure_file(softhsm2-reset-on-fork.conf.in softhsm2-reset-on-fork.conf)
 configure_file(softhsm2-mech.conf.in softhsm2-mech.conf)
 configure_file(tokens/dummy.in tokens/dummy)

--- a/src/lib/test/ForkTests.cpp
+++ b/src/lib/test/ForkTests.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020 by Red Hat, Inc.
+ *
+ * Author: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*****************************************************************************
+ ForkTests.cpp
+
+ Contains test cases for forking scenarios
+ *****************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include "ForkTests.h"
+#include "cryptoki.h"
+#include "osmutex.h"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ForkTests);
+
+void ForkTests::setUp()
+{
+
+#ifndef _WIN32
+	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
+}
+
+void ForkTests::tearDown()
+{
+	// Just make sure that we finalize any previous failed tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+}
+
+void ForkTests::testFork()
+{
+	CK_RV rv;
+	pid_t pid;
+
+	// Just make sure that we finalize any previous failed tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	pid = fork();
+
+	switch(pid) {
+		case -1:
+			CPPUNIT_FAIL("Fork failed");
+			break;
+		case 0:
+			rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+			CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
+			break;
+		default:
+			rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+			CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
+			break;
+	}
+
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+}
+
+void ForkTests::testResetOnFork()
+{
+	CK_RV rv;
+	CK_SLOT_INFO slotInfo;
+	pid_t pid;
+
+	// Just make sure that we finalize any previous failed tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+#ifndef _WIN32
+	setenv("SOFTHSM2_CONF", "./softhsm2-reset-on-fork.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2-reset-on-fork.conf", 1);
+#endif
+
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	pid = fork();
+
+	switch(pid) {
+		case -1:
+			CPPUNIT_FAIL("Fork failed");
+			break;
+		case 0:
+			/* For the child, the token is expected to be reset on fork */
+			rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+			CPPUNIT_ASSERT(rv == CKR_OK);
+			break;
+		default:
+			/* For the parent, the token is expected to be still initialized */
+			rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+			CPPUNIT_ASSERT(rv == CKR_CRYPTOKI_ALREADY_INITIALIZED);
+			break;
+	}
+
+	rv = CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+#ifndef _WIN32
+	setenv("SOFTHSM2_CONF", "./softhsm2.conf", 1);
+#else
+	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
+#endif
+}

--- a/src/lib/test/ForkTests.h
+++ b/src/lib/test/ForkTests.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 by Red Hat, Inc.
+ *
+ * Author: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*****************************************************************************
+ ForkTests.h
+
+ Contains test cases for forking scenarios
+ *****************************************************************************/
+
+#ifndef _SOFTHSM_V2_FORKTESTS_H
+#define _SOFTHSM_V2_FORKTESTS_H
+
+#include "TestsNoPINInitBase.h"
+#include <cppunit/extensions/HelperMacros.h>
+
+class ForkTests : public TestsNoPINInitBase
+{
+	CPPUNIT_TEST_SUITE(ForkTests);
+	CPPUNIT_TEST(testFork);
+	CPPUNIT_TEST(testResetOnFork);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void testFork();
+	void testResetOnFork();
+
+	virtual void setUp();
+	virtual void tearDown();
+};
+
+#endif // !_SOFTHSM_V2_FORKTESTS_H
+

--- a/src/lib/test/Makefile.am
+++ b/src/lib/test/Makefile.am
@@ -25,6 +25,7 @@ p11test_SOURCES =		p11test.cpp \
 				AsymWrapUnwrapTests.cpp \
 				TestsBase.cpp \
 				TestsNoPINInitBase.cpp \
+				ForkTests.cpp \
 				../common/log.cpp \
 				../common/osmutex.cpp
 
@@ -37,6 +38,7 @@ TESTS = 			p11test
 EXTRA_DIST =			$(srcdir)/CMakeLists.txt \
 				$(srcdir)/*.h \
 				$(srcdir)/softhsm2-alt.conf.win32 \
+				$(srcdir)/softhsm2-reset-on-fork.conf.win32 \
 				$(srcdir)/softhsm2-mech.conf.win32 \
 				$(srcdir)/softhsm2.conf.win32 \
 				$(srcdir)/tokens/dummy.in

--- a/src/lib/test/softhsm2-reset-on-fork.conf.in
+++ b/src/lib/test/softhsm2-reset-on-fork.conf.in
@@ -1,0 +1,8 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = @builddir@/tokens
+objectstore.backend = file
+log.level = INFO
+slots.removable = false
+
+library.reset_on_fork = true

--- a/src/lib/test/softhsm2-reset-on-fork.conf.win32
+++ b/src/lib/test/softhsm2-reset-on-fork.conf.win32
@@ -1,0 +1,8 @@
+# SoftHSM v2 configuration file
+
+directories.tokendir = .\tokens
+objectstore.backend = file
+log.level = INFO
+slots.removable = false
+
+library.reset_on_fork = true

--- a/win32/p11test/p11test.vcxproj.in
+++ b/win32/p11test/p11test.vcxproj.in
@@ -65,6 +65,7 @@
       <Command>
 copy ..\..\src\lib\test\softhsm2.conf.win32 "$(TargetDir)\softhsm2.conf"
 copy ..\..\src\lib\test\softhsm2-alt.conf.win32 "$(TargetDir)\softhsm2-alt.conf"
+copy ..\..\src\lib\test\softhsm2-reset-on-fork.conf.win32 "$(TargetDir)\softhsm2-reset-on-fork.conf"
 copy ..\..\src\lib\test\softhsm2-mech.conf.win32 "$(TargetDir)\softhsm2-mech.conf"
 mkdir "$(TargetDir)\tokens" 2&gt; nul
 copy ..\..\src\lib\test\tokens\dummy.in "$(TargetDir)\tokens\dummy"
@@ -96,6 +97,7 @@ copy ..\..\src\lib\test\tokens\dummy.in "$(TargetDir)\tokens\dummy"
       <Command>
 copy ..\..\src\lib\test\softhsm2.conf.win32 "$(TargetDir)\softhsm2.conf"
 copy ..\..\src\lib\test\softhsm2-alt.conf.win32 "$(TargetDir)\softhsm2-alt.conf"
+copy ..\..\src\lib\test\softhsm2-reset-on-fork.conf.win32 "$(TargetDir)\softhsm2-reset-on-fork.conf"
 copy ..\..\src\lib\test\softhsm2-mech.conf.win32 "$(TargetDir)\softhsm2-mech.conf"
 mkdir "$(TargetDir)\tokens" 2&gt; nul
 copy ..\..\src\lib\test\tokens\dummy.in "$(TargetDir)\tokens\dummy"


### PR DESCRIPTION
Add the configuration option "library.reset_on_fork".  When set to "true", will
make SoftHSM to reset its state on fork.

---
Was  "Add a configuration option to emulate hardware device"

Previous description:

Add the configuration option "slots.hardware".  When set to "true", will
make SoftHSM to set the CKF_HW_SLOT flag in the structure returned by
C_GetSlotInfo().

The added configuration option is useful for testing applications which
requires hardware slots and/or change behaviour for hardware slots.

Also reset the SoftHSM instance when a fork is detected and the
CKF_HW_SLOT flag is set. This emulates a common behaviour for
hardware devices.