### PR TITLE
Fix memory leak in OSSLCryptoFactory

### DIFF
--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -236,6 +236,11 @@ OSSLCryptoFactory::~OSSLCryptoFactory()
 	}
 #endif
 
+	// Finish the rd_rand engine
+	ENGINE_finish(rdrand_engine);
+	ENGINE_free(rdrand_engine);
+	rdrand_engine = NULL;
+
 	// Destroy the one-and-only RNG
 	delete rng;
 


### PR DESCRIPTION
Previously, the rdrand_engine was not being freed in OSSLCryptoFactory
destructor.  With this change the rdrand_engine will be freed avoiding
memory leak.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>