### PR TITLE
Fix issue #518 by locking before the object set is accessed

### DIFF
--- a/src/lib/object_store/SessionObjectStore.cpp
+++ b/src/lib/object_store/SessionObjectStore.cpp
@@ -122,14 +122,14 @@ SessionObject* SessionObjectStore::createObject(CK_SLOT_ID slotID, CK_SESSION_HA
 // Delete an object
 bool SessionObjectStore::deleteObject(SessionObject* object)
 {
+	MutexLocker lock(storeMutex);
+
 	if (objects.find(object) == objects.end())
 	{
 		ERROR_MSG("Cannot delete non-existent object 0x%08X", object);
 
 		return false;
 	}
-
-	MutexLocker lock(storeMutex);
 
 	// Invalidate the object instance
 	object->invalidate();


### PR DESCRIPTION
Moves the locking point when deleting objects forward to fix #518 