### PR TITLE
Fix advertised min and max mechanism sizes according to final PKCS#11 3.0 specification

### DIFF
--- a/src/lib/crypto/BotanEDDSA.cpp
+++ b/src/lib/crypto/BotanEDDSA.cpp
@@ -396,13 +396,13 @@ bool BotanEDDSA::deriveKey(SymmetricKey **ppSymmetricKey, PublicKey* publicKey, 
 unsigned long BotanEDDSA::getMinKeySize()
 {
 	// Only Ed25519 is supported
-	return 32*8;
+	return 255;
 }
 
 unsigned long BotanEDDSA::getMaxKeySize()
 {
 	// Only Ed25519 is supported
-	return 32*8;
+	return 255;
 }
 
 bool BotanEDDSA::reconstructKeyPair(AsymmetricKeyPair** ppKeyPair, ByteString& serialisedData)

--- a/src/lib/crypto/OSSLEDDSA.cpp
+++ b/src/lib/crypto/OSSLEDDSA.cpp
@@ -363,13 +363,13 @@ bool OSSLEDDSA::deriveKey(SymmetricKey **ppSymmetricKey, PublicKey* publicKey, P
 unsigned long OSSLEDDSA::getMinKeySize()
 {
 	// Ed25519 is supported
-	return 32*8;
+	return 255;
 }
 
 unsigned long OSSLEDDSA::getMaxKeySize()
 {
 	// Ed448 is supported
-	return 57*8;
+	return 448;
 }
 
 bool OSSLEDDSA::reconstructKeyPair(AsymmetricKeyPair** ppKeyPair, ByteString& serialisedData)

--- a/src/lib/test/ForkTests.cpp
+++ b/src/lib/test/ForkTests.cpp
@@ -94,7 +94,6 @@ void ForkTests::testFork()
 void ForkTests::testResetOnFork()
 {
 	CK_RV rv;
-	CK_SLOT_INFO slotInfo;
 	pid_t pid;
 
 	// Just make sure that we finalize any previous failed tests


### PR DESCRIPTION
The section "2.3.10 Edwards Elliptic curve key pair generation" lists the key limits as following:

> For this mechanism, the only allowed values are 255 and 448 as RFC 8032 only defines curves of these two sizes.
> A Cryptoki implementation may support one or both of these curves and should set the ulMinKeySize and ulMaxKeySize fields accordingly.

[1] https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/csprd01/pkcs11-curr-v3.0-csprd01.html#_Toc10560876