### PR TITLE
Avoid creating duplicate mechanisms

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -596,6 +596,8 @@ CK_RV SoftHSM::C_Finalize(CK_VOID_PTR pReserved)
 
 	isInitialised = false;
 
+	supportedMechanisms.clear();
+
 	SoftHSM::reset();
 	return CKR_OK;
 }
@@ -777,6 +779,7 @@ void SoftHSM::prepareSupportedMecahnisms(std::map<std::string, CK_MECHANISM_TYPE
 	t["CKM_EDDSA"]			= CKM_EDDSA;
 #endif
 
+	supportedMechanisms.clear();
 	for (auto it = t.begin(); it != t.end(); ++it)
 	{
 		supportedMechanisms.push_back(it->second);


### PR DESCRIPTION
I noticed weird behavior when the library is loaded into longer-running
process, which issues several cycles of C_Initialize & C_Finalize,
where I saw exactly the same amount of duplicate items as the amount
of the calls to C_Initialize.

I was not able to replicated it in a testsuite, probably because of
different way how the memory is handled inside of C++ code and when
called from C code as a PKCS#11 library.

This fix is just making sure that the list is empty before filling it
with new mechanisms. Other possiblity would be to move the clean to
C_Finalize(), which is counterpart to the C_Initialize(), containing
the initialization of this list.