### PR TITLE
Implement C_CopyObject for DB backend

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1618,6 +1618,7 @@ CK_RV SoftHSM::C_CopyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject
 	{
 		if (!object->attributeExists(attrType))
 		{
+			WARNING_MSG("Attribute 0x%lx does not exist even though it was reported as next.");
 			rv = CKR_FUNCTION_FAILED;
 			break;
 		}

--- a/src/lib/object_store/DBObject.cpp
+++ b/src/lib/object_store/DBObject.cpp
@@ -487,6 +487,7 @@ static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
 	case CKA_EXPONENT_1: return akBinary;
 	case CKA_EXPONENT_2: return akBinary;
 	case CKA_COEFFICIENT: return akBinary;
+	case CKA_PUBLIC_KEY_INFO: return akBinary;
 	case CKA_PRIME: return akBinary;
 	case CKA_SUBPRIME: return akBinary;
 	case CKA_BASE: return akBinary;
@@ -501,6 +502,7 @@ static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
 	case CKA_KEY_GEN_MECHANISM: return akInteger;
 	case CKA_MODIFIABLE: return akBoolean;
 	case CKA_COPYABLE: return akBoolean;
+	case CKA_DESTROYABLE: return akBoolean;
 	case CKA_ECDSA_PARAMS: return akBinary;
 	case CKA_EC_POINT: return akBinary;
 	case CKA_SECONDARY_AUTH: return akBoolean;

--- a/src/lib/object_store/DBObject.h
+++ b/src/lib/object_store/DBObject.h
@@ -62,6 +62,9 @@ public:
 	// create tables to support storage of attributes for the object.
 	bool createTables();
 
+	// update schema to support new features with dbs from previous versions.
+	bool migrateTables();
+
 	// drop tables that support storage of attributes for the object.
 	bool dropTables();
 

--- a/src/lib/object_store/DBToken.cpp
+++ b/src/lib/object_store/DBToken.cpp
@@ -114,7 +114,7 @@ DBToken::DBToken(const std::string &baseDir, const std::string &tokenName, const
 
 	// First create the tables that support storage of object attributes and then insert the object containing
 	// the token info into the database.
-	if (!tokenObject.createTables() || !tokenObject.insert() || tokenObject.objectId()!=DBTOKEN_OBJECT_TOKENINFO)
+	if (!tokenObject.createTables() || !tokenObject.migrateTables() || !tokenObject.insert() || tokenObject.objectId()!=DBTOKEN_OBJECT_TOKENINFO)
 	{
 		tokenObject.dropConnection();
 
@@ -203,7 +203,7 @@ DBToken::DBToken(const std::string &baseDir, const std::string &tokenName)
 	DBObject tokenObject(_connection);
 
 	// First find the token obect that indicates the token is properly initialized.
-	if (!tokenObject.find(DBTOKEN_OBJECT_TOKENINFO))
+	if (!tokenObject.find(DBTOKEN_OBJECT_TOKENINFO) || !tokenObject.migrateTables())
 	{
 		tokenObject.dropConnection();
 


### PR DESCRIPTION
Formerly there were no way to list all attributes, as they are scattered in different tables. This PR implements it using a view, through which all attributes can be seen. This view is then used for attribute enumeration, allowing C_CopyObject to work.

The view is added in `DBObject::migrateTables()`, which is called when opening existing token. It should be compatible with tokens created in previous version.

If we did not insist on minimalizing changes, it might be even better to throw all attributes in a single table - SQLite is fine with varying types of table cells.