### PR TITLE
Get OpenSSL Ed448/X448 working

### DIFF
--- a/src/bin/util/softhsm2-util-ossl.cpp
+++ b/src/bin/util/softhsm2-util-ossl.cpp
@@ -892,7 +892,8 @@ int crypto_save_eddsa
 // Convert the OpenSSL key to binary
 
 #define X25519_KEYLEN	32
-#define X448_KEYLEN	57
+#define X448_KEYLEN	56
+#define ED448_KEYLEN	57
 
 #define PUBPREFIXLEN	12
 #define PRIVPREFIXLEN	16
@@ -925,9 +926,12 @@ eddsa_key_material_t* crypto_malloc_eddsa(EVP_PKEY* pkey)
 		keyMat->sizeA = X25519_KEYLEN;
 		break;
 	case NID_X448:
-	case NID_ED448:
 		keyMat->sizeK = X448_KEYLEN;
 		keyMat->sizeA = X448_KEYLEN;
+		break;
+	case NID_ED448:
+		keyMat->sizeK = ED448_KEYLEN;
+		keyMat->sizeA = ED448_KEYLEN;
 		break;
 	default:
 		crypto_free_eddsa(keyMat);

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -12004,10 +12004,10 @@ ByteString SoftHSM::getECDHPubData(ByteString& pubData)
 {
 	size_t len = pubData.size();
 	size_t controlOctets = 2;
-	if (len == 32 || len == 65 || len == 97 || len == 133)
+	if (len == 32 || len == 56 || len == 65 || len == 97 || len == 133)
 	{
 		// Raw: Length matches the public key size of:
-		// EDDSA: X25519
+		// EDDSA: X25519, X448
 		// ECDSA: P-256, P-384, or P-521
 		controlOctets = 0;
 	}

--- a/src/lib/crypto/OSSLEDDSA.cpp
+++ b/src/lib/crypto/OSSLEDDSA.cpp
@@ -368,7 +368,7 @@ unsigned long OSSLEDDSA::getMinKeySize()
 
 unsigned long OSSLEDDSA::getMaxKeySize()
 {
-	// Ed448 will be supported
+	// Ed448 is supported
 	return 57*8;
 }
 

--- a/src/lib/crypto/OSSLEDPrivateKey.cpp
+++ b/src/lib/crypto/OSSLEDPrivateKey.cpp
@@ -38,7 +38,8 @@
 #include <openssl/x509.h>
 
 #define X25519_KEYLEN	32
-#define X448_KEYLEN	57
+#define X448_KEYLEN	56
+#define ED448_KEYLEN	57
 
 #define PREFIXLEN	16
 
@@ -49,8 +50,8 @@ const unsigned char x25519_prefix[] = {
 };
 
 const unsigned char x448_prefix[] = {
-	0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
-	0x03, 0x2b, 0x65, 0x6f, 0x04, 0x22, 0x04, 0x20
+	0x30, 0x46, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
+	0x03, 0x2b, 0x65, 0x6f, 0x04, 0x3a, 0x04, 0x38
 };
 
 const unsigned char ed25519_prefix[] = {
@@ -59,8 +60,8 @@ const unsigned char ed25519_prefix[] = {
 };
 
 const unsigned char ed448_prefix[] = {
-	0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
-	0x03, 0x2b, 0x65, 0x71, 0x04, 0x22, 0x04, 0x20
+	0x30, 0x47, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
+	0x03, 0x2b, 0x65, 0x71, 0x04, 0x3b, 0x04, 0x39
 };
 
 // Constructors
@@ -93,7 +94,7 @@ unsigned long OSSLEDPrivateKey::getOrderLength() const
 	if (nid == NID_ED25519)
 		return X25519_KEYLEN;
 	if (nid == NID_ED448)
-		return X448_KEYLEN;
+		return ED448_KEYLEN;
 	return 0;
 }
 
@@ -133,7 +134,6 @@ void OSSLEDPrivateKey::setFromOSSL(const EVP_PKEY* inPKEY)
 		memcpy(&inK[0], &der[PREFIXLEN], X25519_KEYLEN);
 		break;
 	case NID_X448:
-	case NID_ED448:
 		if (len != (X448_KEYLEN + PREFIXLEN))
 		{
 			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", X448_KEYLEN + PREFIXLEN, len);
@@ -141,6 +141,15 @@ void OSSLEDPrivateKey::setFromOSSL(const EVP_PKEY* inPKEY)
 		}
 		inK.resize(X448_KEYLEN);
 		memcpy(&inK[0], &der[PREFIXLEN], X448_KEYLEN);
+		break;
+	case NID_ED448:
+		if (len != (ED448_KEYLEN + PREFIXLEN))
+		{
+			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", ED448_KEYLEN + PREFIXLEN, len);
+			return;
+		}
+		inK.resize(ED448_KEYLEN);
+		memcpy(&inK[0], &der[PREFIXLEN], ED448_KEYLEN);
 		break;
 	default:
 		return;
@@ -263,14 +272,14 @@ void OSSLEDPrivateKey::createOSSLKey()
 		memcpy(&der[PREFIXLEN], k.const_byte_str(), X448_KEYLEN);
 		break;
 	case NID_ED448:
-		if (k.size() != X448_KEYLEN)
+		if (k.size() != ED448_KEYLEN)
 		{
-			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", X448_KEYLEN, k.size());
+			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", ED448_KEYLEN, k.size());
 			return;
 		}
-		der.resize(PREFIXLEN + X448_KEYLEN);
+		der.resize(PREFIXLEN + ED448_KEYLEN);
 		memcpy(&der[0], ed448_prefix, PREFIXLEN);
-		memcpy(&der[PREFIXLEN], k.const_byte_str(), X448_KEYLEN);
+		memcpy(&der[PREFIXLEN], k.const_byte_str(), ED448_KEYLEN);
 		break;
 	default:
 		return;

--- a/src/lib/crypto/OSSLEDPublicKey.cpp
+++ b/src/lib/crypto/OSSLEDPublicKey.cpp
@@ -40,7 +40,8 @@
 #include <string.h>
 
 #define X25519_KEYLEN	32
-#define X448_KEYLEN	57
+#define X448_KEYLEN	56
+#define ED448_KEYLEN	57
 
 #define PREFIXLEN	12
 
@@ -51,8 +52,8 @@ const unsigned char x25519_prefix[] = {
 };
 
 const unsigned char x448_prefix[] = {
-	0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
-	0x6f, 0x03, 0x21, 0x00
+	0x30, 0x42, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+	0x6f, 0x03, 0x39, 0x00
 };
 
 const unsigned char ed25519_prefix[] = {
@@ -61,8 +62,8 @@ const unsigned char ed25519_prefix[] = {
 };
 
 const unsigned char ed448_prefix[] = {
-	0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
-	0x71, 0x03, 0x21, 0x00
+	0x30, 0x43, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+	0x71, 0x03, 0x3a, 0x00
 };
 
 // Constructors
@@ -95,7 +96,7 @@ unsigned long OSSLEDPublicKey::getOrderLength() const
 	if (nid == NID_ED25519)
 		return X25519_KEYLEN;
 	if (nid == NID_ED448)
-		return X448_KEYLEN;
+		return ED448_KEYLEN;
 	return 0;
 }
 
@@ -135,7 +136,6 @@ void OSSLEDPublicKey::setFromOSSL(const EVP_PKEY* inPKEY)
 		memcpy(&raw[0], &der[PREFIXLEN], X25519_KEYLEN);
 		break;
 	case NID_X448:
-	case NID_ED448:
 		if (len != (X448_KEYLEN + PREFIXLEN))
 		{
 			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", X448_KEYLEN + PREFIXLEN, len);
@@ -143,6 +143,16 @@ void OSSLEDPublicKey::setFromOSSL(const EVP_PKEY* inPKEY)
 		}
 		raw.resize(X448_KEYLEN);
 		memcpy(&raw[0], &der[PREFIXLEN], X448_KEYLEN);
+		break;
+	case NID_ED448:
+		if (len != (ED448_KEYLEN + PREFIXLEN))
+		{
+			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu",
+				  ED448_KEYLEN + PREFIXLEN, len);
+			return;
+		}
+		raw.resize(ED448_KEYLEN);
+		memcpy(&raw[0], &der[PREFIXLEN], ED448_KEYLEN);
 		break;
 	default:
 		return;
@@ -230,14 +240,14 @@ void OSSLEDPublicKey::createOSSLKey()
 		memcpy(&der[PREFIXLEN], raw.const_byte_str(), X448_KEYLEN);
 		break;
 	case NID_ED448:
-		if (len != X448_KEYLEN)
+		if (len != ED448_KEYLEN)
 		{
-			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", X448_KEYLEN, len);
+			ERROR_MSG("Invalid size. Expected: %lu, Actual: %lu", ED448_KEYLEN, len);
 			return;
 		}
-		der.resize(PREFIXLEN + X448_KEYLEN);
+		der.resize(PREFIXLEN + ED448_KEYLEN);
 		memcpy(&der[0], ed448_prefix, PREFIXLEN);
-		memcpy(&der[PREFIXLEN], raw.const_byte_str(), X448_KEYLEN);
+		memcpy(&der[PREFIXLEN], raw.const_byte_str(), ED448_KEYLEN);
 		break;
 	default:
 		return;

--- a/src/lib/crypto/OSSLUtil.cpp
+++ b/src/lib/crypto/OSSLUtil.cpp
@@ -135,6 +135,14 @@ ByteString OSSL::oid2ByteString(int nid)
 			name = "curve25519";
 			break;
 
+		case EVP_PKEY_ED448:
+			name = "edwards448";
+			break;
+
+		case EVP_PKEY_X448:
+			name = "curve448";
+			break;
+
 		default:
 			return rv;
 	}
@@ -185,6 +193,16 @@ int OSSL::byteString2oid(const ByteString& byteString)
 		if (strcmp((char *)curve_name->data, "curve25519") == 0)
 		{
 			return EVP_PKEY_X25519;
+		}
+
+		if (strcmp((char *)curve_name->data, "edwards448") == 0)
+		{
+			return EVP_PKEY_ED448;
+		}
+
+		if (strcmp((char *)curve_name->data, "curve448") == 0)
+		{
+			return EVP_PKEY_X448;
 		}
 	}
 

--- a/src/lib/crypto/test/EDDSATests.h
+++ b/src/lib/crypto/test/EDDSATests.h
@@ -43,9 +43,11 @@ class EDDSATests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testSerialisation);
 	CPPUNIT_TEST(testPKCS8);
 	CPPUNIT_TEST(testSigningVerifying);
-	CPPUNIT_TEST(testSignVerifyKnownVector);
+	CPPUNIT_TEST(testSignVerifyKnownVectorEd25519);
+	CPPUNIT_TEST(testSignVerifyKnownVectorEd448);
 	CPPUNIT_TEST(testDerivation);
-	CPPUNIT_TEST(testDeriveKnownVector);
+	CPPUNIT_TEST(testDeriveKnownVectorX25519);
+	CPPUNIT_TEST(testDeriveKnownVectorX448);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -53,9 +55,11 @@ public:
 	void testSerialisation();
 	void testPKCS8();
 	void testSigningVerifying();
-	void testSignVerifyKnownVector();
+	void testSignVerifyKnownVectorEd25519();
+	void testSignVerifyKnownVectorEd448();
 	void testDerivation();
-	void testDeriveKnownVector();
+	void testDeriveKnownVectorX25519();
+	void testDeriveKnownVectorX448();
 
 	void setUp();
 	void tearDown();

--- a/src/lib/test/DeriveTests.h
+++ b/src/lib/test/DeriveTests.h
@@ -44,7 +44,7 @@ class DeriveTests : public TestsBase
 	CPPUNIT_TEST(testEcdsaDerive);
 #endif
 #ifdef WITH_EDDSA
-	CPPUNIT_TEST(testEddsaDerive);
+	CPPUNIT_TEST_PARAMETERIZED(testEddsaDerive, {"X25519", "X448"});
 #endif
 	CPPUNIT_TEST(testSymDerive);
 	CPPUNIT_TEST_SUITE_END();
@@ -55,7 +55,7 @@ public:
 	void testEcdsaDerive();
 #endif
 #ifdef WITH_EDDSA
-	void testEddsaDerive();
+	void testEddsaDerive(const char* alg);
 #endif
 	void testSymDerive();
 
@@ -75,7 +75,7 @@ protected:
 	void ecdhDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hPublicKey, CK_OBJECT_HANDLE hPrivateKey, CK_OBJECT_HANDLE &hKey, bool useRaw);
 #endif
 #ifdef WITH_EDDSA
-	CK_RV generateEdKeyPair(const char* curve, CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk);
+	CK_RV generateEdKeyPair(const char* alg, CK_SESSION_HANDLE hSession, CK_BBOOL bTokenPuk, CK_BBOOL bPrivatePuk, CK_BBOOL bTokenPrk, CK_BBOOL bPrivatePrk, CK_OBJECT_HANDLE &hPuk, CK_OBJECT_HANDLE &hPrk);
 #endif
 	bool compareSecret(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey1, CK_OBJECT_HANDLE hKey2);
 	void symDerive(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey, CK_OBJECT_HANDLE &hDerive, CK_MECHANISM_TYPE mechType, CK_KEY_TYPE keyType);

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -170,7 +170,10 @@ CK_RV SignVerifyTests::generateED(const char* curve, CK_SESSION_HANDLE hSession,
 {
 	CK_MECHANISM mechanism = { CKM_EC_EDWARDS_KEY_PAIR_GEN, NULL_PTR, 0 };
 	CK_KEY_TYPE keyType = CKK_EC_EDWARDS;
-	CK_BYTE oidEd25519[] = { 0x06, 0x03, 0x2B, 0x65, 0x70 };
+	CK_BYTE curveNameEd25519[] = { 0x13, 0x0c, 0x65, 0x64, 0x77, 0x61, 0x72,
+				       0x64, 0x73, 0x32, 0x35, 0x35, 0x31, 0x39 };
+	CK_BYTE curveNameEd448[] = { 0x13, 0x0a, 0x65, 0x64, 0x77, 0x61,
+				     0x72, 0x64, 0x73, 0x34, 0x34, 0x38 };
 	CK_BYTE label[] = { 0x12, 0x34 }; // dummy
 	CK_BYTE id[] = { 123 } ; // dummy
 	CK_BBOOL bFalse = CK_FALSE;
@@ -203,8 +206,13 @@ CK_RV SignVerifyTests::generateED(const char* curve, CK_SESSION_HANDLE hSession,
 	/* Select the curve */
 	if (strcmp(curve, "Ed25519") == 0)
 	{
-		pukAttribs[0].pValue = oidEd25519;
-		pukAttribs[0].ulValueLen = sizeof(oidEd25519);
+		pukAttribs[0].pValue = curveNameEd25519;
+		pukAttribs[0].ulValueLen = sizeof(curveNameEd25519);
+	}
+	else if (strcmp(curve, "Ed448") == 0)
+	{
+		pukAttribs[0].pValue = curveNameEd448;
+		pukAttribs[0].ulValueLen = sizeof(curveNameEd448);
 	}
 	else
 	{
@@ -536,8 +544,13 @@ void SignVerifyTests::testEcSignVerify()
 #endif
 
 #ifdef WITH_EDDSA
-void SignVerifyTests::testEdSignVerify()
+void SignVerifyTests::testEdSignVerify(const char* curve)
 {
+#ifdef WITH_BOTAN
+	if (strcmp(curve, "Ed448") == 0)
+		return;
+#endif
+
 	CK_RV rv;
 	CK_SESSION_HANDLE hSessionRO;
 	CK_SESSION_HANDLE hSessionRW;
@@ -569,22 +582,22 @@ void SignVerifyTests::testEdSignVerify()
 	CK_OBJECT_HANDLE hPrk = CK_INVALID_HANDLE;
 
 	// Public Session keys
-	rv = generateED("Ed25519", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
+	rv = generateED(curve, hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_EDDSA, hSessionRO, hPuk,hPrk);
 
 	// Private Session Keys
-	rv = generateED("Ed25519", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
+	rv = generateED(curve, hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_EDDSA, hSessionRO, hPuk,hPrk);
 
 	// Public Token Keys
-	rv = generateED("Ed25519", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
+	rv = generateED(curve, hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_EDDSA, hSessionRO, hPuk,hPrk);
 
 	// Private Token Keys
-	rv = generateED("Ed25519", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
+	rv = generateED(curve, hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_EDDSA, hSessionRO, hPuk,hPrk);
 }

--- a/src/lib/test/SignVerifyTests.h
+++ b/src/lib/test/SignVerifyTests.h
@@ -46,7 +46,7 @@ class SignVerifyTests : public TestsBase
 	CPPUNIT_TEST(testEcSignVerify);
 #endif
 #ifdef WITH_EDDSA
-	CPPUNIT_TEST(testEdSignVerify);
+	CPPUNIT_TEST_PARAMETERIZED(testEdSignVerify, {"Ed25519", "Ed448"});
 #endif
 	CPPUNIT_TEST(testMacSignVerify);
 	CPPUNIT_TEST_SUITE_END();
@@ -57,7 +57,7 @@ public:
 	void testEcSignVerify();
 #endif
 #ifdef WITH_EDDSA
-	void testEdSignVerify();
+	void testEdSignVerify(const char* curve);
 #endif
 	void testMacSignVerify();
 


### PR DESCRIPTION
This puts the finishing touches on the OpenSSL Ed448/X448 implementation. I'm able to successfully run BIND's Ed448 DNSSEC tests with these changes.
