### PR TITLE
Flush files before unlocking

### DIFF
--- a/src/lib/object_store/File.cpp
+++ b/src/lib/object_store/File.cpp
@@ -709,6 +709,8 @@ bool File::lock(bool block /* = true */)
 // Unlock the file
 bool File::unlock()
 {
+	flush();
+
 #ifndef _WIN32
 	struct flock fl;
 	fl.l_type = F_UNLCK;
@@ -757,7 +759,7 @@ bool File::unlock()
 	return valid;
 }
 
-// Flush the buffered stream to background storage
+// Flush the buffered stream to background storage and discard unread fetched data
 bool File::flush()
 {
 	return valid && !fflush(stream);


### PR DESCRIPTION
Destroying the File object will call fclose() and this will flush writes but this should only happen while the file is still locked.
Flush pending writes before every unlock. This also discards all unused data fetched from the file while locked, because it is now stale.

SoftHSM is writing to token.object files after unlocking, when the File is destroyed:
```
20:54:22.344661 openat(AT_FDCWD, "/var/lib/softhsm/tokens//4184d325-ecda-4355-83b1-6f4156b0fde0/token.object", O_RDWR|O_CREAT, 0640) = 5
20:54:22.344686 fcntl(5, F_GETFL)       = 0x8002 (flags O_RDWR|O_LARGEFILE)
20:54:22.344703 fcntl(5, F_SETLKW, {l_type=F_WRLCK, l_whence=SEEK_SET, l_start=0, l_len=0}) = 0
20:54:22.344722 openat(AT_FDCWD, "/var/lib/softhsm/tokens//4184d325-ecda-4355-83b1-6f4156b0fde0/token.lock", O_WRONLY|O_CREAT|O_TRUNC, 0640) = 6
20:54:22.344821 fcntl(6, F_GETFL)       = 0x8001 (flags O_WRONLY|O_LARGEFILE)
20:54:22.344843 fstat(5, {st_mode=S_IFREG|0660, st_size=320, ...}) = 0
20:54:22.344865 read(5, "****
20:54:22.344893 lseek(5, 0, SEEK_SET)   = 0
20:54:22.344911 ftruncate(5, 0)         = 0
20:54:22.344962 fcntl(5, F_SETLK, {l_type=F_UNLCK, l_whence=SEEK_SET, l_start=0, l_len=0}) = 0
20:54:22.344982 close(6)                = 0
20:54:22.344999 write(5, "**** <-- this should have been called before unlocking
20:54:22.345023 close(5)                = 0
```