### PR TITLE
doc: Fix category title to reflect the actual option name

### DIFF
--- a/src/lib/common/softhsm2.conf.5.in
+++ b/src/lib/common/softhsm2.conf.5.in
@@ -64,7 +64,7 @@ slots.removable = true
 .fi
 .RE
 .LP
-.SH TOKEN.MECHANISMS
+.SH SLOTS.MECHANISMS
 Allows to enable and disable any of the PKCS#11 mechanisms reported in the
 C_GetMechanismList().
 The option accepts string argument containing the comma separated list of all


### PR DESCRIPTION
this is broken since the rename in 03c6202a