### PR TITLE
fix for issue #589: specify `EVP_md_null()` as hashing algorithm for EdDSA sig and vfy

### DIFF
--- a/src/lib/crypto/OSSLEDDSA.cpp
+++ b/src/lib/crypto/OSSLEDDSA.cpp
@@ -85,7 +85,7 @@ bool OSSLEDDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 	signature.resize(len);
 	memset(&signature[0], 0, len);
 	EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-	if (!EVP_DigestSignInit(ctx, NULL, NULL, NULL, pkey))
+	if (!EVP_DigestSignInit(ctx, NULL, EVP_md_null(), NULL, pkey))
 	{
 		ERROR_MSG("EDDSA sign init failed (0x%08X)", ERR_get_error());
 		EVP_MD_CTX_free(ctx);
@@ -166,7 +166,7 @@ bool OSSLEDDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 		return false;
 	}
 	EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-	if (!EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, pkey))
+	if (!EVP_DigestVerifyInit(ctx, NULL, EVP_md_null(), NULL, pkey))
 	{
 		ERROR_MSG("EDDSA verify init failed (0x%08X)", ERR_get_error());
 		EVP_MD_CTX_free(ctx);


### PR DESCRIPTION
This patch hopefully fixes issue #589. I have tested for signature, using ED25519 and ED448 private keys. I couldn't validate for verify, but this should be trivial - maybe part of the test suite.

Regards,

