### PR TITLE
Enforce attributes becoming read-only once set to CK_TRUE on CKA_WRAP…

### DIFF
--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -466,6 +466,15 @@ CK_RV P11Attribute::update(Token* token, bool isPrivate, CK_VOID_PTR pValue, CK_
 			return updateAttr(token, isPrivate, pValue, ulValueLen, op);
 		}
 	}
+	// ck11  Can only be changed to CK_TRUE on a C_SetAttributeValue call; actual
+	//       enforcement happens in the specific attribute implementation.
+	if ((checks & ck11) == ck11)
+	{
+		if (OBJECT_OP_SET==op || OBJECT_OP_COPY==op)
+		{
+			return updateAttr(token, isPrivate, pValue, ulValueLen, op);
+		}
+	}
 
 	// ck17  Can be changed in the process of copying the object using C_CopyObject.
 	if ((checks & ck17) == ck17)

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -448,6 +448,52 @@ void ObjectTests::checkCommonPrivateKeyAttributes(CK_SESSION_HANDLE hSession, CK
 	free(attribs[0].pValue);
 }
 
+void ObjectTests::checkToTrueAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject)
+{
+	// Check Table 25 note 11 enforcement on CKA_WRAP_WITH_TRUSTED
+	CK_RV rv = CKR_OK;
+	CK_BBOOL bTrue = CK_TRUE;
+	CK_BBOOL bFalse = CK_FALSE;
+	CK_ATTRIBUTE wwt_to_false[] = {
+		{ CKA_WRAP_WITH_TRUSTED, &bFalse, sizeof(bFalse) }
+	};
+	CK_ATTRIBUTE wwt_to_true[] = {
+		{ CKA_WRAP_WITH_TRUSTED, &bTrue, sizeof(bTrue) }
+	};
+
+	// Default was CK_FALSE, so setting to CK_FALSE should work
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, &wwt_to_false[0], 1) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Now set it to CK_TRUE
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, &wwt_to_true[0], 1) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Once CK_TRUE, it cannot go back to CK_FALSE
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, &wwt_to_false[0], 1) );
+	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_READ_ONLY);
+
+	// Check Table 25 note 11 enforcement on CKA_SENSITIVE
+	CK_ATTRIBUTE sensitive_to_false[] = {
+		{ CKA_SENSITIVE, &bFalse, sizeof(bFalse) }
+	};
+	CK_ATTRIBUTE sensitive_to_true[] = {
+		{ CKA_SENSITIVE, &bTrue, sizeof(bTrue) }
+	};
+
+	// Default was CK_FALSE, so setting to CK_FALSE should work
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, &sensitive_to_false[0], 1) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Now set it to CK_TRUE
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, &sensitive_to_true[0], 1) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Once CK_TRUE, it cannot go back to CK_FALSE
+	rv = CRYPTOKI_F_PTR( C_SetAttributeValue(hSession, hObject, &sensitive_to_false[0], 1) );
+	CPPUNIT_ASSERT(rv == CKR_ATTRIBUTE_READ_ONLY);
+}
+
 void ObjectTests::checkCommonRSAPublicKeyAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_BYTE_PTR pModulus, CK_ULONG ulModulusLen, CK_ULONG ulModulusBits, CK_BYTE_PTR pPublicExponent, CK_ULONG ulPublicExponentLen)
 {
 	CK_RV rv;
@@ -1786,6 +1832,7 @@ void ObjectTests::testDefaultRSAPrivAttributes()
 	checkCommonKeyAttributes(hSession, hObject, objType, NULL_PTR, 0, emptyDate, 0, emptyDate, 0, CK_FALSE, CK_FALSE, CK_UNAVAILABLE_INFORMATION, NULL_PTR, 0);
 	checkCommonPrivateKeyAttributes(hSession, hObject, NULL_PTR, 0, CK_FALSE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_FALSE, CK_FALSE, CK_FALSE, NULL_PTR, 0, CK_FALSE);
 	checkCommonRSAPrivateKeyAttributes(hSession, hObject, pN, sizeof(pN), NULL_PTR, 0, pD, sizeof(pD), NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0);
+	checkToTrueAttributes(hSession, hObject);
 }
 
 void ObjectTests::testAlwaysNeverAttribute()

--- a/src/lib/test/ObjectTests.h
+++ b/src/lib/test/ObjectTests.h
@@ -180,6 +180,7 @@ protected:
 		CK_BYTE_PTR pExponent2, CK_ULONG ulExponent2Len,
 		CK_BYTE_PTR pCoefficient, CK_ULONG ulCoefficientLen
 	);
+	void checkToTrueAttributes(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject);
 
 	CK_RV createDataObjectMinimal(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hObject);
 	CK_RV createDataObjectMCD(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_BBOOL bModifiable, CK_BBOOL bCopyable, CK_BBOOL bDestroyable, CK_OBJECT_HANDLE &hObject);


### PR DESCRIPTION
This fixes #584 and enforces the following behaviour (according to v2.40, Table 10, 25 and 27):

For the following attributes, once their value has been set to `CK_TRUE`, they become read-only (that is: a call to `C_SetAttributeValue(..)` that attempts to change them to `CK_FALSE` will return `CKR_ATTRIBUTE_READ_ONLY`):

* `CKA_WRAP_WITH_TRUSTED`
* `CKA_SENSITIVE`