### PR TITLE
Fix issue 585 by resetting en/decrypt op on input validation

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -2589,12 +2589,17 @@ CK_RV SoftHSM::C_Encrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (pData == NULL_PTR) return CKR_ARGUMENTS_BAD;
-	if (pulEncryptedDataLen == NULL_PTR) return CKR_ARGUMENTS_BAD;
-
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
+
+	if ((pData == NULL_PTR) || (pulEncryptedDataLen == NULL_PTR))
+	{
+		// Fix issue 585
+		session->resetOp();
+
+		return CKR_ARGUMENTS_BAD;
+	}
 
 	// Check if we are doing the correct operation
 	if (session->getOpType() != SESSION_OP_ENCRYPT)
@@ -2685,12 +2690,16 @@ CK_RV SoftHSM::C_EncryptUpdate(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (pData == NULL_PTR) return CKR_ARGUMENTS_BAD;
-	if (pulEncryptedDataLen == NULL_PTR) return CKR_ARGUMENTS_BAD;
-
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
+
+	if ((pData == NULL_PTR) || (pulEncryptedDataLen == NULL_PTR))
+	{
+		session->resetOp();
+
+		return CKR_ARGUMENTS_BAD;
+	}
 
 	// Check if we are doing the correct operation
 	if (session->getOpType() != SESSION_OP_ENCRYPT)
@@ -3327,12 +3336,16 @@ CK_RV SoftHSM::C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData,
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (pEncryptedData == NULL_PTR) return CKR_ARGUMENTS_BAD;
-	if (pulDataLen == NULL_PTR) return CKR_ARGUMENTS_BAD;
-
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
+
+	if ((pEncryptedData == NULL_PTR) || (pulDataLen == NULL_PTR))
+	{
+		session->resetOp();
+
+		return CKR_ARGUMENTS_BAD;
+	}
 
 	// Check if we are doing the correct operation
 	if (session->getOpType() != SESSION_OP_DECRYPT)
@@ -3427,12 +3440,16 @@ CK_RV SoftHSM::C_DecryptUpdate(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncrypte
 {
 	if (!isInitialised) return CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (pEncryptedData == NULL_PTR) return CKR_ARGUMENTS_BAD;
-	if (pDataLen == NULL_PTR) return CKR_ARGUMENTS_BAD;
-
 	// Get the session
 	Session* session = (Session*)handleManager->getSession(hSession);
 	if (session == NULL) return CKR_SESSION_HANDLE_INVALID;
+
+	if ((pEncryptedData == NULL_PTR) || (pDataLen == NULL_PTR))
+	{
+		session->resetOp();
+
+		return CKR_ARGUMENTS_BAD;
+	}
 
 	// Check if we are doing the correct operation
 	if (session->getOpType() != SESSION_OP_DECRYPT)

--- a/src/lib/test/SymmetricAlgorithmTests.h
+++ b/src/lib/test/SymmetricAlgorithmTests.h
@@ -50,6 +50,7 @@ class SymmetricAlgorithmTests : public TestsBase
 	CPPUNIT_TEST(testAesCtrOverflow);
 	CPPUNIT_TEST(testGenericKey);
 	CPPUNIT_TEST(testEncDecFinalNULLValidation);
+	CPPUNIT_TEST(testOpTermIssue585);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -62,6 +63,7 @@ public:
 	void testAesCtrOverflow();
 	void testGenericKey();
 	void testEncDecFinalNULLValidation();
+	void testOpTermIssue585();
 
 protected:
 	CK_RV generateGenericKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);


### PR DESCRIPTION
Fixes issue #585 by properly resetting encrypt or decrypt operation status when one of the input parameter validation checks fails with `CKR_ARGUMENTS_BAD`.