### PR TITLE
InfoTests::testGetMechanismNegativeListConfig() not working when testing

### DIFF
--- a/src/lib/test/InfoTests.cpp
+++ b/src/lib/test/InfoTests.cpp
@@ -365,7 +365,6 @@ void InfoTests::testGetMechanismListConfig()
 	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
 #endif
 }
-#endif // P11_SHARED_LIBRARY
 
 void InfoTests::testGetMechanismNegativeListConfig()
 {
@@ -432,6 +431,7 @@ void InfoTests::testGetMechanismNegativeListConfig()
 	setenv("SOFTHSM2_CONF", ".\\softhsm2.conf", 1);
 #endif
 }
+#endif // P11_SHARED_LIBRARY
 
 void InfoTests::testWaitForSlotEvent()
 {


### PR DESCRIPTION
another shared library than SoftHSM.