### PR TITLE
Do not refresh object store before fetching object.

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -609,6 +609,8 @@ CK_RV SoftHSM::C_Initialize(CK_VOID_PTR pInitArgs)
 	// Load the handle manager
 	handleManager = new HandleManager();
 
+	doRefresh = Configuration::i()->getBool("objectstore.readrefresh", true);
+
 	// Set the state to initialised
 	isInitialised = true;
 
@@ -1605,7 +1607,7 @@ CK_RV SoftHSM::C_CopyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject
 
 	// Check the object handle.
 	OSObject *object = (OSObject *)handleManager->getObject(hObject);
-	if (object == NULL_PTR || !object->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (object == NULL_PTR || !object->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL wasOnToken = object->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL wasPrivate = object->getBooleanValue(CKA_PRIVATE, true);
@@ -1774,7 +1776,7 @@ CK_RV SoftHSM::C_DestroyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObj
 
 	// Check the object handle.
 	OSObject *object = (OSObject *)handleManager->getObject(hObject);
-	if (object == NULL_PTR || !object->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (object == NULL_PTR || !object->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = object->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = object->getBooleanValue(CKA_PRIVATE, true);
@@ -1822,7 +1824,7 @@ CK_RV SoftHSM::C_GetObjectSize(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObj
 
 	// Check the object handle.
 	OSObject *object = (OSObject *)handleManager->getObject(hObject);
-	if (object == NULL_PTR || !object->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (object == NULL_PTR || !object->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	*pulSize = CK_UNAVAILABLE_INFORMATION;
 
@@ -1846,7 +1848,7 @@ CK_RV SoftHSM::C_GetAttributeValue(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE 
 
 	// Check the object handle.
 	OSObject *object = (OSObject *)handleManager->getObject(hObject);
-	if (object == NULL_PTR || !object->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (object == NULL_PTR || !object->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = object->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = object->getBooleanValue(CKA_PRIVATE, true);
@@ -1893,7 +1895,7 @@ CK_RV SoftHSM::C_SetAttributeValue(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE 
 
 	// Check the object handle.
 	OSObject *object = (OSObject *)handleManager->getObject(hObject);
-	if (object == NULL_PTR || !object->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (object == NULL_PTR || !object->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = object->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = object->getBooleanValue(CKA_PRIVATE, true);
@@ -2163,7 +2165,7 @@ CK_RV SoftHSM::SymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -2410,7 +2412,7 @@ CK_RV SoftHSM::AsymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMec
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -2882,7 +2884,7 @@ CK_RV SoftHSM::SymDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -3130,7 +3132,7 @@ CK_RV SoftHSM::AsymDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMec
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -3773,7 +3775,7 @@ CK_RV SoftHSM::C_DigestKey(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject)
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hObject);
-	if (key == NULL_PTR || !key->isValid()) return CKR_KEY_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_KEY_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -3924,7 +3926,7 @@ CK_RV SoftHSM::MacSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechani
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -4076,7 +4078,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -4902,7 +4904,7 @@ CK_RV SoftHSM::MacVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -5054,7 +5056,7 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -6490,7 +6492,7 @@ CK_RV SoftHSM::C_WrapKey
 
 	// Check the wrapping key handle.
 	OSObject *wrapKey = (OSObject *)handleManager->getObject(hWrappingKey);
-	if (wrapKey == NULL_PTR || !wrapKey->isValid()) return CKR_WRAPPING_KEY_HANDLE_INVALID;
+	if (wrapKey == NULL_PTR || !wrapKey->isValid(doRefresh)) return CKR_WRAPPING_KEY_HANDLE_INVALID;
 
 	CK_BBOOL isWrapKeyOnToken = wrapKey->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isWrapKeyPrivate = wrapKey->getBooleanValue(CKA_PRIVATE, true);
@@ -6532,7 +6534,7 @@ CK_RV SoftHSM::C_WrapKey
 
 	// Check the to be wrapped key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_KEY_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_KEY_HANDLE_INVALID;
 
 	CK_BBOOL isKeyOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isKeyPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -6957,7 +6959,7 @@ CK_RV SoftHSM::C_UnwrapKey
 
 	// Check the unwrapping key handle.
 	OSObject *unwrapKey = (OSObject *)handleManager->getObject(hUnwrappingKey);
-	if (unwrapKey == NULL_PTR || !unwrapKey->isValid()) return CKR_UNWRAPPING_KEY_HANDLE_INVALID;
+	if (unwrapKey == NULL_PTR || !unwrapKey->isValid(doRefresh)) return CKR_UNWRAPPING_KEY_HANDLE_INVALID;
 
 	CK_BBOOL isUnwrapKeyOnToken = unwrapKey->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isUnwrapKeyPrivate = unwrapKey->getBooleanValue(CKA_PRIVATE, true);
@@ -7255,7 +7257,7 @@ CK_RV SoftHSM::C_DeriveKey
 
 	// Check the key handle.
 	OSObject *key = (OSObject *)handleManager->getObject(hBaseKey);
-	if (key == NULL_PTR || !key->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (key == NULL_PTR || !key->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
 	CK_BBOOL isKeyOnToken = key->getBooleanValue(CKA_TOKEN, false);
 	CK_BBOOL isKeyPrivate = key->getBooleanValue(CKA_PRIVATE, true);
@@ -10358,7 +10360,7 @@ CK_RV SoftHSM::deriveDH
 
 	// Get the base key handle
 	OSObject *baseKey = (OSObject *)handleManager->getObject(hBaseKey);
-	if (baseKey == NULL || !baseKey->isValid())
+	if (baseKey == NULL || !baseKey->isValid(doRefresh))
 		return CKR_KEY_HANDLE_INVALID;
 
 	// Get the DH algorithm handler
@@ -10690,7 +10692,7 @@ CK_RV SoftHSM::deriveECDH
 
 	// Get the base key handle
 	OSObject *baseKey = (OSObject *)handleManager->getObject(hBaseKey);
-	if (baseKey == NULL || !baseKey->isValid())
+	if (baseKey == NULL || !baseKey->isValid(doRefresh))
 		return CKR_KEY_HANDLE_INVALID;
 
 	// Get the ECDH algorithm handler
@@ -11044,7 +11046,7 @@ CK_RV SoftHSM::deriveEDDSA
 
 	// Get the base key handle
 	OSObject *baseKey = (OSObject *)handleManager->getObject(hBaseKey);
-	if (baseKey == NULL || !baseKey->isValid())
+	if (baseKey == NULL || !baseKey->isValid(doRefresh))
 		return CKR_KEY_HANDLE_INVALID;
 
 	// Get the EDDSA algorithm handler
@@ -11570,7 +11572,7 @@ CK_RV SoftHSM::deriveSymmetric
 
 	// Check the key handle
 	OSObject *baseKey = (OSObject *)handleManager->getObject(hBaseKey);
-	if (baseKey == NULL_PTR || !baseKey->isValid()) return CKR_OBJECT_HANDLE_INVALID;
+	if (baseKey == NULL_PTR || !baseKey->isValid(doRefresh)) return CKR_OBJECT_HANDLE_INVALID;
 
     // Get the data
     ByteString secretValue;

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -186,6 +186,8 @@ private:
 	// Is the SoftHSM PKCS #11 library initialised?
 	bool isInitialised;
 	bool isRemovable;
+	// Do refresh of all objects from storage before validating.
+	bool doRefresh;
 
 	SessionObjectStore* sessionObjectStore;
 	ObjectStore* objectStore;

--- a/src/lib/common/Configuration.cpp
+++ b/src/lib/common/Configuration.cpp
@@ -51,6 +51,7 @@ const struct config Configuration::valid_config[] = {
 	{ "slots.removable",		CONFIG_TYPE_BOOL },
 	{ "slots.mechanisms",		CONFIG_TYPE_STRING },
 	{ "library.reset_on_fork",	CONFIG_TYPE_BOOL },
+	{ "objectstore.readrefresh",	CONFIG_TYPE_BOOL },
 	{ "",				CONFIG_TYPE_UNSUPPORTED }
 };
 

--- a/src/lib/common/softhsm2.conf.5.in
+++ b/src/lib/common/softhsm2.conf.5.in
@@ -102,6 +102,32 @@ library.reset_on_fork = true
 .fi
 .RE
 .LP
+.SH OBJECTSTORE.READREFRESH
+If set to false, then this will affect the refreshing of the object store in
+the following way before an object is used but not changed:
+.IP * 2
+No files will be read if 'objectstore.backend = file'.
+.IP * 2
+No wait for mutex to unlock if 'objectstore.backend = db'.
+.LP
+Depending of what kind of HW that is used setting 'false' may improve the
+performance of the HSM.
+.LP
+But the drawback is that if one processes is using an object handle from a
+token for multiple function calls then this process may still use the old
+unmodified or deleted object even if it is changed or deleted. Another
+process may have called C_DestroyObject or C_SetAttributeValue. But every
+time a process gets a new handle for an object the objectstore of this
+process is updated for all objects even if this property is false.
+.LP 
+Default is true.
+.LP
+.RS
+.nf
+objectstore.readrefresh = false
+.fi
+.RE
+.LP
 .SH ENVIRONMENT
 .TP
 SOFTHSM2_CONF

--- a/src/lib/common/softhsm2.conf.5.in
+++ b/src/lib/common/softhsm2.conf.5.in
@@ -103,12 +103,9 @@ library.reset_on_fork = true
 .RE
 .LP
 .SH OBJECTSTORE.READREFRESH
-If set to false, then this will affect the refreshing of the object store in
-the following way before an object is used but not changed:
-.IP * 2
-No files will be read if 'objectstore.backend = file'.
-.IP * 2
-No wait for mutex to unlock if 'objectstore.backend = db'.
+If set to false and if 'objectstore.backend = file', then this will affect
+the refreshing of the object store.
+Before using an object that is not changed, no files will be read.
 .LP
 Depending of what kind of HW that is used setting 'false' may improve the
 performance of the HSM.
@@ -119,7 +116,9 @@ unmodified or deleted object even if it is changed or deleted. Another
 process may have called C_DestroyObject or C_SetAttributeValue. But every
 time a process gets a new handle for an object the objectstore of this
 process is updated for all objects even if this property is false.
-.LP 
+.LP
+If 'objectstore.backend = db' then the value of this property is ignored.
+.LP
 Default is true.
 .LP
 .RS

--- a/src/lib/common/softhsm2.conf.in
+++ b/src/lib/common/softhsm2.conf.in
@@ -15,3 +15,6 @@ slots.mechanisms = ALL
 
 # If the library should reset the state on fork
 library.reset_on_fork = false
+
+# Set to false if there should be no update of a token objects each time it is used.
+objectstore.readrefresh = true

--- a/src/lib/object_store/DBObject.cpp
+++ b/src/lib/object_store/DBObject.cpp
@@ -1362,10 +1362,15 @@ bool DBObject::deleteAttribute(CK_ATTRIBUTE_TYPE type)
 }
 
 // The validity state of the object
-bool DBObject::isValid()
+// If not 'doRefresh' we know that the object allready exists in the DB
+// and hence _objectId should have been initialized.
+bool DBObject::isValid(const bool doRefresh)
 {
-	MutexLocker lock(_mutex);
-
+	if (doRefresh)
+	{
+		// Wait for update of object.
+		MutexLocker lock(_mutex);
+	}
 	return _objectId != 0 && _connection != NULL;
 }
 

--- a/src/lib/object_store/DBObject.cpp
+++ b/src/lib/object_store/DBObject.cpp
@@ -1362,15 +1362,10 @@ bool DBObject::deleteAttribute(CK_ATTRIBUTE_TYPE type)
 }
 
 // The validity state of the object
-// If not 'doRefresh' we know that the object allready exists in the DB
-// and hence _objectId should have been initialized.
-bool DBObject::isValid(const bool doRefresh)
+bool DBObject::isValid(const bool doRefresh __attribute__((unused)))
 {
-	if (doRefresh)
-	{
-		// Wait for update of object.
-		MutexLocker lock(_mutex);
-	}
+	MutexLocker lock(_mutex);
+
 	return _objectId != 0 && _connection != NULL;
 }
 

--- a/src/lib/object_store/DBObject.h
+++ b/src/lib/object_store/DBObject.h
@@ -96,7 +96,7 @@ public:
 	virtual bool deleteAttribute(CK_ATTRIBUTE_TYPE type);
 
 	// The validity state of the object
-	virtual bool isValid();
+	virtual bool isValid(bool doRefresh);
 
 	// Start an attribute set transaction; this method is used when - for
 	// example - a key is generated and all its attributes need to be

--- a/src/lib/object_store/DBToken.cpp
+++ b/src/lib/object_store/DBToken.cpp
@@ -679,7 +679,7 @@ OSObject *DBToken::createObject()
 		return NULL;
 	}
 
-	if (!newObject->isValid())
+	if (!newObject->isValid(true))
 	{
 		newObject->abortTransaction();
 		delete newObject;

--- a/src/lib/object_store/OSObject.h
+++ b/src/lib/object_store/OSObject.h
@@ -64,7 +64,8 @@ public:
 	virtual bool deleteAttribute(CK_ATTRIBUTE_TYPE type) = 0;
 
 	// The validity state of the object
-	virtual bool isValid() = 0;
+	// If doRefresh==true then update the object from the storage before validating.
+	virtual bool isValid(bool doRefresh=true) = 0;
 
 	// Start an attribute set transaction; this method is used when - for
 	// example - a key is generated and all its attributes need to be

--- a/src/lib/object_store/ObjectFile.cpp
+++ b/src/lib/object_store/ObjectFile.cpp
@@ -262,11 +262,13 @@ bool ObjectFile::deleteAttribute(CK_ATTRIBUTE_TYPE type)
 	return valid;
 }
 
-// The validity state of the object (refresh from disk as a side effect)
-bool ObjectFile::isValid()
+// The validity state of the object (may refresh from disk as a side effect)
+bool ObjectFile::isValid(const bool doRefresh)
 {
-	refresh();
-
+	if(doRefresh)
+	{
+		refresh();
+	}
 	return valid;
 }
 

--- a/src/lib/object_store/ObjectFile.h
+++ b/src/lib/object_store/ObjectFile.h
@@ -76,7 +76,7 @@ public:
 	virtual bool deleteAttribute(CK_ATTRIBUTE_TYPE type);
 
 	// The validity state of the object (refresh from disk as a side effect)
-	virtual bool isValid();
+	virtual bool isValid(bool doRefresh=true);
 
 	// Invalidate the object file externally; this method is normally
 	// only called by the OSToken class in case an object file has

--- a/src/lib/object_store/SessionObject.cpp
+++ b/src/lib/object_store/SessionObject.cpp
@@ -217,7 +217,8 @@ bool SessionObject::deleteAttribute(CK_ATTRIBUTE_TYPE type)
 }
 
 // The validity state of the object
-bool SessionObject::isValid()
+// the doRefresh parameter has no meaning for this implementation since noting is stored on disk.
+bool SessionObject::isValid(const bool doRefresh __attribute__((unused)))
 {
     return valid;
 }

--- a/src/lib/object_store/SessionObject.h
+++ b/src/lib/object_store/SessionObject.h
@@ -73,7 +73,7 @@ public:
 	virtual bool deleteAttribute(CK_ATTRIBUTE_TYPE type);
 
 	// The validity state of the object
-	virtual bool isValid();
+	virtual bool isValid(bool doRefresh);
 
 	bool hasSlotID(CK_SLOT_ID inSlotID);
 

--- a/src/lib/object_store/SessionObjectStore.cpp
+++ b/src/lib/object_store/SessionObjectStore.cpp
@@ -106,7 +106,7 @@ SessionObject* SessionObjectStore::createObject(CK_SLOT_ID slotID, CK_SESSION_HA
 	// Create the new object file
 	SessionObject* newObject = new SessionObject(this, slotID, hSession, isPrivate);
 
-	if (!newObject->isValid())
+	if (!newObject->isValid(false))
 	{
 		ERROR_MSG("Failed to create new object");
 


### PR DESCRIPTION
Before this commit the object store for a file token was always refreshed by reading
the file of the token every time an object of the token was fetched.
Now the HSM may be configured not to refresh when fetching an object. But the
refresh will still be done after an application gets a handle for an object.
    
The reason for this change is that the CPU time consumed by the reading may not
be negligible for some HW.