### PR TITLE
Fix CMake build by adding DEFAULT_UMASK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ set(DEFAULT_SOFTHSM2_CONF "${CMAKE_INSTALL_FULL_SYSCONFDIR}/softhsm2.conf"
     CACHE STRING "The default location of softhsm.conf")
 set(DEFAULT_TOKENDIR "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/softhsm/tokens/"
     CACHE STRING "The default location of the token directory")
+set(DEFAULT_UMASK "0077"
+    CACHE STRING "The default file mode creation mask")
 
 set(MAX_PIN_LEN 255 CACHE STRING "Maximum PIN length")
 set(MIN_PIN_LEN 4 CACHE STRING "Minimum PIN length")

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -18,6 +18,9 @@
 /* The default location of the token directory */
 #cmakedefine DEFAULT_TOKENDIR "@DEFAULT_TOKENDIR@"
 
+/* The default file mode creation mask */
+#cmakedefine DEFAULT_UMASK @DEFAULT_UMASK@
+
 /* Define if advanced AES key wrap without pad is supported */
 #cmakedefine HAVE_AES_KEY_WRAP @HAVE_AES_KEY_WRAP@
 


### PR DESCRIPTION
The config option DEFAULT_UMASK was introduced with commit de5bb8a but
hasn't been added to CMake configuration.