### PR TITLE
Replace AES-CBC with AES-GCM in SecureDataManager

### DIFF
--- a/src/lib/data_mgr/SecureDataManager.h
+++ b/src/lib/data_mgr/SecureDataManager.h
@@ -132,9 +132,6 @@ private:
 	// The masked version of the actual key
 	ByteString maskedKey;
 
-	// The "magic" data used to detect if a PIN was likely to be correct
-	ByteString magic;
-
 	// The mask; this is not a stack member but a heap member. This
 	// hopefully ensures that the mask ends up in a memory location
 	// that is not logically linked to the masked key


### PR DESCRIPTION
Use AES-GCM for encrypting the master key (derived from the PIN) and
get rid of the magic bytes.
Use AES-GCM for encrypting object attributes and thus guarantee the
integrity of the object files (i.e. detect if the object store has been
tampered).

Issue: #623