### PR TITLE
fix check minimal Botan version

### DIFF
--- a/m4/acx_crypto_backend.m4
+++ b/m4/acx_crypto_backend.m4
@@ -119,7 +119,7 @@ AC_DEFUN([ACX_CRYPTO_BACKEND],[
 	elif test "x${crypto_backend}" = "xbotan"; then
 		AC_MSG_RESULT(Botan)
 
-		ACX_BOTAN(2,0,0)
+		ACX_BOTAN(2,5,0)
 
 		CRYPTO_INCLUDES=$BOTAN_CFLAGS
 		CRYPTO_LIBS=$BOTAN_LIBS


### PR DESCRIPTION
compilation with Botan crypto backend on Ubuntu 18 fails.

way to reproduce:
```
$ sudo apt install libbotan-2-dev
$ sudo apt list --installed | grep botan
libbotan-2-dev/bionic,now 2.4.0-5ubuntu1 amd64 [installed]
$ ./autogen.sh
$ ./configure --with-crypto-backend=botan 
$ make

 ....lot of output....

BotanUtil.cpp:172:13: error: ‘class Botan::BER_Object’ has no member named ‘is_a’
  if (object.is_a(Botan::PRINTABLE_STRING, Botan::ASN1_Tag(0)))
             ^~~~
```

BER_Object is defined in include/botan-2/botan/asn1_obj.h
Member function 'is_a' was added in [Botan version 2.5](https://github.com/randombit/botan/blob/2.5.0/src/lib/asn1/asn1_obj.h) 
