### PR TITLE
Fix "Transaction in database is already active." bug

### DIFF
--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -272,7 +272,7 @@ CK_RV P11Object::saveTemplate(Token *token, bool isPrivate, CK_ATTRIBUTE_PTR pTe
 			if (!isSpecified)
 			{
 				ERROR_MSG("Mandatory attribute (0x%08X) was not specified in template", (unsigned int)i->first);
-
+				osobject->abortTransaction();
 				return CKR_TEMPLATE_INCOMPLETE;
 			}
 		}


### PR DESCRIPTION
Since the transaction is not aborted in the db backend after an incorrect object creation request is made, the database access process fails in the next database access calls.

> ondergormez@ondergormez-IdeaPad:$ ./CreateTokenObject10times.py 
exception1: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception2: CKR_GENERAL_ERROR (0x00000005)
exception3: CKR_GENERAL_ERROR (0x00000005)
exception4: CKR_GENERAL_ERROR (0x00000005)
exception5: CKR_GENERAL_ERROR (0x00000005)
exception6: CKR_GENERAL_ERROR (0x00000005)
exception7: CKR_GENERAL_ERROR (0x00000005)
exception8: CKR_GENERAL_ERROR (0x00000005)
exception9: CKR_GENERAL_ERROR (0x00000005)
exception10: CKR_GENERAL_ERROR (0x00000005)
ondergormez@ondergormez-IdeaPad:$

The syslog output of the above operations;  

> ondergormez@ondergormez-IdeaPad:$ less /var/log/syslog | grep python3
Aug 25 15:38:44 ondergormez-IdeaPad python3: P11Objects.cpp(274): Mandatory attribute (0x00000011) was not specified in template
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:44 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBObject.cpp(1402): Transaction in database is already active.
Aug 25 15:38:45 ondergormez-IdeaPad python3: DBToken.cpp(670): Unable to start a transaction in token database at "/var/lib/softhsm/tokens//dca70363-2561-0b5c-4c05-4f08043a82f9/sqlite3.db"
ondergormez@ondergormez-IdeaPad:$ 

The error message that occurs after the bug is fixed is as expected;  

> ondergormez@ondergormez-IdeaPad:$ ./CreateTokenObject10times.py 
exception1: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception2: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception3: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception4: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception5: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception6: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception7: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception8: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception9: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
exception10: CKR_TEMPLATE_INCOMPLETE (0x000000D0)
ondergormez@ondergormez-IdeaPad:$

The syslog output of the above operations;  

> ondergormez@ondergormez-IdeaPad:$ less /var/log/syslog | grep python3
Aug 25 15:45:04 ondergormez-IdeaPad python3: P11Objects.cpp(274): Mandatory attribute (0x00000011) was not specified in template
Aug 25 15:46:47 ondergormez-IdeaPad python3: message repeated 19 times: [ P11Objects.cpp(274): Mandatory attribute (0x00000011) was not specified in template]
ondergormez@ondergormez-IdeaPad:$

Test Code;  


[CreateTokenObject10times.py.txt](https://github.com/opendnssec/SoftHSMv2/files/7047262/CreateTokenObject10times.py.txt)
