### PR TITLE
fix for issue #628 - CKA_VALUE_LEN is synthetized on every secret key

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -7135,12 +7135,17 @@ CK_RV SoftHSM::C_UnwrapKey
 			// Secret Attributes
 			if (objClass == CKO_SECRET_KEY)
 			{
-				ByteString value;
-				if (isPrivate)
-					token->encrypt(keydata, value);
-				else
-					value = keydata;
-				bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+				// CKA_VALUE_LEN synthetized for all secret keys
+				bOK = bOK && osobject->setAttribute(CKA_VALUE_LEN, keydata.size());
+
+				if(bOK) {
+					ByteString value;
+					if (isPrivate)
+						token->encrypt(keydata, value);
+					else
+						value = keydata;
+					bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+				}
 			}
 			else if (keyType == CKK_RSA)
 			{

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -1227,9 +1227,19 @@ void SymmetricAlgorithmTests::aesWrapUnwrapGeneric(CK_MECHANISM_TYPE mechanismTy
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	CPPUNIT_ASSERT(hNew != CK_INVALID_HANDLE);
 
+	CK_ULONG returned_value_len = 0;
+	CK_ATTRIBUTE checkattribs[] = {
+		{ CKA_VALUE_LEN, &returned_value_len, sizeof returned_value_len },
+	};
+
+	rv = CRYPTOKI_F_PTR( C_GetAttributeValue(hSession, hNew, checkattribs, sizeof(checkattribs)/sizeof(CK_ATTRIBUTE)) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+	CPPUNIT_ASSERT(returned_value_len == keyLen);
+
 	free(wrappedPtr);
 	wrappedPtr = NULL_PTR;
 	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hSecret) );
+	rv = CRYPTOKI_F_PTR( C_DestroyObject(hSession, hNew) );
 	CPPUNIT_ASSERT(rv == CKR_OK);
 }
 


### PR DESCRIPTION
This little patch (including test code) will synthetize a `CKA_VALUE_LEN` attribute for all secret keys, whenever `C_UnwrapKey()` is invoked. This should address issue #628.
