### PR TITLE
Support encryption for END_DATE and START_DATE attributes in private keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Linux with Botan
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare
         run: |
           sudo apt-get update -qq
@@ -31,7 +31,7 @@ jobs:
     name: Linux with OpenSSL 1.1.1
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare
         run: |
           sudo apt-get update -qq
@@ -58,7 +58,7 @@ jobs:
     name: Linux with OpenSSL 3.0
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare
         run: |
           sudo apt-get update -qq
@@ -79,7 +79,7 @@ jobs:
     name: Linux with OpenSSL 3.5.6
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare
         env:
           OPENSSL_VERSION: 3.5.6
@@ -127,7 +127,7 @@ jobs:
           - backend: botan
             extra-options: --with-botan=$(brew --prefix botan@2)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare
         run: |
           brew install automake libtool cppunit botan@2
@@ -190,8 +190,8 @@ jobs:
             build-options: "-DENABLE_MLDSA=ON"
             mldsa-test: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: actions/checkout@v6
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
         with:
           arch: ${{ matrix.arch }}
       - name: Create vcpkg.json

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -1173,7 +1173,7 @@ bool P11AttrStartDate::setDefault()
 }
 
 // Update the value if allowed
-CK_RV P11AttrStartDate::updateAttr(Token* /*token*/, bool /*isPrivate*/, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int /*op*/)
+CK_RV P11AttrStartDate::updateAttr(Token *token, bool isPrivate, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int op)
 {
 	// Attribute specific checks
 
@@ -1182,8 +1182,35 @@ CK_RV P11AttrStartDate::updateAttr(Token* /*token*/, bool /*isPrivate*/, CK_VOID
 		return CKR_ATTRIBUTE_VALUE_INVALID;
 	}
 
+	ByteString plaintext((unsigned char*)pValue, ulValueLen);
+	ByteString value;
+
+	// Encrypt if private
+
+	if (isPrivate)
+	{
+		if (!token->encrypt(plaintext, value))
+			return CKR_GENERAL_ERROR;
+	}
+	else
+		value = plaintext;
+
+	// Attribute specific checks
+
+	if (value.size() < ulValueLen)
+		return CKR_GENERAL_ERROR;
+
 	// Store data
-	osobject->setAttribute(type, ByteString((unsigned char*)pValue, ulValueLen));
+
+	osobject->setAttribute(type, value);
+
+	// Set the CKA_START_DATE during C_CreateObject
+
+	if (op == OBJECT_OP_CREATE && osobject->attributeExists(CKA_START_DATE))
+    {
+        OSAttribute osAttribute(value);
+        osobject->setAttribute(CKA_START_DATE, osAttribute);
+    }
 
 	return CKR_OK;
 }
@@ -1200,7 +1227,7 @@ bool P11AttrEndDate::setDefault()
 }
 
 // Update the value if allowed
-CK_RV P11AttrEndDate::updateAttr(Token* /*token*/, bool /*isPrivate*/, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int /*op*/)
+CK_RV P11AttrEndDate::updateAttr(Token *token, bool isPrivate, CK_VOID_PTR pValue, CK_ULONG ulValueLen, int op)
 {
 	// Attribute specific checks
 
@@ -1209,8 +1236,35 @@ CK_RV P11AttrEndDate::updateAttr(Token* /*token*/, bool /*isPrivate*/, CK_VOID_P
 		return CKR_ATTRIBUTE_VALUE_INVALID;
 	}
 
+	ByteString plaintext((unsigned char*)pValue, ulValueLen);
+	ByteString value;
+
+	// Encrypt if private
+
+	if (isPrivate)
+	{
+		if (!token->encrypt(plaintext, value))
+			return CKR_GENERAL_ERROR;
+	}
+	else
+		value = plaintext;
+
+	// Attribute specific checks
+
+	if (value.size() < ulValueLen)
+		return CKR_GENERAL_ERROR;
+
 	// Store data
-	osobject->setAttribute(type, ByteString((unsigned char*)pValue, ulValueLen));
+
+	osobject->setAttribute(type, value);
+
+	// Set the CKA_END_DATE during C_CreateObject
+
+	if (op == OBJECT_OP_CREATE && osobject->attributeExists(CKA_END_DATE))
+    {
+        OSAttribute osAttribute(value);
+        osobject->setAttribute(CKA_END_DATE, osAttribute);
+    }
 
 	return CKR_OK;
 }

--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -158,6 +158,7 @@ CK_RV P11Object::loadTemplate(Token *token, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG
 		}
 
 		// case 1,3,4 and 5 of the attribute checks are done while retrieving the attribute itself.
+		DEBUG_MSG("Attribute 0x%lx = (%p) @ %lu", pTemplate[i].type, pTemplate[i].pValue, i);
 		CK_RV retrieve_rv = attr->retrieve(token, isPrivate, pTemplate[i].pValue, &pTemplate[i].ulValueLen);
 		if (retrieve_rv == CKR_ATTRIBUTE_SENSITIVE) {
 			// If case 1 applies to any of the requested attributes, then the call should
@@ -168,6 +169,7 @@ CK_RV P11Object::loadTemplate(Token *token, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG
 			// return the value CKR_BUFFER_TOO_SMALL.
 			buffer_too_small = true;
 		} else if (retrieve_rv != CKR_OK) {
+			ERROR_MSG("Could not update Attribute in loadTemplate 0x%lx = (%p) @ %lu", pTemplate[i].type, pTemplate[i].pValue, i);
 		    return CKR_GENERAL_ERROR;
 		}
 
@@ -230,10 +232,12 @@ CK_RV P11Object::saveTemplate(Token *token, bool isPrivate, CK_ATTRIBUTE_PTR pTe
 			return CKR_ATTRIBUTE_TYPE_INVALID;
 		}
 
-		// Additonal checks are done while updating the attributes themselves.
+		// Additional checks are done while updating the attributes themselves.
+		DEBUG_MSG("Attribute 0x%lx = (%x)", pTemplate[i].type, pTemplate[i].pValue);
 		CK_RV rv = attr->update(token,isPrivate, pTemplate[i].pValue, pTemplate[i].ulValueLen, op);
 		if (rv != CKR_OK)
 		{
+			ERROR_MSG("Could not update Attribute in saveTemplate 0x%lx = (%p) @ %lu", pTemplate[i].type, pTemplate[i].pValue, i);
 			osobject->abortTransaction();
 			return rv;
 		}

--- a/src/lib/data_mgr/SecureDataManager.cpp
+++ b/src/lib/data_mgr/SecureDataManager.cpp
@@ -397,6 +397,7 @@ void SecureDataManager::logout()
 // Decrypt the supplied data
 bool SecureDataManager::decrypt(const ByteString& encrypted, ByteString& plaintext)
 {
+	DEBUG_MSG("encrypted %s", encrypted.hex_str().c_str());
 	// Check the object logged in state
 	if ((!userLoggedIn && !soLoggedIn) || (maskedKey.size() != 32))
 	{
@@ -424,6 +425,7 @@ bool SecureDataManager::decrypt(const ByteString& encrypted, ByteString& plainte
 	}
 
 	// Take the IV from the input data
+	DEBUG_MSG("AES block size %d", aes->getBlockSize());
 	ByteString IV = encrypted.substr(0, aes->getBlockSize());
 
 	if (IV.size() != aes->getBlockSize())
@@ -433,16 +435,21 @@ bool SecureDataManager::decrypt(const ByteString& encrypted, ByteString& plainte
 		return false;
 	}
 
+	DEBUG_MSG("IV %s", IV.hex_str().c_str());
+
 	ByteString finalBlock;
 
 	if (!aes->decryptInit(&theKey, SymMode::CBC, IV) ||
 	    !aes->decryptUpdate(encrypted.substr(aes->getBlockSize()), plaintext) ||
 	    !aes->decryptFinal(finalBlock))
 	{
+		ERROR_MSG("Error when decrypting data");
 		return false;
 	}
 
 	plaintext += finalBlock;
+
+	DEBUG_MSG("plaintext %s", plaintext.hex_str().c_str());
 
 	return true;
 }

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -1757,6 +1757,69 @@ void ObjectTests::testDefaultRSAPubAttributes()
 	checkCommonRSAPublicKeyAttributes(hSession, hObject, pN, sizeof(pN), 512, pE, sizeof(pE));
 }
 
+void ObjectTests::testDefaultRSAPubAttributesWithDates()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession;
+	CK_OBJECT_HANDLE hObject = CK_INVALID_HANDLE;
+
+	// Minimal RSA public key object
+	CK_OBJECT_CLASS objClass = CKO_PUBLIC_KEY;
+	CK_KEY_TYPE objType = CKK_RSA;
+	CK_BYTE pN[] = { 0xC6, 0x47, 0xDD, 0x74, 0x3B, 0xCB, 0xDC, 0x6F, 0xCE, 0xA7,
+			 0xF0, 0x5F, 0x29, 0x4B, 0x27, 0x00, 0xCC, 0x92, 0xE9, 0x20,
+			 0x8A, 0x2C, 0x87, 0x36, 0x47, 0x24, 0xB0, 0xD5, 0x7D, 0xB0,
+			 0x92, 0x01, 0xA0, 0xA3, 0x55, 0x2E, 0x3F, 0xFE, 0xA7, 0x4C,
+			 0x4B, 0x3F, 0x9D, 0x4E, 0xCB, 0x78, 0x12, 0xA9, 0x42, 0xAD,
+			 0x51, 0x1F, 0x3B, 0xBD, 0x3D, 0x6A, 0xE5, 0x38, 0xB7, 0x45,
+			 0x65, 0x50, 0x30, 0x35 };
+        CK_BYTE pE[] = { 0x01, 0x00, 0x01 };
+	CK_DATE startDate = {
+		{'2', '0', '2', '2'},
+		{'0', '1'},
+		{'0', '1'}
+	};
+	CK_DATE endDate = {
+		{'3', '9', '9', '9'},
+		{'1', '2'},
+		{'3', '1'}
+	};
+	CK_ATTRIBUTE objTemplate[] = {
+		{ CKA_CLASS, &objClass, sizeof(objClass) },
+		{ CKA_KEY_TYPE, &objType, sizeof(objType) },
+		{ CKA_MODULUS, pN, sizeof(pN) },
+		{ CKA_PUBLIC_EXPONENT, pE, sizeof(pE) },
+		{ CKA_START_DATE, &startDate, sizeof(startDate) },
+		{ CKA_END_DATE, &endDate, sizeof(endDate) }
+	};
+
+	// Just make sure that we finalize any previous tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	// Initialize the library and start the test.
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Open read-write session
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Login USER into the sessions so we can create a private objects
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Create minimal RSA public key object
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Check attributes in RSA public key object
+	checkCommonObjectAttributes(hSession, hObject, objClass);
+	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_FALSE, CK_TRUE, NULL_PTR, 0, CK_TRUE, CK_TRUE);
+	checkCommonKeyAttributes(hSession, hObject, objType, NULL_PTR, 0, startDate, sizeof(startDate), endDate, sizeof(endDate), CK_FALSE, CK_FALSE, CK_UNAVAILABLE_INFORMATION, NULL_PTR, 0);
+	checkCommonPublicKeyAttributes(hSession, hObject, NULL_PTR, 0, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_FALSE, NULL_PTR, 0);
+	checkCommonRSAPublicKeyAttributes(hSession, hObject, pN, sizeof(pN), 512, pE, sizeof(pE));
+}
+
 void ObjectTests::testDefaultRSAPrivAttributes()
 {
 	CK_RV rv;
@@ -1820,6 +1883,80 @@ void ObjectTests::testDefaultRSAPrivAttributes()
 	checkCommonPrivateKeyAttributes(hSession, hObject, NULL_PTR, 0, CK_FALSE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_FALSE, CK_FALSE, CK_FALSE, NULL_PTR, 0, CK_FALSE);
 	checkCommonRSAPrivateKeyAttributes(hSession, hObject, pN, sizeof(pN), NULL_PTR, 0, pD, sizeof(pD), NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0);
 	checkToTrueAttributes(hSession, hObject);
+}
+
+void ObjectTests::testDefaultRSAPrivAttributesWithDates()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession;
+	CK_OBJECT_HANDLE hObject = CK_INVALID_HANDLE;
+
+	// Minimal RSA private key object
+	CK_OBJECT_CLASS objClass = CKO_PRIVATE_KEY;
+	CK_KEY_TYPE objType = CKK_RSA;
+	CK_BBOOL bTrue = CK_TRUE;
+	CK_BBOOL bFalse = CK_FALSE;
+	CK_BYTE pN[] = { 0xC6, 0x47, 0xDD, 0x74, 0x3B, 0xCB, 0xDC, 0x6F, 0xCE, 0xA7,
+			 0xF0, 0x5F, 0x29, 0x4B, 0x27, 0x00, 0xCC, 0x92, 0xE9, 0x20,
+			 0x8A, 0x2C, 0x87, 0x36, 0x47, 0x24, 0xB0, 0xD5, 0x7D, 0xB0,
+			 0x92, 0x01, 0xA0, 0xA3, 0x55, 0x2E, 0x3F, 0xFE, 0xA7, 0x4C,
+			 0x4B, 0x3F, 0x9D, 0x4E, 0xCB, 0x78, 0x12, 0xA9, 0x42, 0xAD,
+			 0x51, 0x1F, 0x3B, 0xBD, 0x3D, 0x6A, 0xE5, 0x38, 0xB7, 0x45,
+			 0x65, 0x50, 0x30, 0x35 };
+        CK_BYTE pD[] = { 0x6D, 0x94, 0x6B, 0xEB, 0xFF, 0xDC, 0x03, 0x80, 0x7B, 0x0A,
+			 0x4F, 0x0A, 0x98, 0x6C, 0xA3, 0x2A, 0x8A, 0xE4, 0xAA, 0x18,
+			 0x44, 0xA4, 0xA5, 0x39, 0x37, 0x0A, 0x2C, 0xFC, 0x5F, 0xD1,
+			 0x44, 0x6E, 0xCE, 0x25, 0x9B, 0xE5, 0xD1, 0x51, 0xAF, 0xA8,
+			 0x30, 0xD1, 0x4D, 0x3C, 0x60, 0x33, 0xB5, 0xED, 0x4C, 0x39,
+			 0xDA, 0x68, 0x78, 0xF9, 0x6B, 0x4F, 0x47, 0x55, 0xB2, 0x02,
+			 0x00, 0x7E, 0x9C, 0x05 };
+	CK_DATE startDate = {
+		{'2', '0', '2', '2'},
+		{'0', '1'},
+		{'0', '1'}
+	};
+	CK_DATE endDate = {
+		{'3', '9', '9', '9'},
+		{'1', '2'},
+		{'3', '1'}
+	};
+	// Make the key non-sensitive and extractable so that we can test it.
+	CK_ATTRIBUTE objTemplate[] = {
+		{ CKA_CLASS, &objClass, sizeof(objClass) },
+		{ CKA_KEY_TYPE, &objType, sizeof(objType) },
+		{ CKA_SENSITIVE, &bFalse, sizeof(bFalse) },
+		{ CKA_EXTRACTABLE, &bTrue, sizeof(bTrue) },
+		{ CKA_MODULUS, pN, sizeof(pN) },
+		{ CKA_PRIVATE_EXPONENT, pD, sizeof(pD) },
+		{ CKA_START_DATE, &startDate, sizeof(startDate) },
+		{ CKA_END_DATE, &endDate, sizeof(endDate) }
+	};
+
+	// Just make sure that we finalize any previous tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	// Initialize the library and start the test.
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Open read-write session
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Login USER into the sessions so we can create a private objects
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Create minimal RSA public key object
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, objTemplate, sizeof(objTemplate)/sizeof(CK_ATTRIBUTE), &hObject) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Check attributes in RSA public key object
+	checkCommonObjectAttributes(hSession, hObject, objClass);
+	checkCommonStorageObjectAttributes(hSession, hObject, CK_FALSE, CK_TRUE, CK_TRUE, NULL_PTR, 0, CK_TRUE, CK_TRUE);
+	checkCommonKeyAttributes(hSession, hObject, objType, NULL_PTR, 0, startDate, sizeof(startDate), endDate, sizeof(endDate), CK_FALSE, CK_FALSE, CK_UNAVAILABLE_INFORMATION, NULL_PTR, 0);
+	checkCommonPrivateKeyAttributes(hSession, hObject, NULL_PTR, 0, CK_FALSE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_TRUE, CK_FALSE, CK_FALSE, CK_FALSE, NULL_PTR, 0, CK_FALSE);
+	checkCommonRSAPrivateKeyAttributes(hSession, hObject, pN, sizeof(pN), NULL_PTR, 0, pD, sizeof(pD), NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0, NULL_PTR, 0);
 }
 
 void ObjectTests::testAlwaysNeverAttribute()

--- a/src/lib/test/ObjectTests.h
+++ b/src/lib/test/ObjectTests.h
@@ -61,6 +61,8 @@ class ObjectTests : public TestsBase
 	CPPUNIT_TEST(testReAuthentication);
 	CPPUNIT_TEST(testTemplateAttribute);
 	CPPUNIT_TEST(testCreateSecretKey);
+	CPPUNIT_TEST(testDefaultRSAPubAttributesWithDates);
+	CPPUNIT_TEST(testDefaultRSAPrivAttributesWithDates);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -84,6 +86,8 @@ public:
 	void testAllowedMechanisms();
 	void testTemplateAttribute();
 	void testCreateSecretKey();
+	void testDefaultRSAPubAttributesWithDates();
+	void testDefaultRSAPrivAttributesWithDates();
 
 protected:
 	void checkCommonObjectAttributes

--- a/win32/softhsm2.sln.in
+++ b/win32/softhsm2.sln.in
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual C++ Express 2010
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "softhsm2", "softhsm2\softhsm2.vcxproj", "{801F5AB2-7A62-4085-B129-D15E2D717219}"


### PR DESCRIPTION
Addresses the issue in #655 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Start/end date attributes are now stored reliably, respect privacy (encrypted when marked private), and are handled correctly during object creation.

* **Tests**
  * Added RSA public/private key tests validating start/end date attribute behavior on object creation.

* **Chores**
  * Improved debug/error logging for template processing and data decryption; updated CI checkout/tooling versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->