### PR TITLE
Fix memory leak in SoftHSM::UnwrapKeySym.

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -6812,9 +6812,10 @@ CK_RV SoftHSM::UnwrapKeySym
 		CK_RV rv = CKR_OK;
 		if (!cipher->unwrapKey(unwrappingkey, mode, wrapped, keydata))
 			rv = CKR_GENERAL_ERROR;
-		cipher->recycleKey(unwrappingkey);
-		CryptoFactory::i()->recycleSymmetricAlgorithm(cipher);
 	}
+
+	cipher->recycleKey(unwrappingkey);
+	CryptoFactory::i()->recycleSymmetricAlgorithm(cipher);
 	return rv;
 }
 


### PR DESCRIPTION
When using C_UnwrapKey with CKM_xxx_CBC_PAD, the unwrapping key and
cipher objects were not being recycled on success.