### PR TITLE
avoid unnecessary check for sqlite3 binary

### DIFF
--- a/m4/acx_sqlite3.m4
+++ b/m4/acx_sqlite3.m4
@@ -4,18 +4,12 @@ AC_DEFUN([ACX_SQLITE3],[
 		[
 			SQLITE3_INCLUDES="-I$withval/include"
 			SQLITE3_LIBDIRS="-L$withval/lib"
-			AC_PATH_PROGS(SQLITE3, sqlite3, sqlite3, $withval/bin)
 			
 		],[
 			SQLITE3_INCLUDES=""
 			SQLITE3_LIBDIRS=""
-			AC_PATH_PROGS(SQLITE3, sqlite3, sqlite3, $PATH)
 		])
 
-	
-	if ! test -x "$SQLITE3"; then
-		AC_MSG_ERROR([sqlite3 command not found])
-	fi
 	
 	AC_MSG_CHECKING(what are the SQLite3 includes)
 	AC_MSG_RESULT($SQLITE3_INCLUDES)


### PR DESCRIPTION
Only the library is used, not the sqlite3 binary. Drop this check to simplify cross-compilation (as no native sqlite3 binary is needed).