### PR TITLE
Mitigate bruteforce attempts

### DIFF
--- a/src/lib/common/Configuration.cpp
+++ b/src/lib/common/Configuration.cpp
@@ -51,6 +51,7 @@ const struct config Configuration::valid_config[] = {
 	{ "slots.removable",		CONFIG_TYPE_BOOL },
 	{ "slots.mechanisms",		CONFIG_TYPE_STRING },
 	{ "library.reset_on_fork",	CONFIG_TYPE_BOOL },
+	{ "login.fail_delay",		CONFIG_TYPE_INT },
 	{ "",				CONFIG_TYPE_UNSUPPORTED }
 };
 

--- a/src/lib/data_mgr/SecureDataManager.cpp
+++ b/src/lib/data_mgr/SecureDataManager.cpp
@@ -40,11 +40,18 @@
  *****************************************************************************/
 
 #include "config.h"
+#include "Configuration.h"
 #include "SecureDataManager.h"
 #include "CryptoFactory.h"
 #include "AESKey.h"
 #include "SymmetricAlgorithm.h"
 #include "RFC4880.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
 
 // Constructors
 
@@ -263,6 +270,7 @@ bool SecureDataManager::login(const ByteString& passphrase, const ByteString& en
 
 	if (!RFC4880::PBEDeriveKey(passphrase, salt, &pbeKey))
 	{
+		sleep(Configuration::i()->getInt("login.fail_delay", 0));
 		return false;
 	}
 
@@ -275,6 +283,7 @@ bool SecureDataManager::login(const ByteString& passphrase, const ByteString& en
 	    !aes->decryptUpdate(encryptedKeyData, decryptedKeyData) ||
 	    !aes->decryptFinal(finalBlock))
 	{
+		sleep(Configuration::i()->getInt("login.fail_delay", 0));
 		delete pbeKey;
 
 		return false;
@@ -288,6 +297,7 @@ bool SecureDataManager::login(const ByteString& passphrase, const ByteString& en
 	if (decryptedKeyData.substr(0, 3) != magic)
 	{
 		// The passphrase was incorrect
+		sleep(Configuration::i()->getInt("login.fail_delay", 0));
 		DEBUG_MSG("Incorrect passphrase supplied");
 
 		return false;


### PR DESCRIPTION
Hi,
I have seen past issues about this topic, which have all been disregarded because "if an attacker has access to the SoftHSM library, he could also access the filesystem and loot the token file, to try and bruteforce locally".

**However**, as a QubesOS user, I use extensively SoftHSM in combination with socat, so that my SoftHSM server is on a virtual machine with all my certificates (a vault VM), and my clients (for instance a Firefox process) are all in other VMs, with no direct access to the vault's file system. In such cases, I feel it makes the most sense to implement a kind of rate limiting in SoftHSM as it would drastically reduce the bruteforce pace of an attacker in a client VM. The way I implemented it is very trivial, feel free to make it cleaner or to tell me what to do in order to make it so.
By default, when no configuration option is added to the config file, it does not change the behavior of SoftHSM (no delay on failed attempts). However, if you add the `login.fail_delay` (here again, the name might not be in line with the configuration options naming scheme, feel free to tell me about it) in your config file, the value of the option you provided (in seconds) will be waited on a failed attempt.

Feel free to reach out if you have any question, or to make any modification to the code of this PR.

Best regards,
Antoine