### PR TITLE
Limit number of sessions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,11 @@ AC_DEFINE_UNQUOTED(
 	[Minimum PIN length]
 )
 AC_DEFINE_UNQUOTED(
+	[MAX_SESSION_COUNT],
+	[16],
+	[Maximum session count]
+)
+AC_DEFINE_UNQUOTED(
 	[DEFAULT_SOFTHSM2_CONF],
 	["$default_softhsm2_conf"],
 	[The default location of softhsm2.conf]

--- a/src/lib/session_mgr/SessionManager.cpp
+++ b/src/lib/session_mgr/SessionManager.cpp
@@ -36,6 +36,7 @@
 
 #include "SessionManager.h"
 #include "log.h"
+#include "config.h"
 
 // Constructor
 SessionManager::SessionManager()
@@ -82,8 +83,7 @@ CK_RV SessionManager::openSession
 	// Can not open a Read-Only session when in SO mode
 	if ((flags & CKF_RW_SESSION) == 0 && token->isSOLoggedIn()) return CKR_SESSION_READ_WRITE_SO_EXISTS;
 
-	// TODO: Do we want to check for maximum number of sessions?
-	// return CKR_SESSION_COUNT
+	if (sessions.size() == MAX_SESSION_COUNT) return CKR_SESSION_COUNT;
 
 	// Create the session
 	bool rwSession = ((flags & CKF_RW_SESSION) == CKF_RW_SESSION) ? true : false;

--- a/src/lib/slot_mgr/Token.cpp
+++ b/src/lib/slot_mgr/Token.cpp
@@ -519,7 +519,7 @@ CK_RV Token::getTokenInfo(CK_TOKEN_INFO_PTR info)
 	info->ulRwSessionCount = CK_UNAVAILABLE_INFORMATION;
 
 	info->ulMaxRwSessionCount = CK_EFFECTIVELY_INFINITE;
-	info->ulMaxSessionCount = CK_EFFECTIVELY_INFINITE;
+	info->ulMaxSessionCount = MAX_SESSION_COUNT;
 	info->ulMaxPinLen = MAX_PIN_LEN;
 	info->ulMinPinLen = MIN_PIN_LEN;
 	info->ulTotalPublicMemory = CK_UNAVAILABLE_INFORMATION;


### PR DESCRIPTION
When SoftHSMv2 is used for testing PKCS#11 client code before hardware is available, maximum session count on a token needs to be set in order to detects bugs in client code where sessions are leaked and remain open. This can cause problems since most hardware implementations have a limit on opened sessions count.

This change sets a limit to general session count.