### PR TITLE
Return function unsupported error from C_GetObjectSize

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1829,7 +1829,7 @@ CK_RV SoftHSM::C_GetObjectSize(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObj
 
 	*pulSize = CK_UNAVAILABLE_INFORMATION;
 
-	return CKR_OK;
+	return CKR_FUNCTION_NOT_SUPPORTED;
 }
 
 // Retrieve the specified attributes for the given object

--- a/src/lib/test/ObjectTests.cpp
+++ b/src/lib/test/ObjectTests.cpp
@@ -1229,7 +1229,7 @@ void ObjectTests::testGetObjectSize()
 	// Get the object size
 	CK_ULONG objectSize;
 	rv = CRYPTOKI_F_PTR( C_GetObjectSize(hSession, hObject, &objectSize) );
-	CPPUNIT_ASSERT(rv == CKR_OK);
+	CPPUNIT_ASSERT(rv == CKR_FUNCTION_NOT_SUPPORTED);
 	CPPUNIT_ASSERT(objectSize == CK_UNAVAILABLE_INFORMATION);
 
 	// Close session


### PR DESCRIPTION
Currently C_GetObjectSize is unsupported and always returns pulSize =
CK_UNAVAILABLE_INFORMATION and CKR_OK return code. But since the
implementation is obviously not complit we should rather return
CKR_FUNCTION_NOT_SUPPORTED instead of CKR_OK
