### PR TITLE
Fix 'Assertion failed' in softhsm2-dump-file when encountering a zero-length element

### DIFF
--- a/src/bin/dump/softhsm2-dump-file.cpp
+++ b/src/bin/dump/softhsm2-dump-file.cpp
@@ -437,13 +437,15 @@ void dump(FILE* stream)
 			}
 			printf("(length %lu)\n", (unsigned long) len);
 
-			std::vector<uint8_t> value((size_t) len);
-			if (!readBytes(stream, value))
-			{
-				corrupt(stream);
-				return;
+			if (len > 0) {
+				std::vector<uint8_t> value((size_t) len);
+				if (!readBytes(stream, value))
+				{
+					corrupt(stream);
+					return;
+				}
+				dumpBytes(value);
 			}
-			dumpBytes(value);
 		}
 		else if (disktype == ATTRMAP_ATTR)
 		{
@@ -461,13 +463,15 @@ void dump(FILE* stream)
 			}
 			printf("(length %lu)\n", (unsigned long) len);
 
-			std::vector<Attribute> value;
-			if (!readMap(stream, len, value))
-			{
-				corrupt(stream);
-				return;
-			}
-			dumpMap(value);
+			if (len > 0) {
+				std::vector<Attribute> value;
+				if (!readMap(stream, len, value))
+				{
+					corrupt(stream);
+					return;
+				}
+				dumpMap(value);
+			}	
 		}
 		else if (disktype == MECHSET_ATTR)
 		{


### PR DESCRIPTION
softhsm2-dump-file dies when it encounters a zero-length element
like CKA_SUBJECT in imported keypairs, but tries to treat the
element as std::vector.

Example output:

...
00 00 00 00 00 00 01 01 CKA_SUBJECT
00 00 00 00 00 00 00 03 byte string attribute
00 00 00 00 00 00 00 00 (length 0)
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector<_Tp, _Alloc>::reference = unsigned char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.

Program received signal SIGABRT, Aborted.