### PR TITLE
Fix header include error for ck_rsa_pkcs_oaep_params

### DIFF
--- a/src/lib/pkcs11/pkcs11.h
+++ b/src/lib/pkcs11/pkcs11.h
@@ -981,7 +981,7 @@ struct ck_rsa_pkcs_oaep_params {
 
 struct ck_rsa_aes_key_wrap_params {
   unsigned long aes_key_bits;
-  ck_rsa_pkcs_oaep_params *oaep_params;
+  struct ck_rsa_pkcs_oaep_params *oaep_params;
 };
 
 struct ck_aes_ctr_params {


### PR DESCRIPTION
Add missing 'struct' keyword for ck_rsa_pkcs_oaep_params to resolve unknown type name error. 

Resolves #810 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized a public API type for RSA-AES key wrap parameters by switching the OAEP parameters field to an explicit struct type for clarity and consistency. This may require minor source updates for applications interfacing with the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->