### PR TITLE
Support RSA PSS for import in softhsm2-util

### DIFF
--- a/src/bin/util/softhsm2-util-ossl.cpp
+++ b/src/bin/util/softhsm2-util-ossl.cpp
@@ -156,6 +156,7 @@ int crypto_import_key_pair
 	switch (EVP_PKEY_type(EVP_PKEY_id(pkey)))
 	{
 		case EVP_PKEY_RSA:
+		case EVP_PKEY_RSA_PSS:
 			rsa = EVP_PKEY_get1_RSA(pkey);
 			break;
 		case EVP_PKEY_DSA:


### PR DESCRIPTION
This should fix #721 . The type is differnt from RSA PSS so it needs to be added there.

I tested the change manual and the import went through after this. I don't see any tests for util so it comes wihtout a test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing RSA-PSS key pairs; RSA-PSS keys are now recognized and processed the same as standard RSA during import.
  - Existing import behavior for RSA, DSA, EC, and EdDSA remains unchanged.
  - No changes to public interfaces, CLI options, or configuration are required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->