### PR TITLE
implement OAESP params for asymmetric encryption

### DIFF
--- a/src/lib/crypto/AsymmetricAlgorithm.h
+++ b/src/lib/crypto/AsymmetricAlgorithm.h
@@ -41,6 +41,8 @@
 #include "PrivateKey.h"
 #include "RNG.h"
 #include "SymmetricKey.h"
+#include "pkcs11.h"  // For CK_MECHANISM_TYPE and other types
+
 
 struct AsymAlgo
 {
@@ -138,10 +140,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding) = 0;
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr) = 0;
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding) = 0;
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr) = 0;
 
 	// Wrap/Unwrap keys
 	bool wrapKey(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);

--- a/src/lib/crypto/OSSLDH.cpp
+++ b/src/lib/crypto/OSSLDH.cpp
@@ -91,7 +91,7 @@ bool OSSLDH::verifyFinal(const ByteString& /*signature*/)
 
 // Encryption functions
 bool OSSLDH::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
-		     ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/)
+		     ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("DH does not support encryption");
 
@@ -100,7 +100,7 @@ bool OSSLDH::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
 
 // Decryption functions
 bool OSSLDH::decrypt(PrivateKey* /*privateKey*/, const ByteString& /*encryptedData*/,
-		     ByteString& /*data*/, const AsymMech::Type /*padding*/)
+		     ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("DH does not support decryption");
 

--- a/src/lib/crypto/OSSLDH.h
+++ b/src/lib/crypto/OSSLDH.h
@@ -54,10 +54,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding);
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Key factory
 	virtual bool generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParameters* parameters, RNG* rng = NULL);

--- a/src/lib/crypto/OSSLDSA.cpp
+++ b/src/lib/crypto/OSSLDSA.cpp
@@ -437,7 +437,7 @@ bool OSSLDSA::verifyFinal(const ByteString& signature)
 
 // Encryption functions
 bool OSSLDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
-		      ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/)
+		      ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("DSA does not support encryption");
 
@@ -446,7 +446,7 @@ bool OSSLDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
 
 // Decryption functions
 bool OSSLDSA::decrypt(PrivateKey* /*privateKey*/, const ByteString& /*encryptedData*/,
-		      ByteString& /*data*/, const AsymMech::Type /*padding*/)
+		      ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("DSA does not support decryption");
 

--- a/src/lib/crypto/OSSLDSA.h
+++ b/src/lib/crypto/OSSLDSA.h
@@ -60,10 +60,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding);
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Key factory
 	virtual bool generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParameters* parameters, RNG* rng = NULL);

--- a/src/lib/crypto/OSSLECDH.cpp
+++ b/src/lib/crypto/OSSLECDH.cpp
@@ -94,7 +94,7 @@ bool OSSLECDH::verifyFinal(const ByteString& /*signature*/)
 
 // Encryption functions
 bool OSSLECDH::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
-		       ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/)
+		       ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("ECDH does not support encryption");
 
@@ -103,7 +103,7 @@ bool OSSLECDH::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
 
 // Decryption functions
 bool OSSLECDH::decrypt(PrivateKey* /*privateKey*/, const ByteString& /*encryptedData*/,
-		       ByteString& /*data*/, const AsymMech::Type /*padding*/)
+		       ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("ECDH does not support decryption");
 

--- a/src/lib/crypto/OSSLECDH.h
+++ b/src/lib/crypto/OSSLECDH.h
@@ -54,10 +54,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding);
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Key factory
 	virtual bool generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParameters* parameters, RNG* rng = NULL);

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -331,7 +331,7 @@ bool OSSLECDSA::verifyFinal(const ByteString& /*signature*/)
 
 // Encryption functions
 bool OSSLECDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
-			ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/)
+			ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("ECDSA does not support encryption");
 
@@ -340,7 +340,7 @@ bool OSSLECDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
 
 // Decryption functions
 bool OSSLECDSA::decrypt(PrivateKey* /*privateKey*/, const ByteString& /*encryptedData*/,
-			ByteString& /*data*/, const AsymMech::Type /*padding*/)
+			ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("ECDSA does not support decryption");
 

--- a/src/lib/crypto/OSSLECDSA.h
+++ b/src/lib/crypto/OSSLECDSA.h
@@ -56,10 +56,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding);
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Key factory
 	virtual bool generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParameters* parameters, RNG* rng = NULL);

--- a/src/lib/crypto/OSSLEDDSA.cpp
+++ b/src/lib/crypto/OSSLEDDSA.cpp
@@ -208,7 +208,7 @@ bool OSSLEDDSA::verifyFinal(const ByteString& /*signature*/)
 
 // Encryption functions
 bool OSSLEDDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
-			ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
+			ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* /*oaepParams*/)
 {
 	ERROR_MSG("EDDSA does not support encryption");
 
@@ -217,7 +217,7 @@ bool OSSLEDDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
 
 // Decryption functions
 bool OSSLEDDSA::decrypt(PrivateKey* /*privateKey*/, const ByteString& /*encryptedData*/,
-			ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
+			ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* /*oaepParams*/)
 {
 	ERROR_MSG("EDDSA does not support decryption");
 

--- a/src/lib/crypto/OSSLEDDSA.cpp
+++ b/src/lib/crypto/OSSLEDDSA.cpp
@@ -208,7 +208,7 @@ bool OSSLEDDSA::verifyFinal(const ByteString& /*signature*/)
 
 // Encryption functions
 bool OSSLEDDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
-			ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/)
+			ByteString& /*encryptedData*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("EDDSA does not support encryption");
 
@@ -217,7 +217,7 @@ bool OSSLEDDSA::encrypt(PublicKey* /*publicKey*/, const ByteString& /*data*/,
 
 // Decryption functions
 bool OSSLEDDSA::decrypt(PrivateKey* /*privateKey*/, const ByteString& /*encryptedData*/,
-			ByteString& /*data*/, const AsymMech::Type /*padding*/)
+			ByteString& /*data*/, const AsymMech::Type /*padding*/, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams)
 {
 	ERROR_MSG("EDDSA does not support decryption");
 

--- a/src/lib/crypto/OSSLEDDSA.h
+++ b/src/lib/crypto/OSSLEDDSA.h
@@ -56,10 +56,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding);
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Key factory
 	virtual bool generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParameters* parameters, RNG* rng = NULL);

--- a/src/lib/crypto/OSSLRSA.h
+++ b/src/lib/crypto/OSSLRSA.h
@@ -60,10 +60,10 @@ public:
 	virtual bool verifyFinal(const ByteString& signature);
 
 	// Encryption functions
-	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding);
+	virtual bool encrypt(PublicKey* publicKey, const ByteString& data, ByteString& encryptedData, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Decryption functions
-	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding);
+	virtual bool decrypt(PrivateKey* privateKey, const ByteString& encryptedData, ByteString& data, const AsymMech::Type padding, const CK_RSA_PKCS_OAEP_PARAMS* oaepParams = nullptr);
 
 	// Key factory
 	virtual bool generateKeyPair(AsymmetricKeyPair** ppKeyPair, AsymmetricParameters* parameters, RNG* rng = NULL);


### PR DESCRIPTION
Fixes https://github.com/softhsm/SoftHSMv2/issues/795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable RSA-OAEP support: selectable hash algorithms (SHA-1/224/256/384/512), matching MGF variants, and optional label. OAEP parameters are retained across init/encrypt/decrypt and wrap/unwrap flows.

* **Bug Fixes**
  * Corrected RSA-OAEP input size checks to use the chosen hash length.
  * Relaxed OAEP validation with clearer error messages.
  * Improved failure-path resource handling.

* **Refactor**
  * Unified mechanism/parameter handling and extended encrypt/decrypt APIs to accept optional OAEP parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->