### PR TITLE
Fixed PKCS#11 3.2 C_Decapsulate definition

### DIFF
--- a/src/lib/pkcs11/pkcs11.h
+++ b/src/lib/pkcs11/pkcs11.h
@@ -2848,7 +2848,7 @@ _CK_DECLARE_FUNCTION (C_DecapsulateKey,
                        struct ck_attribute *templ,
                        unsigned long attribute_count,
                        unsigned char *ciphertext,
-                       unsigned long *ciphertext_len,
+                       unsigned long ciphertext_len,
                        ck_object_handle_t *key_ptr));
 _CK_DECLARE_FUNCTION (C_VerifySignatureInit,
                       (ck_session_handle_t session,
@@ -3053,6 +3053,7 @@ typedef unsigned char CK_BBOOL;
 typedef unsigned long int CK_ULONG;
 typedef long int CK_LONG;
 typedef CK_BYTE *CK_BYTE_PTR;
+typedef CK_FLAGS *CK_FLAGS_PTR;
 typedef CK_CHAR *CK_CHAR_PTR;
 typedef CK_UTF8CHAR *CK_UTF8CHAR_PTR;
 typedef CK_ULONG *CK_ULONG_PTR;


### PR DESCRIPTION
There is a slight difference between reference PKCS#11 3.2 functions header and the one from p11kit merged in #827
Definition of `CK_FLAGS_PTR` was also missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cryptographic operation API parameters for improved type consistency.
  * Added new type definition aliases for flag parameters.
  * Standardized type declarations in compatibility layer.

*Note: These are API-level changes that may require updates for developers using this library.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->