### PR TITLE
fix: object_store: stop throwing errors when checking generation file

### DIFF
--- a/src/lib/object_store/File.cpp
+++ b/src/lib/object_store/File.cpp
@@ -143,6 +143,20 @@ File::~File()
 	}
 }
 
+// Check if a file exists without trying to open it
+// May be used when a routine just wants to check file existence,
+// and does not want to throw an error by trying to open it.
+bool File::exists(const std::string& path)
+{
+#ifndef _WIN32
+	struct stat buf;
+	return stat(path.c_str(), &buf) == 0;
+#else
+	return _access(path.c_str(), 0) == 0;
+#endif
+}
+
+
 // Check if the file is valid
 bool File::isValid()
 {

--- a/src/lib/object_store/File.h
+++ b/src/lib/object_store/File.h
@@ -47,6 +47,11 @@ public:
 	// Destructor
 	virtual ~File();
 
+	// Check if a file exists without trying to open it
+	// May be used when a routine just wants to check file existence,
+	// and does not want to throw an error by trying to open it.
+	static bool exists(const std::string& path);
+
 	// Check if the file is valid
 	bool isValid();
 

--- a/src/lib/object_store/Generation.cpp
+++ b/src/lib/object_store/Generation.cpp
@@ -88,6 +88,13 @@ bool Generation::sync(File &objectFile)
 // Check if the target was updated
 bool Generation::wasUpdated()
 {
+
+	// Check if path file exists before anything
+	if (!File::exists(path))
+	{
+		return true;
+	}
+
 	if (isToken)
 	{
 		MutexLocker lock(genMutex);

--- a/src/lib/object_store/test/FileTests.cpp
+++ b/src/lib/object_store/test/FileTests.cpp
@@ -74,16 +74,18 @@ void FileTests::testExistNotExist()
 	// Test pre-condition
 	CPPUNIT_ASSERT(!exists("nonExistentFile"));
 
-	// Attempt to open a file known not to exist
+	// Check the 'exists' static routine, then attempt to open a file known not to exist
 #ifndef _WIN32
+	CPPUNIT_ASSERT(!File::exists("testdir/nonExistentFile"));
 	File doesntExist("testdir/nonExistentFile", DEFAULT_UMASK);
 #else
+	CPPUNIT_ASSERT(!File::exists("testdir\\nonExistentFile"));
 	File doesntExist("testdir\\nonExistentFile", DEFAULT_UMASK);
 #endif
 
 	CPPUNIT_ASSERT(!doesntExist.isValid());
 
-	// Attempt to open a file known to exist
+	// Check the 'exists' static routine, then attempt to open a file known to exist
 #ifndef _WIN32
 	CPPUNIT_ASSERT(!system("echo someStuff > testdir/existingFile"));
 #else
@@ -92,8 +94,10 @@ void FileTests::testExistNotExist()
 	CPPUNIT_ASSERT(exists("existingFile"));
 
 #ifndef _WIN32
+	CPPUNIT_ASSERT(File::exists("testdir/existingFile"));
 	File exists("testdir/existingFile", DEFAULT_UMASK);
 #else
+	CPPUNIT_ASSERT(File::exists("testdir\\existingFile"));
 	File exists("testdir\\existingFile", DEFAULT_UMASK);
 #endif
 


### PR DESCRIPTION
A new routine is added to File class, to check whether a file exists or not. It will allow file existence check, without trying to open the file and thus throw an error when the use case is valid.

This new routine is added to Generation wasUpdated routine: if the generation file does not exist, the routine will exit without error, instead of trying to open the file and report an error.

Fixes #753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file-existence check so callers can determine whether a file exists without opening it.

* **Bug Fixes**
  * Update detection now treats missing files as needing updates, improving change-detection correctness.

* **Tests**
  * Expanded tests to validate file-existence checks before performing file operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->