### PR TITLE
Fix incorrect call to isMechanismPermitted

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -2455,7 +2455,7 @@ CK_RV SoftHSM::AsymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMec
 		return CKR_KEY_FUNCTION_NOT_PERMITTED;
 
 	// Check if the specified mechanism is allowed for the key
-	if (!isMechanismPermitted(key, pMechanism))
+	if (!isMechanismPermitted(key, pMechanism->mechanism))
 		return CKR_MECHANISM_INVALID;
 
 	// Get key info


### PR DESCRIPTION
This fixes build failure introduced in https://github.com/softhsm/SoftHSMv2/commit/f3c015666e81fc685304e47f780267ca54a25248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect mechanism validation in asymmetric encryption initialization, ensuring proper parameter handling for cryptographic operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->