### PR TITLE
Modify CKR_ATTRIBUTE_READ_ONLY Error when generating ML-DSA key pair using pkcs11-tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ enable_testing()
 
 # config.h include path
 include_directories(${CMAKE_BINARY_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/src/lib/slot_mgr)
+include_directories(${CMAKE_SOURCE_DIR}/src/lib/object_store)
 
 add_subdirectory(src)
 

--- a/cmake/modules/CompilerOptions.cmake
+++ b/cmake/modules/CompilerOptions.cmake
@@ -219,6 +219,10 @@ if(WITH_CRYPTO_BACKEND STREQUAL "botan")
         message(STATUS "Botan: Support for EDDSA is disabled")
     endif(ENABLE_EDDSA)
 
+    if(ENABLE_MLDSA)
+        set(WITH_ML_DSA 1)
+    endif(ENABLE_MLDSA)
+
     # acx_botan_gost.m4
     if(ENABLE_GOST)
         set(testfile ${CMAKE_SOURCE_DIR}/cmake/modules/tests/test_botan_gost.cpp)
@@ -369,6 +373,10 @@ elseif(WITH_CRYPTO_BACKEND STREQUAL "openssl")
     else(ENABLE_EDDSA)
         message(STATUS "OpenSSL: Support for EDDSA is disabled")
     endif(ENABLE_EDDSA)
+
+    if(ENABLE_MLDSA)
+        set(WITH_ML_DSA 1)
+    endif(ENABLE_MLDSA)
 
     # acx_openssl_gost.m4
     if(ENABLE_GOST)

--- a/src/lib/P11Attributes.cpp
+++ b/src/lib/P11Attributes.cpp
@@ -440,8 +440,11 @@ CK_RV P11Attribute::update(Token* token, bool isPrivate, CK_VOID_PTR pValue, CK_
 	{
 		if (OBJECT_OP_GENERATE==op)
 		{
-			ERROR_MSG("Prohibited attribute was passed to key generation function");
-			return CKR_ATTRIBUTE_READ_ONLY;
+            if (type != CKA_PARAMETER_SET) 
+            {
+                ERROR_MSG("Prohibited attribute was passed to key generation function");
+                return CKR_ATTRIBUTE_READ_ONLY;
+            }
 		}
 	}
 


### PR DESCRIPTION
Modify CKR_ATTRIBUTE_READ_ONLY Error when generating ML-DSA key pair using following pkcs11-tool command

* pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --slot 1944964809 --login --pin 1234 --keypairgen --key-type ML-DSA-44 --id 0  --label "ML-DSA-44"

please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ML-DSA support is now configurable across supported cryptographic backends.

* **Bug Fixes**
  * Refined key generation to properly handle parameter set attributes during object creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->