### PR TITLE
Support multipart operation on hashed ECDSA

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -4440,27 +4440,27 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 			break;
 		case CKM_ECDSA_SHA1:
 			mechanism = AsymMech::ECDSA_SHA1;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA224:
 			mechanism = AsymMech::ECDSA_SHA224;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA256:
 			mechanism = AsymMech::ECDSA_SHA256;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA384:
 			mechanism = AsymMech::ECDSA_SHA384;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA512:
 			mechanism = AsymMech::ECDSA_SHA512;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 #endif
@@ -4479,7 +4479,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 #ifdef WITH_EDDSA
 		case CKM_EDDSA:
 			mechanism = AsymMech::EDDSA;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isEDDSA = true;
 			break;
 #endif

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -4479,7 +4479,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 #ifdef WITH_EDDSA
 		case CKM_EDDSA:
 			mechanism = AsymMech::EDDSA;
-			bAllowMultiPartOp = true;
+			bAllowMultiPartOp = false;
 			isEDDSA = true;
 			break;
 #endif

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -4544,27 +4544,27 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 			break;
 		case CKM_ECDSA_SHA1:
 			mechanism = AsymMech::ECDSA_SHA1;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA224:
 			mechanism = AsymMech::ECDSA_SHA224;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA256:
 			mechanism = AsymMech::ECDSA_SHA256;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA384:
 			mechanism = AsymMech::ECDSA_SHA384;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA512:
 			mechanism = AsymMech::ECDSA_SHA512;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 #endif
@@ -4583,7 +4583,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 #ifdef WITH_EDDSA
 		case CKM_EDDSA:
 			mechanism = AsymMech::EDDSA;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isEDDSA = true;
 			break;
 #endif

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -5633,27 +5633,27 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 			break;
 		case CKM_ECDSA_SHA1:
 			mechanism = AsymMech::ECDSA_SHA1;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA224:
 			mechanism = AsymMech::ECDSA_SHA224;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA256:
 			mechanism = AsymMech::ECDSA_SHA256;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA384:
 			mechanism = AsymMech::ECDSA_SHA384;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 		case CKM_ECDSA_SHA512:
 			mechanism = AsymMech::ECDSA_SHA512;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isECDSA = true;
 			break;
 #endif

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -4583,7 +4583,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 #ifdef WITH_EDDSA
 		case CKM_EDDSA:
 			mechanism = AsymMech::EDDSA;
-			bAllowMultiPartOp = true;
+			bAllowMultiPartOp = false;
 			isEDDSA = true;
 			break;
 #endif

--- a/src/lib/crypto/BotanECDSA.cpp
+++ b/src/lib/crypto/BotanECDSA.cpp
@@ -51,6 +51,7 @@ BotanECDSA::BotanECDSA()
 {
 	signer = NULL;
 	verifier = NULL;
+	pCurrentHash = NULL;
 }
 
 // Destructor
@@ -58,6 +59,11 @@ BotanECDSA::~BotanECDSA()
 {
 	delete signer;
 	delete verifier;
+
+	if (pCurrentHash != NULL)
+	{
+		delete pCurrentHash;
+	}
 }
 
 // Signing functions
@@ -169,27 +175,162 @@ bool BotanECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 	return true;
 }
 
-// Signing functions
-bool BotanECDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			  const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+bool BotanECDSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
+		const void* param /* = NULL */, const size_t paramLen /* = 0 */)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the private key is the right type
+	if (!privateKey->isOfType(BotanECDSAPrivateKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::signFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::signUpdate(const ByteString& /*dataToSign*/)
+bool BotanECDSA::signUpdate(const ByteString& dataToSign)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signUpdate(dataToSign))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(dataToSign))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::signFinal(ByteString& /*signature*/)
+bool BotanECDSA::signFinal(ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	// Save necessary state before calling super class signFinal
+	BotanECDSAPrivateKey* pk = (BotanECDSAPrivateKey*) currentPrivateKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::signFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the Botan key
+	Botan::ECDSA_PrivateKey* botanKey = pk->getBotanKey();
+
+	if (botanKey == NULL)
+	{
+		ERROR_MSG("Could not get the Botan private key");
+
+		return false;
+	}
+
+	try
+	{
+		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
+		signer = new Botan::PK_Signer(*botanKey, *rng->getRNG(), "Raw");
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not create the signer token");
+
+		return false;
+	}
+
+	// Perform the signature operation
+	std::vector<uint8_t> signResult;
+	try
+	{
+		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
+		signResult = signer->sign_message(hash.const_byte_str(), hash.size(), *rng->getRNG());
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not sign the data");
+
+		delete signer;
+		signer = NULL;
+
+		return false;
+	}
+
+	// Return the result
+	signature.resize(signResult.size());
+	memcpy(&signature[0], signResult.data(), signResult.size());
+
+	delete signer;
+	signer = NULL;
+
+	return true;
 }
 
 // Verification functions
@@ -298,27 +439,159 @@ bool BotanECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 	return verResult;
 }
 
-// Verification functions
-bool BotanECDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			    const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+bool BotanECDSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
+		const void* param /* = NULL */, const size_t paramLen /* = 0 */)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the public key is the right type
+	if (!publicKey->isOfType(BotanECDSAPublicKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::verifyFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::verifyUpdate(const ByteString& /*originalData*/)
+bool BotanECDSA::verifyUpdate(const ByteString& originalData)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyUpdate(originalData))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(originalData))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::verifyFinal(const ByteString& /*signature*/)
+bool BotanECDSA::verifyFinal(const ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	// Save necessary state before calling super class verifyFinal
+	BotanECDSAPublicKey* pk = (BotanECDSAPublicKey*) currentPublicKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::verifyFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the Botan key
+	Botan::ECDSA_PublicKey* botanKey = pk->getBotanKey();
+
+	if (botanKey == NULL)
+	{
+		ERROR_MSG("Could not get the Botan public key");
+
+		return false;
+	}
+
+	try
+	{
+		verifier = new Botan::PK_Verifier(*botanKey, "Raw");
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not create the verifier token");
+
+		return false;
+	}
+
+	// Perform the verify operation
+	bool verResult;
+	try
+	{
+		verResult = verifier->verify_message(hash.const_byte_str(),
+							hash.size(),
+							signature.const_byte_str(),
+							signature.size());
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not check the signature");
+
+		delete verifier;
+		verifier = NULL;
+
+		return false;
+	}
+
+	delete verifier;
+	verifier = NULL;
+
+	return verResult;
 }
 
 // Encryption functions

--- a/src/lib/crypto/BotanECDSA.cpp
+++ b/src/lib/crypto/BotanECDSA.cpp
@@ -51,6 +51,7 @@ BotanECDSA::BotanECDSA()
 {
 	signer = NULL;
 	verifier = NULL;
+	pCurrentHash = NULL;
 }
 
 // Destructor
@@ -58,6 +59,11 @@ BotanECDSA::~BotanECDSA()
 {
 	delete signer;
 	delete verifier;
+
+	if (pCurrentHash != NULL)
+	{
+		delete pCurrentHash;
+	}
 }
 
 // Signing functions
@@ -169,26 +175,162 @@ bool BotanECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 // Signing functions
-bool BotanECDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			  const MechanismParam* /*mecahnismParam = NULL*/)
+bool BotanECDSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
+		const MechanismParam* mechanismParam /* = NULL */)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, mechanismParam))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the private key is the right type
+	if (!privateKey->isOfType(BotanECDSAPrivateKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::signFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::signUpdate(const ByteString& /*dataToSign*/)
+bool BotanECDSA::signUpdate(const ByteString& dataToSign)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signUpdate(dataToSign))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(dataToSign))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::signFinal(ByteString& /*signature*/)
+bool BotanECDSA::signFinal(ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	// Save necessary state before calling super class signFinal
+	BotanECDSAPrivateKey* pk = (BotanECDSAPrivateKey*) currentPrivateKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::signFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the Botan key
+	Botan::ECDSA_PrivateKey* botanKey = pk->getBotanKey();
+
+	if (botanKey == NULL)
+	{
+		ERROR_MSG("Could not get the Botan private key");
+
+		return false;
+	}
+
+	try
+	{
+		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
+		signer = new Botan::PK_Signer(*botanKey, *rng->getRNG(), "Raw");
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not create the signer token");
+
+		return false;
+	}
+
+	// Perform the signature operation
+	std::vector<uint8_t> signResult;
+	try
+	{
+		BotanRNG* rng = (BotanRNG*)BotanCryptoFactory::i()->getRNG();
+		signResult = signer->sign_message(hash.const_byte_str(), hash.size(), *rng->getRNG());
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not sign the data");
+
+		delete signer;
+		signer = NULL;
+
+		return false;
+	}
+
+	// Return the result
+	signature.resize(signResult.size());
+	memcpy(&signature[0], signResult.data(), signResult.size());
+
+	delete signer;
+	signer = NULL;
+
+	return true;
 }
 
 // Verification functions
@@ -297,26 +439,159 @@ bool BotanECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 // Verification functions
-bool BotanECDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			    const MechanismParam* /*mecahnismParam = NULL*/)
+bool BotanECDSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
+		const MechanismParam* mechanismParam /* = NULL */)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, mechanismParam))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the public key is the right type
+	if (!publicKey->isOfType(BotanECDSAPublicKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::verifyFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::verifyUpdate(const ByteString& /*originalData*/)
+bool BotanECDSA::verifyUpdate(const ByteString& originalData)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyUpdate(originalData))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(originalData))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool BotanECDSA::verifyFinal(const ByteString& /*signature*/)
+bool BotanECDSA::verifyFinal(const ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	// Save necessary state before calling super class verifyFinal
+	BotanECDSAPublicKey* pk = (BotanECDSAPublicKey*) currentPublicKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::verifyFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the Botan key
+	Botan::ECDSA_PublicKey* botanKey = pk->getBotanKey();
+
+	if (botanKey == NULL)
+	{
+		ERROR_MSG("Could not get the Botan public key");
+
+		return false;
+	}
+
+	try
+	{
+		verifier = new Botan::PK_Verifier(*botanKey, "Raw");
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not create the verifier token");
+
+		return false;
+	}
+
+	// Perform the verify operation
+	bool verResult;
+	try
+	{
+		verResult = verifier->verify_message(hash.const_byte_str(),
+							hash.size(),
+							signature.const_byte_str(),
+							signature.size());
+	}
+	catch (...)
+	{
+		ERROR_MSG("Could not check the signature");
+
+		delete verifier;
+		verifier = NULL;
+
+		return false;
+	}
+
+	delete verifier;
+	verifier = NULL;
+
+	return verResult;
 }
 
 // Encryption functions

--- a/src/lib/crypto/BotanECDSA.h
+++ b/src/lib/crypto/BotanECDSA.h
@@ -35,6 +35,7 @@
 
 #include "config.h"
 #include "AsymmetricAlgorithm.h"
+#include "HashAlgorithm.h"
 #include <botan/pubkey.h>
 
 class BotanECDSA : public AsymmetricAlgorithm
@@ -79,6 +80,7 @@ public:
 private:
 	Botan::PK_Signer* signer;
 	Botan::PK_Verifier* verifier;
+	HashAlgorithm* pCurrentHash;
 };
 
 #endif // !_SOFTHSM_V2_BOTANECDSA_H

--- a/src/lib/crypto/BotanECDSA.h
+++ b/src/lib/crypto/BotanECDSA.h
@@ -35,6 +35,7 @@
 
 #include "config.h"
 #include "AsymmetricAlgorithm.h"
+#include "HashAlgorithm.h"
 #include <botan/pubkey.h>
 
 class BotanECDSA : public AsymmetricAlgorithm
@@ -81,6 +82,7 @@ public:
 private:
 	Botan::PK_Signer* signer;
 	Botan::PK_Verifier* verifier;
+	HashAlgorithm* pCurrentHash;
 };
 
 #endif // !_SOFTHSM_V2_BOTANECDSA_H

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -48,6 +48,21 @@
 #endif
 #include <string.h>
 
+// Constructor
+OSSLECDSA::OSSLECDSA()
+{
+	pCurrentHash = NULL;
+}
+
+// Destructor
+OSSLECDSA::~OSSLECDSA()
+{
+	if (pCurrentHash != NULL)
+	{
+		delete pCurrentHash;
+	}
+}
+
 // Signing functions
 bool OSSLECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 		     ByteString& signature, const AsymMech::Type mechanism,
@@ -159,26 +174,168 @@ bool OSSLECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 	return true;
 }
 
-bool OSSLECDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			 const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+bool OSSLECDSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
+			 const void* param /* = NULL */, const size_t paramLen /* = 0 */)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the private key is the right type
+	if (!privateKey->isOfType(OSSLECPrivateKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::signFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::signUpdate(const ByteString& /*dataToSign*/)
+bool OSSLECDSA::signUpdate(const ByteString& dataToSign)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signUpdate(dataToSign))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(dataToSign))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::signFinal(ByteString& /*signature*/)
+bool OSSLECDSA::signFinal(ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	// Save necessary state before calling super class signFinal
+	OSSLECPrivateKey* pk = (OSSLECPrivateKey*) currentPrivateKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::signFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the OpenSSL key
+	EC_KEY* eckey = pk->getOSSLKey();
+
+	if (eckey == NULL)
+	{
+		ERROR_MSG("Could not get the OpenSSL private key");
+
+		return false;
+	}
+
+	// Use the OpenSSL implementation and not any engine
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
+#ifdef WITH_FIPS
+	if (FIPS_mode())
+		ECDSA_set_method(eckey, FIPS_ecdsa_openssl());
+	else
+		ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#else
+	ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#endif
+
+#else
+	EC_KEY_set_method(eckey, EC_KEY_OpenSSL());
+#endif
+
+	// Perform the signature operation
+	size_t len = pk->getOrderLength();
+	if (len == 0)
+	{
+		ERROR_MSG("Could not get the order length");
+		return false;
+	}
+
+	signature.resize(2 * len);
+	memset(&signature[0], 0, 2 * len);
+
+	ECDSA_SIG* sig = ECDSA_do_sign(hash.const_byte_str(), hash.size(), eckey);
+	if (sig == NULL)
+	{
+		ERROR_MSG("ECDSA sign failed (0x%08X)", ERR_get_error());
+		return false;
+	}
+
+	// Store the 2 values with padding
+	const BIGNUM* bn_r = NULL;
+	const BIGNUM* bn_s = NULL;
+	ECDSA_SIG_get0(sig, &bn_r, &bn_s);
+	BN_bn2bin(bn_r, &signature[len - BN_num_bytes(bn_r)]);
+	BN_bn2bin(bn_s, &signature[2 * len - BN_num_bytes(bn_s)]);
+	ECDSA_SIG_free(sig);
+
+	return true;
 }
 
 // Verification functions
@@ -309,26 +466,184 @@ bool OSSLECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 	return true;
 }
 
-bool OSSLECDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			   const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+bool OSSLECDSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
+			   const void* param /* = NULL */, const size_t paramLen /* = 0 */)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the public key is the right type
+	if (!publicKey->isOfType(OSSLECPublicKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::verifyFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::verifyUpdate(const ByteString& /*originalData*/)
+bool OSSLECDSA::verifyUpdate(const ByteString& originalData)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyUpdate(originalData))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(originalData))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::verifyFinal(const ByteString& /*signature*/)
+bool OSSLECDSA::verifyFinal(const ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	// Save necessary state before calling super class verifyFinal
+	OSSLECPublicKey* pk = (OSSLECPublicKey*) currentPublicKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::verifyFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the OpenSSL key
+	EC_KEY* eckey = pk->getOSSLKey();
+
+	if (eckey == NULL)
+	{
+		ERROR_MSG("Could not get the OpenSSL public key");
+
+		return false;
+	}
+
+	// Use the OpenSSL implementation and not any engine
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
+#ifdef WITH_FIPS
+	if (FIPS_mode())
+		ECDSA_set_method(eckey, FIPS_ecdsa_openssl());
+	else
+		ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#else
+	ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#endif
+
+#else
+	EC_KEY_set_method(eckey, EC_KEY_OpenSSL());
+#endif
+
+	// Perform the verify operation
+	size_t len = pk->getOrderLength();
+	if (len == 0)
+	{
+		ERROR_MSG("Could not get the order length");
+		return false;
+	}
+	if (signature.size() != 2 * len)
+	{
+		ERROR_MSG("Invalid buffer length");
+		return false;
+	}
+
+	ECDSA_SIG* sig = ECDSA_SIG_new();
+	if (sig == NULL)
+	{
+		ERROR_MSG("Could not create an ECDSA_SIG object");
+		return false;
+	}
+
+	const unsigned char *s = signature.const_byte_str();
+	BIGNUM* bn_r = BN_bin2bn(s, len, NULL);
+	BIGNUM* bn_s = BN_bin2bn(s + len, len, NULL);
+	if (bn_r == NULL || bn_s == NULL ||
+	    !ECDSA_SIG_set0(sig, bn_r, bn_s))
+	{
+		ERROR_MSG("Could not add data to the ECDSA_SIG object");
+		ECDSA_SIG_free(sig);
+		return false;
+	}
+
+	int ret = ECDSA_do_verify(hash.const_byte_str(), hash.size(), sig, eckey);
+	if (ret != 1)
+	{
+		if (ret < 0)
+			ERROR_MSG("ECDSA verify failed (0x%08X)", ERR_get_error());
+
+		ECDSA_SIG_free(sig);
+		return false;
+	}
+
+	ECDSA_SIG_free(sig);
+	return true;
 }
 
 // Encryption functions

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -626,6 +626,8 @@ bool OSSLECDSA::verifyFinal(const ByteString& signature)
 	    !ECDSA_SIG_set0(sig, bn_r, bn_s))
 	{
 		ERROR_MSG("Could not add data to the ECDSA_SIG object");
+		BN_free(bn_r);
+		BN_free(bn_s);
 		ECDSA_SIG_free(sig);
 		return false;
 	}

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -429,6 +429,8 @@ bool OSSLECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 	    !ECDSA_SIG_set0(sig, bn_r, bn_s))
 	{
 		ERROR_MSG("Could not add data to the ECDSA_SIG object");
+		BN_free(bn_r);
+		BN_free(bn_s);
 		ECDSA_SIG_free(sig);
 		return false;
 	}
@@ -445,6 +447,7 @@ bool OSSLECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
                 || !digest->hashFinal(prepDataToSign))
         {
             delete digest;
+			ECDSA_SIG_free(sig);
             return false;
         }
         delete digest;

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -48,6 +48,21 @@
 #endif
 #include <string.h>
 
+// Constructor
+OSSLECDSA::OSSLECDSA()
+{
+	pCurrentHash = NULL;
+}
+
+// Destructor
+OSSLECDSA::~OSSLECDSA()
+{
+	if (pCurrentHash != NULL)
+	{
+		delete pCurrentHash;
+	}
+}
+
 // Signing functions
 bool OSSLECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 		     ByteString& signature, const AsymMech::Type mechanism,
@@ -158,26 +173,168 @@ bool OSSLECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 	return true;
 }
 
-bool OSSLECDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			 const MechanismParam* /* mechanismParam = NULL */)
+bool OSSLECDSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
+			 const MechanismParam* mechanismParam /* = NULL */)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, mechanismParam))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the private key is the right type
+	if (!privateKey->isOfType(OSSLECPrivateKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::signFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::signUpdate(const ByteString& /*dataToSign*/)
+bool OSSLECDSA::signUpdate(const ByteString& dataToSign)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signUpdate(dataToSign))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(dataToSign))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::signFinal(ByteString& /*signature*/)
+bool OSSLECDSA::signFinal(ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part signing");
+	// Save necessary state before calling super class signFinal
+	OSSLECPrivateKey* pk = (OSSLECPrivateKey*) currentPrivateKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::signFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the OpenSSL key
+	EC_KEY* eckey = pk->getOSSLKey();
+
+	if (eckey == NULL)
+	{
+		ERROR_MSG("Could not get the OpenSSL private key");
+
+		return false;
+	}
+
+	// Use the OpenSSL implementation and not any engine
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
+#ifdef WITH_FIPS
+	if (FIPS_mode())
+		ECDSA_set_method(eckey, FIPS_ecdsa_openssl());
+	else
+		ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#else
+	ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#endif
+
+#else
+	EC_KEY_set_method(eckey, EC_KEY_OpenSSL());
+#endif
+
+	// Perform the signature operation
+	size_t len = pk->getOrderLength();
+	if (len == 0)
+	{
+		ERROR_MSG("Could not get the order length");
+		return false;
+	}
+
+	signature.resize(2 * len);
+	memset(&signature[0], 0, 2 * len);
+
+	ECDSA_SIG* sig = ECDSA_do_sign(hash.const_byte_str(), hash.size(), eckey);
+	if (sig == NULL)
+	{
+		ERROR_MSG("ECDSA sign failed (0x%08X)", ERR_get_error());
+		return false;
+	}
+
+	// Store the 2 values with padding
+	const BIGNUM* bn_r = NULL;
+	const BIGNUM* bn_s = NULL;
+	ECDSA_SIG_get0(sig, &bn_r, &bn_s);
+	BN_bn2bin(bn_r, &signature[len - BN_num_bytes(bn_r)]);
+	BN_bn2bin(bn_s, &signature[2 * len - BN_num_bytes(bn_s)]);
+	ECDSA_SIG_free(sig);
+
+	return true;
 }
 
 // Verification functions
@@ -307,26 +464,184 @@ bool OSSLECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 	return true;
 }
 
-bool OSSLECDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			   const MechanismParam* /* mechanismParam = NULL */)
+bool OSSLECDSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
+			   const MechanismParam* mechanismParam /* = NULL */)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, mechanismParam))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the public key is the right type
+	if (!publicKey->isOfType(OSSLECPublicKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	HashAlgo::Type hash = HashAlgo::Unknown;
+
+	switch (mechanism)
+	{
+		case AsymMech::ECDSA_SHA1:
+			hash = HashAlgo::SHA1;
+			break;
+		case AsymMech::ECDSA_SHA224:
+			hash = HashAlgo::SHA224;
+			break;
+		case AsymMech::ECDSA_SHA256:
+			hash = HashAlgo::SHA256;
+			break;
+		case AsymMech::ECDSA_SHA384:
+			hash = HashAlgo::SHA384;
+			break;
+		case AsymMech::ECDSA_SHA512:
+			hash = HashAlgo::SHA512;
+			break;
+		default:
+			ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
+
+			ByteString dummy;
+			AsymmetricAlgorithm::verifyFinal(dummy);
+
+			return false;
+	}
+
+	pCurrentHash = CryptoFactory::i()->getHashAlgorithm(hash);
+
+	if (pCurrentHash == NULL || !pCurrentHash->hashInit())
+	{
+		if (pCurrentHash != NULL)
+		{
+			delete pCurrentHash;
+			pCurrentHash = NULL;
+		}
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::verifyUpdate(const ByteString& /*originalData*/)
+bool OSSLECDSA::verifyUpdate(const ByteString& originalData)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyUpdate(originalData))
+	{
+		return false;
+	}
 
-	return false;
+	if (!pCurrentHash->hashUpdate(originalData))
+	{
+		delete pCurrentHash;
+		pCurrentHash = NULL;
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	return true;
 }
 
-bool OSSLECDSA::verifyFinal(const ByteString& /*signature*/)
+bool OSSLECDSA::verifyFinal(const ByteString& signature)
 {
-	ERROR_MSG("ECDSA does not support multi part verifying");
+	// Save necessary state before calling super class verifyFinal
+	OSSLECPublicKey* pk = (OSSLECPublicKey*) currentPublicKey;
 
-	return false;
+	if (!AsymmetricAlgorithm::verifyFinal(signature))
+	{
+		return false;
+	}
+
+	ByteString hash;
+
+	bool bResult = pCurrentHash->hashFinal(hash);
+
+	delete pCurrentHash;
+	pCurrentHash = NULL;
+
+	if (!bResult)
+	{
+		return false;
+	}
+
+	// Get the OpenSSL key
+	EC_KEY* eckey = pk->getOSSLKey();
+
+	if (eckey == NULL)
+	{
+		ERROR_MSG("Could not get the OpenSSL public key");
+
+		return false;
+	}
+
+	// Use the OpenSSL implementation and not any engine
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
+#ifdef WITH_FIPS
+	if (FIPS_mode())
+		ECDSA_set_method(eckey, FIPS_ecdsa_openssl());
+	else
+		ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#else
+	ECDSA_set_method(eckey, ECDSA_OpenSSL());
+#endif
+
+#else
+	EC_KEY_set_method(eckey, EC_KEY_OpenSSL());
+#endif
+
+	// Perform the verify operation
+	size_t len = pk->getOrderLength();
+	if (len == 0)
+	{
+		ERROR_MSG("Could not get the order length");
+		return false;
+	}
+	if (signature.size() != 2 * len)
+	{
+		ERROR_MSG("Invalid buffer length");
+		return false;
+	}
+
+	ECDSA_SIG* sig = ECDSA_SIG_new();
+	if (sig == NULL)
+	{
+		ERROR_MSG("Could not create an ECDSA_SIG object");
+		return false;
+	}
+
+	const unsigned char *s = signature.const_byte_str();
+	BIGNUM* bn_r = BN_bin2bn(s, len, NULL);
+	BIGNUM* bn_s = BN_bin2bn(s + len, len, NULL);
+	if (bn_r == NULL || bn_s == NULL ||
+	    !ECDSA_SIG_set0(sig, bn_r, bn_s))
+	{
+		ERROR_MSG("Could not add data to the ECDSA_SIG object");
+		ECDSA_SIG_free(sig);
+		return false;
+	}
+
+	int ret = ECDSA_do_verify(hash.const_byte_str(), hash.size(), sig, eckey);
+	if (ret != 1)
+	{
+		if (ret < 0)
+			ERROR_MSG("ECDSA verify failed (0x%08X)", ERR_get_error());
+
+		ECDSA_SIG_free(sig);
+		return false;
+	}
+
+	ECDSA_SIG_free(sig);
+	return true;
 }
 
 // Encryption functions

--- a/src/lib/crypto/OSSLECDSA.h
+++ b/src/lib/crypto/OSSLECDSA.h
@@ -35,13 +35,17 @@
 
 #include "config.h"
 #include "AsymmetricAlgorithm.h"
+#include "HashAlgorithm.h"
 #include <openssl/ecdsa.h>
 
 class OSSLECDSA : public AsymmetricAlgorithm
 {
 public:
+	// Constructor
+	OSSLECDSA();
+
 	// Destructor
-	virtual ~OSSLECDSA() { }
+	virtual ~OSSLECDSA();
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
@@ -74,6 +78,7 @@ public:
 	virtual AsymmetricParameters* newParameters();
 
 private:
+	HashAlgorithm* pCurrentHash;
 };
 
 #endif // !_SOFTHSM_V2_OSSLECDSA_H

--- a/src/lib/crypto/OSSLECDSA.h
+++ b/src/lib/crypto/OSSLECDSA.h
@@ -35,13 +35,17 @@
 
 #include "config.h"
 #include "AsymmetricAlgorithm.h"
+#include "HashAlgorithm.h"
 #include <openssl/ecdsa.h>
 
 class OSSLECDSA : public AsymmetricAlgorithm
 {
 public:
+	// Constructor
+	OSSLECDSA();
+
 	// Destructor
-	virtual ~OSSLECDSA() { }
+	virtual ~OSSLECDSA();
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const MechanismParam* mechanismParam = NULL);
@@ -76,6 +80,7 @@ public:
 	virtual AsymmetricParameters* newParameters();
 
 private:
+	HashAlgorithm* pCurrentHash;
 };
 
 #endif // !_SOFTHSM_V2_OSSLECDSA_H

--- a/src/lib/test/SignVerifyTests.cpp
+++ b/src/lib/test/SignVerifyTests.cpp
@@ -543,246 +543,186 @@ void SignVerifyTests::testEcSignVerify()
 	// Public Session keys
 	rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
-	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
-	rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PUBLIC,IN_SESSION,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
 	// Private Session Keys
 	rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
-	rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,IN_SESSION,IS_PRIVATE,IN_SESSION,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
 	// Public Token Keys
 	rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
-	rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PUBLIC,ON_TOKEN,IS_PUBLIC,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
 	// Private Token Keys
 	rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
+
 	rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
 	CPPUNIT_ASSERT(rv == CKR_OK);
 	signVerifySingle(CKM_ECDSA, hSessionRO, hPuk,hPrk);
+	signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 
-	rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA1, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA224, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA256, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA384, hSessionRO, hPuk,hPrk);
-
-    rv = generateEC("P-256", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-384", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
-    rv = generateEC("P-521", hSessionRW,ON_TOKEN,IS_PRIVATE,ON_TOKEN,IS_PRIVATE,hPuk,hPrk);
-    CPPUNIT_ASSERT(rv == CKR_OK);
-    signVerifySingle(CKM_ECDSA_SHA512, hSessionRO, hPuk,hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA1, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA224, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA256, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA384, hSessionRO, hPuk, hPrk);
+	signVerifyMulti(CKM_ECDSA_SHA512, hSessionRO, hPuk, hPrk);
 }
 #endif
 


### PR DESCRIPTION
This implements missing support for multipart ECDSA hasing including OpenSSL and Botan support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled multi-part ECDSA signing and verification for SHA1, SHA224, SHA256, SHA384, and SHA512 mechanisms.

* **Bug Fixes**
  * Implemented functional multi-part sign/verify flows in the ECDSA cryptography backends, replacing previous non-working multipart behavior.

* **Tests**
  * Expanded and consolidated ECDSA test coverage to exercise both single-part and multi-part signing/verification for the supported SHA mechanisms across common key types and curves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->