### PR TITLE
Clear OpenSSL error queue if rdrand engine is unavailable

### DIFF
--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -165,6 +165,11 @@ OSSLCryptoFactory::OSSLCryptoFactory()
 			WARNING_MSG("ENGINE_set_default returned %lu\n", ERR_get_error());
 		}
 	}
+	else
+	{
+		// Clear OpenSSL error queue if rdrand engine is unavailable
+		ERR_clear_error();
+	}
 #endif
 
 	// Initialise the one-and-only RNG


### PR DESCRIPTION
`ENGINE_by_id("rdrand")` may leave an error in the OpenSSL error queue when the engine is not present, which is an expected condition.

Clear the error queue in this case to avoid propagating stale errors from the error queue to subsequent OpenSSL operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during cryptographic component initialization when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->