### PR TITLE
Fix misaligned read of CK_ULONG via void pointer.

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -2092,7 +2092,8 @@ CK_RV SoftHSM::C_FindObjectsInit(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pT
 				{
 					if (sizeof(CK_ULONG) != pTemplate[i].ulValueLen)
 						break;
-					CK_ULONG ulTemplateValue = *(CK_ULONG_PTR)pTemplate[i].pValue;
+					CK_ULONG ulTemplateValue;
+					memcpy(&ulTemplateValue, pTemplate[i].pValue, sizeof(ulTemplateValue));
 					if (attr.getUnsignedLongValue() != ulTemplateValue)
 						break;
 				}


### PR DESCRIPTION
The PKCS#11 spec defines pValue as CK_VOID_PTR, which carries no alignment guarantee. Casting directly to CK_ULONG_PTR and dereferencing invokes undefined behaviour when the pointer is not 8-byte aligned (UBSAN: load of misaligned address).

Replace the direct cast with memcpy(), which is the correct way to read an unaligned value in C/C++.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attribute matching in object initialization to properly handle unsigned-long value comparisons, improving reliability of attribute-based object lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->