### PR TITLE
Fix misaligned read of CK_OBJECT_CLASS via PKCS#11 pValue

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -242,7 +242,7 @@ static CK_RV extractObjectInformation(CK_ATTRIBUTE_PTR pTemplate,
 			case CKA_CLASS:
 				if (pTemplate[i].ulValueLen == sizeof(CK_OBJECT_CLASS))
 				{
-					objClass = *(CK_OBJECT_CLASS_PTR)pTemplate[i].pValue;
+					memcpy(&objClass, pTemplate[i].pValue, sizeof(objClass));
 					bHasClass = true;
 				}
 				break;


### PR DESCRIPTION
The PKCS#11 spec exposes attribute values through pValue, which does not guarantee natural alignment for typed loads. Casting the buffer to a typed pointer and dereferencing it triggers undefined behaviour when the input is misaligned.

Replace the direct dereference with memcpy(), which safely copies the value from possibly unaligned storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal implementation improvement to memory handling in cryptographic object processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->