### PR TITLE
Fix the memory leak in OSSL::byteString2oid

### DIFF
--- a/src/lib/crypto/OSSLUtil.cpp
+++ b/src/lib/crypto/OSSLUtil.cpp
@@ -189,8 +189,10 @@ int OSSL::byteString2oid(const ByteString& byteString)
 		{
 			return NID_undef;
 		}
-
-		return OBJ_obj2nid(oid);
+		
+		int nid = OBJ_obj2nid(oid);
+		ASN1_OBJECT_free(oid);
+		return nid;
 	}
 	else if (pclass == V_ASN1_UNIVERSAL && tag == V_ASN1_PRINTABLESTRING)
 	{
@@ -216,6 +218,8 @@ int OSSL::byteString2oid(const ByteString& byteString)
 		{
 			return EVP_PKEY_X448;
 		}
+
+		ASN1_STRING_free(curve_name);
 	}
 
 	return NID_undef;


### PR DESCRIPTION
The function `OSSL::byteString2oid` in `SoftHSM2` (OpenSSL backend) leaks memory when decoding PKCS#11 attribute values as ASN.1 objects or strings. It calls `d2i_ASN1_OBJECT` and `d2i_ASN1_PRINTABLESTRING` which allocate new OpenSSL objects, but these objects are never freed after their NIDs are extracted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed memory leaks in cryptographic operations that could accumulate over time and negatively impact application stability and performance, particularly in long-running or high-volume usage scenarios.
* Improved resource management in certificate processing operations to reduce overall memory footprint and prevent potential stability issues that may occur during sustained application usage and extended runtime periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->