### PR TITLE
fix misaligned access when reading PKCS#11 attributes

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -240,36 +240,36 @@ static CK_RV extractObjectInformation(CK_ATTRIBUTE_PTR pTemplate,
 		switch (pTemplate[i].type)
 		{
 			case CKA_CLASS:
-				if (pTemplate[i].ulValueLen == sizeof(CK_OBJECT_CLASS))
+				if (pTemplate[i].ulValueLen == sizeof(CK_OBJECT_CLASS) && pTemplate[i].pValue != NULL_PTR)
 				{
 					memcpy(&objClass, pTemplate[i].pValue, sizeof(objClass));
 					bHasClass = true;
 				}
 				break;
 			case CKA_KEY_TYPE:
-				if (pTemplate[i].ulValueLen == sizeof(CK_KEY_TYPE))
+				if (pTemplate[i].ulValueLen == sizeof(CK_KEY_TYPE) && pTemplate[i].pValue != NULL_PTR)
 				{
-					keyType = *(CK_KEY_TYPE*)pTemplate[i].pValue;
+					memcpy(&keyType, pTemplate[i].pValue, sizeof(keyType));
 					bHasKeyType = true;
 				}
 				break;
 			case CKA_CERTIFICATE_TYPE:
-				if (pTemplate[i].ulValueLen == sizeof(CK_CERTIFICATE_TYPE))
+				if (pTemplate[i].ulValueLen == sizeof(CK_CERTIFICATE_TYPE) && pTemplate[i].pValue != NULL_PTR)
 				{
-					certType = *(CK_CERTIFICATE_TYPE*)pTemplate[i].pValue;
+					memcpy(&certType, pTemplate[i].pValue, sizeof(certType));
 					bHasCertType = true;
 				}
 				break;
 			case CKA_TOKEN:
-				if (pTemplate[i].ulValueLen == sizeof(CK_BBOOL))
+				if (pTemplate[i].ulValueLen == sizeof(CK_BBOOL) && pTemplate[i].pValue != NULL_PTR)
 				{
-					isOnToken = *(CK_BBOOL*)pTemplate[i].pValue;
+					memcpy(&isOnToken, pTemplate[i].pValue, sizeof(isOnToken));
 				}
 				break;
 			case CKA_PRIVATE:
-				if (pTemplate[i].ulValueLen == sizeof(CK_BBOOL))
+				if (pTemplate[i].ulValueLen == sizeof(CK_BBOOL) && pTemplate[i].pValue != NULL_PTR)
 				{
-					isPrivate = *(CK_BBOOL*)pTemplate[i].pValue;
+					memcpy(&isPrivate, pTemplate[i].pValue, sizeof(isPrivate));
 					bHasPrivate = true;
 				}
 				break;
@@ -1711,14 +1711,16 @@ CK_RV SoftHSM::C_CopyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject
 
 	for (CK_ULONG i = 0; i < ulCount; i++)
 	{
-		if ((pTemplate[i].type == CKA_TOKEN) && (pTemplate[i].ulValueLen == sizeof(CK_BBOOL)))
+		if ((pTemplate[i].type == CKA_TOKEN) && (pTemplate[i].ulValueLen == sizeof(CK_BBOOL)) &&
+		    (pTemplate[i].pValue != NULL_PTR))
 		{
-			isOnToken = *(CK_BBOOL*)pTemplate[i].pValue;
+			memcpy(&isOnToken, pTemplate[i].pValue, sizeof(isOnToken));
 			continue;
 		}
-		if ((pTemplate[i].type == CKA_PRIVATE) && (pTemplate[i].ulValueLen == sizeof(CK_BBOOL)))
+		if ((pTemplate[i].type == CKA_PRIVATE) && (pTemplate[i].ulValueLen == sizeof(CK_BBOOL)) &&
+		    (pTemplate[i].pValue != NULL_PTR))
 		{
-			isPrivate = *(CK_BBOOL*)pTemplate[i].pValue;
+			memcpy(&isPrivate, pTemplate[i].pValue, sizeof(isPrivate));
 			continue;
 		}
 	}
@@ -2080,9 +2082,12 @@ CK_RV SoftHSM::C_FindObjectsInit(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pT
 
 			if (attr.isBooleanAttribute())
 			{
-				if (sizeof(CK_BBOOL) != pTemplate[i].ulValueLen)
+				if (sizeof(CK_BBOOL) != pTemplate[i].ulValueLen ||
+				    pTemplate[i].pValue == NULL_PTR)
 					break;
-				bool bTemplateValue = (*(CK_BBOOL*)pTemplate[i].pValue == CK_TRUE);
+				CK_BBOOL b = CK_FALSE;
+				memcpy(&b, pTemplate[i].pValue, sizeof(b));
+				bool bTemplateValue = (b == CK_TRUE);
 				if (attr.getBooleanValue() != bTemplateValue)
 					break;
 			}
@@ -2090,7 +2095,8 @@ CK_RV SoftHSM::C_FindObjectsInit(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pT
 			{
 				if (attr.isUnsignedLongAttribute())
 				{
-					if (sizeof(CK_ULONG) != pTemplate[i].ulValueLen)
+					if (sizeof(CK_ULONG) != pTemplate[i].ulValueLen ||
+					    pTemplate[i].pValue == NULL_PTR)
 						break;
 					CK_ULONG ulTemplateValue;
 					memcpy(&ulTemplateValue, pTemplate[i].pValue, sizeof(ulTemplateValue));


### PR DESCRIPTION
CK_ATTRIBUTE.pValue pointers are not guaranteed to be naturally aligned. Direct casts (`*(CK_KEY_TYPE*)pValue`, `*(CK_BBOOL*)pValue`, etc.) trigger undefined behavior.

Security impact: partials read from adjacent memory or DoS

Fixed by using `memcpy()` in all attribute parsing paths (extractObjectInformation, C_CopyObject, C_FindObjectsInit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved robustness of cryptographic attribute handling: added stricter validation and safe decoding for boolean and numeric attributes, including extra guards against missing or malformed values. Enhances reliability when copying and matching objects, reducing memory-safety issues and preventing incorrect attribute interpretation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softhsm/SoftHSMv2/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->