### PR TITLE
for the list of pkcs#11 function, use version numbers according to the implementation

### DIFF
--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -68,6 +68,7 @@ public:
 	virtual ~SoftHSM();
 
 	// PKCS #11 functions
+	// NOTE: keep synchronised with "PKCS #11 function list"
 	CK_RV C_Initialize(CK_VOID_PTR pInitArgs);
 	CK_RV C_Finalize(CK_VOID_PTR pReserved);
 	CK_RV C_GetInfo(CK_INFO_PTR pInfo);

--- a/src/lib/main.cpp
+++ b/src/lib/main.cpp
@@ -50,10 +50,12 @@
 #endif
 
 // PKCS #11 function list
+// NOTE: keep list synchronised with implementation
 static CK_FUNCTION_LIST functionList =
 {
 	// Version information
-	{ CRYPTOKI_VERSION_MAJOR, CRYPTOKI_VERSION_MINOR },
+	// NOTE: keep version numbers according to the implementation
+	{ 2, 40 },
 	// Function pointers
 	C_Initialize,
 	C_Finalize,


### PR DESCRIPTION
Fixes https://github.com/softhsm/SoftHSMv2/issues/852 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added synchronization guidelines for PKCS #11 function declarations to match the external specification.

* **Bug Fixes**
  * Updated PKCS #11 function list version number to 2.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->