### PR TITLE
Added PKCS#11 3.2 ML-DSA multiple-part support in lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,14 @@ jobs:
           make check || (find . -name test-suite.log -exec cat {} \; && false)
 
   linux_ossl_35:
-    name: Linux with OpenSSL 3.5.5
+    name: Linux with OpenSSL 3.5.6
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Prepare
         env:
-          OPENSSL_VERSION: 3.5.5
-          OPENSSL_SHA256: "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89"
+          OPENSSL_VERSION: 3.5.6
+          OPENSSL_SHA256: "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736"
           OPENSSL_INSTALL_DIR: /usr/local/openssl-3.5
           LDFLAGS: "-Wl,-rpath,/usr/local/openssl-3.5/lib64 -L/usr/local/openssl-3.5/lib64"
           PKG_CONFIG_PATH: "/usr/local/openssl-3.5/lib64/pkgconfig"
@@ -97,7 +97,7 @@ jobs:
           cd openssl-${{ env.OPENSSL_VERSION }}
           ./config shared zlib no-ssl3 no-weak-ssl-ciphers --prefix=${{ env.OPENSSL_INSTALL_DIR }} --openssldir=${{ env.OPENSSL_INSTALL_DIR }}
           make -j$(nproc) > build.log
-          sudo make install > install.log
+          sudo make install_sw > install.log
           cd ${{ env.OPENSSL_INSTALL_DIR }}
           sudo ln -sf lib64 lib
       - name: Build

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -4487,7 +4487,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 #ifdef WITH_ML_DSA
 		case CKM_ML_DSA:
 			mechanism = AsymMech::MLDSA;
-			bAllowMultiPartOp = false;
+			bAllowMultiPartOp = true;
 			isMLDSA = true;
 			if (pMechanism->pParameter == NULL_PTR)
 			{
@@ -4520,6 +4520,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 						return CKR_ARGUMENTS_BAD;
 					}
 					mldsaParam.additionalContext = ByteString(ckSignAdditionalContext->pContext, ckSignAdditionalContext->ulContextLen);
+					DEBUG_MSG("Sign MLDSA additionalContextLen=%lu, hedgeType=%d", (unsigned long)mldsaParam.additionalContext.size(), mldsaParam.hedgeType);
 				}
 				mechanismParam = &mldsaParam;
 			}
@@ -4677,7 +4678,7 @@ CK_RV SoftHSM::AsymSignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechan
 	}
 
 	// Initialize signing
-	if (bAllowMultiPartOp && !asymCrypto->signInit(privateKey,mechanism,param,paramLen))
+	if (bAllowMultiPartOp && !asymCrypto->signInit(privateKey,mechanism,param,paramLen,mechanismParam))
 	{
 		asymCrypto->recyclePrivateKey(privateKey);
 		CryptoFactory::i()->recycleAsymmetricAlgorithm(asymCrypto);
@@ -5618,6 +5619,7 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 						return CKR_ARGUMENTS_BAD;
 					}
 					mldsaParam.additionalContext = ByteString(ckSignAdditionalContext->pContext, ckSignAdditionalContext->ulContextLen);
+					DEBUG_MSG("Verify MLDSA additionalContextLen=%lu, hedgeType=%d", (unsigned long)mldsaParam.additionalContext.size(), mldsaParam.hedgeType);
 				}
 				mechanismParam = &mldsaParam;
 			}
@@ -5775,7 +5777,7 @@ CK_RV SoftHSM::AsymVerifyInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 	}
 
 	// Initialize verifying
-	if (bAllowMultiPartOp && !asymCrypto->verifyInit(publicKey,mechanism,param,paramLen))
+	if (bAllowMultiPartOp && !asymCrypto->verifyInit(publicKey,mechanism,param,paramLen,mechanismParam))
 	{
 		asymCrypto->recyclePublicKey(publicKey);
 		CryptoFactory::i()->recycleAsymmetricAlgorithm(asymCrypto);

--- a/src/lib/crypto/AsymmetricAlgorithm.cpp
+++ b/src/lib/crypto/AsymmetricAlgorithm.cpp
@@ -55,7 +55,8 @@ bool AsymmetricAlgorithm::sign(PrivateKey* privateKey, const ByteString& dataToS
 }
 
 bool AsymmetricAlgorithm::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-				   const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+				   const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+				   const MechanismParam* /* mechanismParam = NULL */)
 {
 	if ((currentOperation != NONE) || (privateKey == NULL))
 	{
@@ -104,7 +105,8 @@ bool AsymmetricAlgorithm::verify(PublicKey* publicKey, const ByteString& origina
 }
 
 bool AsymmetricAlgorithm::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-				     const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+				     const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+				     const MechanismParam* /* mechanismParam = NULL */)
 {
 	if ((currentOperation != NONE) || (publicKey == NULL))
 	{

--- a/src/lib/crypto/AsymmetricAlgorithm.h
+++ b/src/lib/crypto/AsymmetricAlgorithm.h
@@ -133,13 +133,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanDH.cpp
+++ b/src/lib/crypto/BotanDH.cpp
@@ -47,7 +47,8 @@
 
 // Signing functions
 bool BotanDH::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-		       const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+		       const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		       const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("DH does not support signing");
 
@@ -70,7 +71,8 @@ bool BotanDH::signFinal(ByteString& /*signature*/)
 
 // Verification functions
 bool BotanDH::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			 const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			 const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("DH does not support verifying");
 

--- a/src/lib/crypto/BotanDH.h
+++ b/src/lib/crypto/BotanDH.h
@@ -44,12 +44,12 @@ public:
 	virtual ~BotanDH() { }
 
 	// Signing functions
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanDSA.cpp
+++ b/src/lib/crypto/BotanDSA.cpp
@@ -134,7 +134,8 @@ bool BotanDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool BotanDSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-			const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
 	{
@@ -349,7 +350,8 @@ bool BotanDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool BotanDSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-			  const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			  const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
 	{

--- a/src/lib/crypto/BotanDSA.h
+++ b/src/lib/crypto/BotanDSA.h
@@ -48,13 +48,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanECDH.cpp
+++ b/src/lib/crypto/BotanECDH.cpp
@@ -48,7 +48,8 @@
 
 // Signing functions
 bool BotanECDH::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			 const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			 const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDH does not support signing");
 
@@ -71,7 +72,8 @@ bool BotanECDH::signFinal(ByteString& /*signature*/)
 
 // Verification functions
 bool BotanECDH::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			   const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			   const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		       const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDH does not support verifying");
 

--- a/src/lib/crypto/BotanECDH.h
+++ b/src/lib/crypto/BotanECDH.h
@@ -44,12 +44,12 @@ public:
 	virtual ~BotanECDH() { }
 
 	// Signing functions
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanECDSA.cpp
+++ b/src/lib/crypto/BotanECDSA.cpp
@@ -171,7 +171,8 @@ bool BotanECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 
 // Signing functions
 bool BotanECDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			  const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			  const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		      const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDSA does not support multi part signing");
 
@@ -300,7 +301,8 @@ bool BotanECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 
 // Verification functions
 bool BotanECDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			    const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			    const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		        const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDSA does not support multi part verifying");
 

--- a/src/lib/crypto/BotanECDSA.h
+++ b/src/lib/crypto/BotanECDSA.h
@@ -48,13 +48,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanEDDSA.cpp
+++ b/src/lib/crypto/BotanEDDSA.cpp
@@ -139,7 +139,8 @@ bool BotanEDDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 
 // Signing functions
 bool BotanEDDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			  const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			  const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		      const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("EDDSA does not support multi part signing");
 
@@ -235,7 +236,8 @@ bool BotanEDDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 
 // Verification functions
 bool BotanEDDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			    const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			    const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		        const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("EDDSA does not support multi part verifying");
 

--- a/src/lib/crypto/BotanEDDSA.h
+++ b/src/lib/crypto/BotanEDDSA.h
@@ -48,13 +48,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanGOST.cpp
+++ b/src/lib/crypto/BotanGOST.cpp
@@ -62,7 +62,8 @@ BotanGOST::~BotanGOST()
 
 // Signing functions
 bool BotanGOST::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-			 const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			 const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
 	{
@@ -197,7 +198,8 @@ bool BotanGOST::signFinal(ByteString& signature)
 
 // Verification functions
 bool BotanGOST::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-			   const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			   const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		       const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
 	{

--- a/src/lib/crypto/BotanGOST.h
+++ b/src/lib/crypto/BotanGOST.h
@@ -47,12 +47,12 @@ public:
 	virtual ~BotanGOST();
 
 	// Signing functions
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/BotanRSA.cpp
+++ b/src/lib/crypto/BotanRSA.cpp
@@ -145,7 +145,8 @@ bool BotanRSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool BotanRSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-			const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		    const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
 	{
@@ -490,7 +491,8 @@ bool BotanRSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool BotanRSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-			  const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			  const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		      const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
 	{

--- a/src/lib/crypto/BotanRSA.h
+++ b/src/lib/crypto/BotanRSA.h
@@ -49,13 +49,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLDH.cpp
+++ b/src/lib/crypto/OSSLDH.cpp
@@ -51,7 +51,8 @@
 
 // Signing functions
 bool OSSLDH::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-		      const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+		      const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		      const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("DH does not support signing");
 
@@ -74,7 +75,8 @@ bool OSSLDH::signFinal(ByteString& /*signature*/)
 
 // Verification functions
 bool OSSLDH::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("DH does not support verifying");
 

--- a/src/lib/crypto/OSSLDH.h
+++ b/src/lib/crypto/OSSLDH.h
@@ -44,12 +44,12 @@ public:
 	virtual ~OSSLDH() { }
 
 	// Signing functions
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLDSA.cpp
+++ b/src/lib/crypto/OSSLDSA.cpp
@@ -104,7 +104,8 @@ bool OSSLDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool OSSLDSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-		       const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+		       const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+			   const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
 	{
@@ -293,7 +294,8 @@ bool OSSLDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool OSSLDSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-			 const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			 const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+			 const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
 	{

--- a/src/lib/crypto/OSSLDSA.h
+++ b/src/lib/crypto/OSSLDSA.h
@@ -49,13 +49,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLECDH.cpp
+++ b/src/lib/crypto/OSSLECDH.cpp
@@ -48,7 +48,8 @@
 
 // Signing functions
 bool OSSLECDH::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		    const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDH does not support signing");
 
@@ -71,7 +72,8 @@ bool OSSLECDH::signFinal(ByteString& /*signature*/)
 
 // Verification functions
 bool OSSLECDH::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			  const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			  const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		      const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDH does not support verifying");
 

--- a/src/lib/crypto/OSSLECDH.h
+++ b/src/lib/crypto/OSSLECDH.h
@@ -44,12 +44,12 @@ public:
 	virtual ~OSSLECDH() { }
 
 	// Signing functions
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLECDSA.cpp
+++ b/src/lib/crypto/OSSLECDSA.cpp
@@ -160,7 +160,8 @@ bool OSSLECDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool OSSLECDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			 const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			 const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDSA does not support multi part signing");
 
@@ -310,7 +311,8 @@ bool OSSLECDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool OSSLECDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			   const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			   const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		       const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("ECDSA does not support multi part verifying");
 

--- a/src/lib/crypto/OSSLECDSA.h
+++ b/src/lib/crypto/OSSLECDSA.h
@@ -45,13 +45,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLEDDSA.cpp
+++ b/src/lib/crypto/OSSLEDDSA.cpp
@@ -103,7 +103,8 @@ bool OSSLEDDSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool OSSLEDDSA::signInit(PrivateKey* /*privateKey*/, const AsymMech::Type /*mechanism*/,
-			 const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			 const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("EDDSA does not support multi part signing");
 
@@ -187,7 +188,8 @@ bool OSSLEDDSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool OSSLEDDSA::verifyInit(PublicKey* /*publicKey*/, const AsymMech::Type /*mechanism*/,
-			   const void* /* param = NULL */, const size_t /* paramLen = 0 */)
+			   const void* /* param = NULL */, const size_t /* paramLen = 0 */,
+		       const MechanismParam* /* mechanismParam */)
 {
 	ERROR_MSG("EDDSA does not support multi part verifying");
 

--- a/src/lib/crypto/OSSLEDDSA.h
+++ b/src/lib/crypto/OSSLEDDSA.h
@@ -45,13 +45,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLGOST.cpp
+++ b/src/lib/crypto/OSSLGOST.cpp
@@ -127,7 +127,8 @@ bool OSSLGOST::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool OSSLGOST::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-			const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		    const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
 	{
@@ -312,7 +313,8 @@ bool OSSLGOST::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool OSSLGOST::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-			  const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			  const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		      const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
 	{

--- a/src/lib/crypto/OSSLGOST.h
+++ b/src/lib/crypto/OSSLGOST.h
@@ -50,13 +50,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/OSSLMLDSA.cpp
+++ b/src/lib/crypto/OSSLMLDSA.cpp
@@ -30,6 +30,7 @@ bool OSSLMLDSA::sign(PrivateKey *privateKey, const ByteString &dataToSign,
 					 const void * /* param  = NULL*/, const size_t  /* paramLen = 0 */,
 					 const MechanismParam* mechanismParam)
 {
+	DEBUG_MSG("sign dataToSign: %s", dataToSign.hex_str().c_str());
 	if (mechanism != AsymMech::MLDSA)
 	{
 		ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
@@ -155,26 +156,82 @@ bool OSSLMLDSA::sign(PrivateKey *privateKey, const ByteString &dataToSign,
 	return true;
 }
 
-bool OSSLMLDSA::signInit(PrivateKey * /*privateKey*/, const AsymMech::Type /*mechanism*/,
-						 const void * /* param = NULL */, const size_t /* paramLen = 0 */)
+bool OSSLMLDSA::signInit(PrivateKey * privateKey, const AsymMech::Type mechanism,
+						 const void * param /* = NULL */ , const size_t paramLen /* = 0 */,
+					     const MechanismParam* mechanismParam /* = NULL */)
 {
-	ERROR_MSG("ML-DSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the private key is the right type
+	if (!privateKey->isOfType(OSSLMLDSAPrivateKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+
+	DEBUG_MSG("signInit mechanismParam != NULL: %d", mechanismParam != NULL);
+
+	if (mechanismParam != NULL && !mechanismParam->isOfType(MLDSAMechanismParam::type))
+	{
+		ERROR_MSG("Invalid mechanism parameter type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::signFinal(dummy);
+
+		return false;
+	}
+	
+	if (mechanismParam != NULL) {
+		delete mechanismParameters;  // safe even if nullptr
+ 		mechanismParameters = mechanismParam->clone();
+	} else {
+		delete mechanismParameters;
+		mechanismParameters = NULL;
+ 	}
+
+	return true;
 }
 
-bool OSSLMLDSA::signUpdate(const ByteString & /*dataToSign*/)
+bool OSSLMLDSA::signUpdate(const ByteString & dataToSign)
 {
-	ERROR_MSG("ML-DSA does not support multi part signing");
+	if (!AsymmetricAlgorithm::signUpdate(dataToSign))
+	{
+		return false;
+	}
 
-	return false;
+	DEBUG_MSG("signUpdate dataToSign %s", dataToSign.hex_str().c_str());
+
+	message += dataToSign;
+	
+	DEBUG_MSG("signUpdate message %s", message.hex_str().c_str());
+
+	return true;
 }
 
-bool OSSLMLDSA::signFinal(ByteString & /*signature*/)
+bool OSSLMLDSA::signFinal(ByteString & signature)
 {
-	ERROR_MSG("ML-DSA does not support multi part signing");
+	DEBUG_MSG("signFinal mechanismParameters != NULL: %d", mechanismParameters != NULL);
+	int rv = OSSLMLDSA::sign(currentPrivateKey, message, signature, currentMechanism, NULL, 0, mechanismParameters);
+	DEBUG_MSG("rv=%d", rv);
 
-	return false;
+	delete mechanismParameters;
+	mechanismParameters = NULL;
+
+	message.resize(0);
+	
+	if (!AsymmetricAlgorithm::signFinal(signature))
+	{
+		return false;
+	}
+
+	return rv;
 }
 
 // Verification functions
@@ -183,6 +240,8 @@ bool OSSLMLDSA::verify(PublicKey *publicKey, const ByteString &originalData,
 					   const void * /* param  = NULL*/, const size_t  /* paramLen = 0 */,
 					   const MechanismParam* mechanismParam)
 {
+	DEBUG_MSG("verify originalData: %s", originalData.hex_str().c_str());
+	DEBUG_MSG("verify signature: %s", signature.hex_str().c_str());
 	if (mechanism != AsymMech::MLDSA)
 	{
 		ERROR_MSG("Invalid mechanism supplied (%i)", mechanism);
@@ -305,26 +364,82 @@ bool OSSLMLDSA::verify(PublicKey *publicKey, const ByteString &originalData,
 	return true;
 }
 
-bool OSSLMLDSA::verifyInit(PublicKey * /*publicKey*/, const AsymMech::Type /*mechanism*/,
-						   const void * /* param = NULL */, const size_t /* paramLen = 0 */)
+bool OSSLMLDSA::verifyInit(PublicKey * publicKey, const AsymMech::Type mechanism,
+						   const void * param /* = NULL */, const size_t paramLen /* = 0 */,
+					       const MechanismParam* mechanismParam /* = NULL */)
 {
-	ERROR_MSG("ML-DSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
+	{
+		return false;
+	}
 
-	return false;
+	// Check if the private key is the right type
+	if (!publicKey->isOfType(OSSLMLDSAPublicKey::type))
+	{
+		ERROR_MSG("Invalid key type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	DEBUG_MSG("verifyInit mechanismParam != NULL: %d", mechanismParam != NULL);
+
+	if (mechanismParam != NULL && !mechanismParam->isOfType(MLDSAMechanismParam::type))
+	{
+		ERROR_MSG("Invalid mechanism parameter type supplied");
+
+		ByteString dummy;
+		AsymmetricAlgorithm::verifyFinal(dummy);
+
+		return false;
+	}
+
+	if (mechanismParam != NULL) {
+		delete mechanismParameters;  // safe even if nullptr
+ 		mechanismParameters = mechanismParam->clone();
+	} else {
+		delete mechanismParameters;
+		mechanismParameters = NULL;
+ 	}
+
+	return true;
 }
 
-bool OSSLMLDSA::verifyUpdate(const ByteString & /*originalData*/)
+bool OSSLMLDSA::verifyUpdate(const ByteString & originalData)
 {
-	ERROR_MSG("ML-DSA does not support multi part verifying");
+	if (!AsymmetricAlgorithm::verifyUpdate(originalData))
+	{
+		return false;
+	}
 
-	return false;
+	DEBUG_MSG("verifyUpdate originalData %s", originalData.hex_str().c_str());
+
+	message += originalData;
+	
+	DEBUG_MSG("verifyUpdate message %s", message.hex_str().c_str());
+
+	return true;
 }
 
-bool OSSLMLDSA::verifyFinal(const ByteString & /*signature*/)
+bool OSSLMLDSA::verifyFinal(const ByteString & signature)
 {
-	ERROR_MSG("ML-DSA does not support multi part verifying");
+	DEBUG_MSG("verifyFinal mechanismParameters != NULL: %d", mechanismParameters != NULL);
+	int rv = OSSLMLDSA::verify(currentPublicKey, message, signature, currentMechanism, NULL, 0, mechanismParameters);
+	DEBUG_MSG("rv=%d", rv);
 
-	return false;
+	delete mechanismParameters;
+	mechanismParameters = NULL;
+
+	message.resize(0);
+	
+	if (!AsymmetricAlgorithm::verifyFinal(signature))
+	{
+		return false;
+	}
+
+	return rv;
 }
 
 // Encryption functions

--- a/src/lib/crypto/OSSLMLDSA.h
+++ b/src/lib/crypto/OSSLMLDSA.h
@@ -15,18 +15,20 @@
 class OSSLMLDSA : public AsymmetricAlgorithm
 {
 public:
+	OSSLMLDSA() : message(), parameters(NULL), paramLength(0), mechanismParameters(NULL) { }
+	
 	// Destructor
 	virtual ~OSSLMLDSA() { }
 
 	// Signing functions
 	virtual bool sign(PrivateKey *privateKey, const ByteString &dataToSign, ByteString &signature, const AsymMech::Type mechanism, const void *param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 
@@ -52,6 +54,10 @@ public:
 private:
 	static int OSSL_RANDOM;
 	static int OSSL_DETERMINISTIC;
+	ByteString message;
+	void* parameters;
+	size_t paramLength;
+	const MechanismParam* mechanismParameters;
 };
 
 #endif // !WITH_ML_DSA

--- a/src/lib/crypto/OSSLRSA.cpp
+++ b/src/lib/crypto/OSSLRSA.cpp
@@ -285,7 +285,8 @@ bool OSSLRSA::sign(PrivateKey* privateKey, const ByteString& dataToSign,
 }
 
 bool OSSLRSA::signInit(PrivateKey* privateKey, const AsymMech::Type mechanism,
-		       const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+		       const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		       const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::signInit(privateKey, mechanism, param, paramLen))
 	{
@@ -843,7 +844,8 @@ bool OSSLRSA::verify(PublicKey* publicKey, const ByteString& originalData,
 }
 
 bool OSSLRSA::verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism,
-			 const void* param /* = NULL */, const size_t paramLen /* = 0 */)
+			 const void* param /* = NULL */, const size_t paramLen /* = 0 */,
+		     const MechanismParam* /* mechanismParam */)
 {
 	if (!AsymmetricAlgorithm::verifyInit(publicKey, mechanism, param, paramLen))
 	{

--- a/src/lib/crypto/OSSLRSA.h
+++ b/src/lib/crypto/OSSLRSA.h
@@ -49,13 +49,13 @@ public:
 
 	// Signing functions
 	virtual bool sign(PrivateKey* privateKey, const ByteString& dataToSign, ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool signInit(PrivateKey* privateKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool signUpdate(const ByteString& dataToSign);
 	virtual bool signFinal(ByteString& signature);
 
 	// Verification functions
 	virtual bool verify(PublicKey* publicKey, const ByteString& originalData, const ByteString& signature, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
-	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0);
+	virtual bool verifyInit(PublicKey* publicKey, const AsymMech::Type mechanism, const void* param = NULL, const size_t paramLen = 0, const MechanismParam* mechanismParam = NULL);
 	virtual bool verifyUpdate(const ByteString& originalData);
 	virtual bool verifyFinal(const ByteString& signature);
 

--- a/src/lib/crypto/test/MLDSATests.cpp
+++ b/src/lib/crypto/test/MLDSATests.cpp
@@ -206,7 +206,7 @@ void MLDSATests::testSigningTestVector()
 	CPPUNIT_ASSERT(dPriv != NULL);
 
 	CPPUNIT_ASSERT(pk.size() != 0);
-	
+
 	CPPUNIT_ASSERT(dPriv->PKCS8Decode(pk));
 
 	MLDSAMechanismParam context = MLDSAMechanismParam(Hedge::Type::DETERMINISTIC_REQUIRED);
@@ -230,7 +230,7 @@ void MLDSATests::testSigningTestVectorEmptyContext()
 	CPPUNIT_ASSERT(dPriv != NULL);
 
 	CPPUNIT_ASSERT(pk.size() != 0);
-	
+
 	CPPUNIT_ASSERT(dPriv->PKCS8Decode(pk));
 
 	std::string contextStr = std::string("");
@@ -256,7 +256,7 @@ void MLDSATests::testSigningTestVectorNonEmptyContext()
 	CPPUNIT_ASSERT(dPriv != NULL);
 
 	CPPUNIT_ASSERT(pk.size() != 0);
-	
+
 	CPPUNIT_ASSERT(dPriv->PKCS8Decode(pk));
 
 	ByteString contextStr = ByteString("436f6e74657874");
@@ -281,7 +281,7 @@ void MLDSATests::testSigningTestVectorLongestContext()
 	CPPUNIT_ASSERT(dPriv != NULL);
 
 	CPPUNIT_ASSERT(pk.size() != 0);
-	
+
 	CPPUNIT_ASSERT(dPriv->PKCS8Decode(pk));
 
 	ByteString contextStr = ByteString("414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141");
@@ -305,7 +305,7 @@ void MLDSATests::testSigningTestVectorContextTooLong()
 	CPPUNIT_ASSERT(dPriv != NULL);
 
 	CPPUNIT_ASSERT(pk.size() != 0);
-	
+
 	CPPUNIT_ASSERT(dPriv->PKCS8Decode(pk));
 
 	ByteString* contextStr = new ByteString("41414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141");
@@ -424,6 +424,257 @@ void MLDSATests::testVerifyingTestVectorContextTooLong()
 	CPPUNIT_ASSERT(!mldsa->verify(dPub, msg, sig, AsymMech::MLDSA, NULL, 0UL, &context));
 
 	mldsa->recyclePublicKey(dPub);
+}
+
+void MLDSATests::testSigningMultiPartVerifying()
+{
+	for (const unsigned long parameterSet : allParameterSets)
+	{
+		// Get domain parameters
+		MLDSAParameters *p = new MLDSAParameters();
+		CPPUNIT_ASSERT(p != NULL);
+		p->setParameterSet(parameterSet);
+
+		// Generate key-pair
+		AsymmetricKeyPair *kp;
+		CPPUNIT_ASSERT(mldsa->generateKeyPair(&kp, p));
+
+		// Generate some data to sign
+		ByteString dataToSign;
+		ByteString dataToSignMultipart;
+
+		RNG *rng = CryptoFactory::i()->getRNG();
+		CPPUNIT_ASSERT(rng != NULL);
+
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 567));
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSignMultipart, 890));
+
+		ByteString all = dataToSign + dataToSignMultipart;
+
+		ByteString sigMultiPart;
+		CPPUNIT_ASSERT(mldsa->signInit(kp->getPrivateKey(), AsymMech::MLDSA));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->signFinal(sigMultiPart));
+
+		CPPUNIT_ASSERT(mldsa->verify(kp->getPublicKey(), all, sigMultiPart, AsymMech::MLDSA));
+
+		mldsa->recycleKeyPair(kp);
+		mldsa->recycleParameters(p);
+	}
+}
+
+void MLDSATests::testSigningMultiPartVerifyingWithContext()
+{
+	for (const unsigned long parameterSet : allParameterSets)
+	{
+		// Get domain parameters
+		MLDSAParameters *p = new MLDSAParameters();
+		CPPUNIT_ASSERT(p != NULL);
+		p->setParameterSet(parameterSet);
+
+		// Generate key-pair
+		AsymmetricKeyPair *kp;
+		CPPUNIT_ASSERT(mldsa->generateKeyPair(&kp, p));
+
+		// Generate some data to sign
+		ByteString dataToSign;
+		ByteString dataToSignMultipart;
+
+		RNG *rng = CryptoFactory::i()->getRNG();
+		CPPUNIT_ASSERT(rng != NULL);
+
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 567));
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSignMultipart, 890));
+
+		ByteString all = dataToSign + dataToSignMultipart;
+
+		const std::string contextStr("HEDGE_PREFERRED");
+		const ByteString contextBS((const unsigned char*)contextStr.data(), contextStr.size());
+
+		MLDSAMechanismParam context = MLDSAMechanismParam(Hedge::Type::HEDGE_PREFERRED, contextBS);
+
+		ByteString sigMultiPart;
+		CPPUNIT_ASSERT(mldsa->signInit(kp->getPrivateKey(), AsymMech::MLDSA, NULL, 0, &context));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->signFinal(sigMultiPart));
+
+		CPPUNIT_ASSERT(mldsa->verify(kp->getPublicKey(), all, sigMultiPart, AsymMech::MLDSA, NULL, 0, &context));
+
+		mldsa->recycleKeyPair(kp);
+		mldsa->recycleParameters(p);
+	}
+}
+
+void MLDSATests::testSigningVerifyingMultiPart()
+{
+	for (const unsigned long parameterSet : allParameterSets)
+	{
+		// Get domain parameters
+		MLDSAParameters *p = new MLDSAParameters();
+		CPPUNIT_ASSERT(p != NULL);
+		p->setParameterSet(parameterSet);
+
+		// Generate key-pair
+		AsymmetricKeyPair *kp;
+		CPPUNIT_ASSERT(mldsa->generateKeyPair(&kp, p));
+
+		// Generate some data to sign
+		ByteString dataToSign;
+		ByteString dataToSignMultipart;
+
+		RNG *rng = CryptoFactory::i()->getRNG();
+		CPPUNIT_ASSERT(rng != NULL);
+
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 567));
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSignMultipart, 890));
+
+		ByteString all = dataToSign + dataToSignMultipart;
+
+		ByteString sig;
+		CPPUNIT_ASSERT(mldsa->sign(kp->getPrivateKey(), all, sig, AsymMech::MLDSA, NULL, 0, NULL));
+
+		CPPUNIT_ASSERT(mldsa->verifyInit(kp->getPublicKey(), AsymMech::MLDSA, NULL, 0, NULL));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->verifyFinal(sig));
+
+		mldsa->recycleKeyPair(kp);
+		mldsa->recycleParameters(p);
+	}
+}
+
+void MLDSATests::testSigningVerifyingMultiPartWithContext()
+{
+	for (const unsigned long parameterSet : allParameterSets)
+	{
+		// Get domain parameters
+		MLDSAParameters *p = new MLDSAParameters();
+		CPPUNIT_ASSERT(p != NULL);
+		p->setParameterSet(parameterSet);
+
+		// Generate key-pair
+		AsymmetricKeyPair *kp;
+		CPPUNIT_ASSERT(mldsa->generateKeyPair(&kp, p));
+
+		// Generate some data to sign
+		ByteString dataToSign;
+		ByteString dataToSignMultipart;
+
+		RNG *rng = CryptoFactory::i()->getRNG();
+		CPPUNIT_ASSERT(rng != NULL);
+
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 567));
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSignMultipart, 890));
+
+		ByteString all = dataToSign + dataToSignMultipart;
+
+		const std::string contextStr("HEDGE_PREFERRED");
+		const ByteString contextBS((const unsigned char*)contextStr.data(), contextStr.size());
+
+		MLDSAMechanismParam context = MLDSAMechanismParam(Hedge::Type::HEDGE_PREFERRED, contextBS);
+
+		ByteString sigMultiPart;
+
+		CPPUNIT_ASSERT(mldsa->sign(kp->getPrivateKey(), all, sigMultiPart, AsymMech::MLDSA, NULL, 0, &context));
+
+		CPPUNIT_ASSERT(mldsa->verifyInit(kp->getPublicKey(), AsymMech::MLDSA, NULL, 0, &context));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->verifyFinal(sigMultiPart));
+
+		mldsa->recycleKeyPair(kp);
+		mldsa->recycleParameters(p);
+	}
+}
+
+void MLDSATests::testSigningMultiPartVerifyingMultiPart()
+{
+	for (const unsigned long parameterSet : allParameterSets)
+	{
+		// Get domain parameters
+		MLDSAParameters *p = new MLDSAParameters();
+		CPPUNIT_ASSERT(p != NULL);
+		p->setParameterSet(parameterSet);
+
+		// Generate key-pair
+		AsymmetricKeyPair *kp;
+		CPPUNIT_ASSERT(mldsa->generateKeyPair(&kp, p));
+
+		// Generate some data to sign
+		ByteString dataToSign;
+		ByteString dataToSignMultipart;
+
+		RNG *rng = CryptoFactory::i()->getRNG();
+		CPPUNIT_ASSERT(rng != NULL);
+
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 567));
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSignMultipart, 890));
+
+		ByteString all = dataToSign + dataToSignMultipart;
+
+		ByteString sigMultiPart;
+		CPPUNIT_ASSERT(mldsa->signInit(kp->getPrivateKey(), AsymMech::MLDSA, NULL, 0, NULL));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->signFinal(sigMultiPart));
+
+		CPPUNIT_ASSERT(mldsa->verifyInit(kp->getPublicKey(), AsymMech::MLDSA, NULL, 0, NULL));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->verifyFinal(sigMultiPart));
+
+		mldsa->recycleKeyPair(kp);
+		mldsa->recycleParameters(p);
+	}
+}
+
+void MLDSATests::testSigningMultiPartVerifyingMultiPartWithContext()
+{
+	for (const unsigned long parameterSet : allParameterSets)
+	{
+		// Get domain parameters
+		MLDSAParameters *p = new MLDSAParameters();
+		CPPUNIT_ASSERT(p != NULL);
+		p->setParameterSet(parameterSet);
+
+		// Generate key-pair
+		AsymmetricKeyPair *kp;
+		CPPUNIT_ASSERT(mldsa->generateKeyPair(&kp, p));
+
+		// Generate some data to sign
+		ByteString dataToSign;
+		ByteString dataToSignMultipart;
+
+		RNG *rng = CryptoFactory::i()->getRNG();
+		CPPUNIT_ASSERT(rng != NULL);
+
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSign, 567));
+		CPPUNIT_ASSERT(rng->generateRandom(dataToSignMultipart, 890));
+
+		ByteString all = dataToSign + dataToSignMultipart;
+
+		const std::string contextStr("HEDGE_PREFERRED");
+		const ByteString contextBS((const unsigned char*)contextStr.data(), contextStr.size());
+
+		MLDSAMechanismParam context = MLDSAMechanismParam(Hedge::Type::HEDGE_PREFERRED, contextBS);
+
+		ByteString sigMultiPart;
+
+		CPPUNIT_ASSERT(mldsa->signInit(kp->getPrivateKey(), AsymMech::MLDSA, NULL, 0, &context));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->signUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->signFinal(sigMultiPart));
+
+		CPPUNIT_ASSERT(mldsa->verifyInit(kp->getPublicKey(), AsymMech::MLDSA, NULL, 0, &context));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSign));
+		CPPUNIT_ASSERT(mldsa->verifyUpdate(dataToSignMultipart));
+		CPPUNIT_ASSERT(mldsa->verifyFinal(sigMultiPart));
+
+		mldsa->recycleKeyPair(kp);
+		mldsa->recycleParameters(p);
+	}
 }
 
 void MLDSATests::testSigningVerifyingHedgePreferred()

--- a/src/lib/crypto/test/MLDSATests.h
+++ b/src/lib/crypto/test/MLDSATests.h
@@ -17,6 +17,12 @@ class MLDSATests : public CppUnit::TestFixture
 	CPPUNIT_TEST(testSerialisation);
 	CPPUNIT_TEST(testPKCS8);
 	CPPUNIT_TEST(testSigningVerifying);
+	CPPUNIT_TEST(testSigningMultiPartVerifying);
+    CPPUNIT_TEST(testSigningMultiPartVerifyingWithContext);
+	CPPUNIT_TEST(testSigningVerifyingMultiPart);
+    CPPUNIT_TEST(testSigningVerifyingMultiPartWithContext);
+	CPPUNIT_TEST(testSigningMultiPartVerifyingMultiPart);
+    CPPUNIT_TEST(testSigningMultiPartVerifyingMultiPartWithContext);
 	CPPUNIT_TEST(testSigningTestVector);
 	CPPUNIT_TEST(testSigningTestVectorEmptyContext);
 	CPPUNIT_TEST(testSigningTestVectorNonEmptyContext);
@@ -43,6 +49,12 @@ public:
 	void testSerialisation();
 	void testPKCS8();
 	void testSigningVerifying();
+	void testSigningMultiPartVerifying();
+    void testSigningMultiPartVerifyingWithContext();
+    void testSigningVerifyingMultiPart();
+    void testSigningVerifyingMultiPartWithContext();
+    void testSigningMultiPartVerifyingMultiPart();
+    void testSigningMultiPartVerifyingMultiPartWithContext();
 	void testSigningTestVector();
 	void testSigningTestVectorEmptyContext();
 	void testSigningTestVectorNonEmptyContext();


### PR DESCRIPTION
Adds the multiple-part support for ML-DSA.
Follow-up of #809 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled multipart ML‑DSA signing and verification. Init APIs accept mechanism-specific parameters and now log ML‑DSA context/hedge details when provided.

* **Tests**
  * Added multipart ML‑DSA tests for streaming sign/verify flows, including a variant exercising additional context/hedge parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->