### PR TITLE
Added support for AES CBC Key Unwrap

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -6627,7 +6627,6 @@ CK_RV SoftHSM::WrapKeySym
 			break;
 
 		case CKM_DES3_CBC:
-			blocksize = 8;
 			algo = SymAlgo::DES3;
 			break;
 

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -1212,7 +1212,7 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 			pInfo->flags = CKF_UNWRAP | CKF_WRAP;
 			/* FALLTHROUGH */
 		case CKM_AES_CBC:
-			pInfo->flags |= CKF_WRAP;
+			pInfo->flags |= CKF_WRAP | CKF_UNWRAP;
 			/* FALLTHROUGH */
 		case CKM_AES_ECB:
 		case CKM_AES_CTR:
@@ -6616,6 +6616,7 @@ CK_RV SoftHSM::WrapKeySym
 			break;
 #endif
 		case CKM_AES_CBC:
+			blocksize = 16;
 			algo = SymAlgo::AES;
 			break;
 
@@ -6626,6 +6627,7 @@ CK_RV SoftHSM::WrapKeySym
 			break;
 
 		case CKM_DES3_CBC:
+			blocksize = 8;
 			algo = SymAlgo::DES3;
 			break;
 
@@ -7217,6 +7219,7 @@ CK_RV SoftHSM::UnwrapKeySym
 			mode = SymWrap::AES_KEYWRAP_PAD;
 			break;
 #endif
+	        case CKM_AES_CBC:
 	        case CKM_AES_CBC_PAD:
 			algo = SymAlgo::AES;
 			blocksize = 16;
@@ -7249,8 +7252,35 @@ CK_RV SoftHSM::UnwrapKeySym
 	ByteString iv;
 	ByteString decryptedFinal;
 	CK_RV rv = CKR_OK;
-	
+
 	switch(pMechanism->mechanism) {
+
+	case CKM_AES_CBC:
+		iv.resize(blocksize);
+		memcpy(&iv[0], pMechanism->pParameter, blocksize);
+
+		if (!cipher->decryptInit(unwrappingkey, SymMode::CBC, iv, false))
+		{
+			cipher->recycleKey(unwrappingkey);
+			CryptoFactory::i()->recycleSymmetricAlgorithm(cipher);
+			return CKR_MECHANISM_INVALID;
+		}
+		if (!cipher->decryptUpdate(wrapped, keydata))
+		{
+			cipher->recycleKey(unwrappingkey);
+			CryptoFactory::i()->recycleSymmetricAlgorithm(cipher);
+			return CKR_GENERAL_ERROR;
+		}
+		// Finalize decryption
+		if (!cipher->decryptFinal(decryptedFinal))
+		{
+			cipher->recycleKey(unwrappingkey);
+			CryptoFactory::i()->recycleSymmetricAlgorithm(cipher);
+			return CKR_GENERAL_ERROR;
+		}
+		keydata += decryptedFinal;
+		// No unpadding for CKM_AES_CBC - returns raw decrypted data
+		break;
 
 	case CKM_AES_CBC_PAD:
 	case CKM_DES3_CBC_PAD:
@@ -7563,6 +7593,7 @@ CK_RV SoftHSM::C_UnwrapKey
 				return rv;
 			break;
 
+	        case CKM_AES_CBC:
 	        case CKM_AES_CBC_PAD:
 			// TODO check block length
 			if (pMechanism->pParameter == NULL_PTR ||

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -1773,7 +1773,6 @@ void SymmetricAlgorithmTests::testAesWrapUnwrap()
     aesWrapUnwrapNonModifiableGeneric(CKM_AES_CBC, hSession, hKey);
 	aesWrapUnwrapRsa(CKM_AES_KEY_WRAP, hSession, hKey);
 	aesWrapUnwrapRsa(CKM_AES_CBC_PAD, hSession, hKey);
-	aesWrapUnwrapRsa(CKM_AES_CBC, hSession, hKey);
 
 #ifdef WITH_GOST
 	aesWrapUnwrapGost(CKM_AES_KEY_WRAP, hSession, hKey);

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -1099,7 +1099,7 @@ void SymmetricAlgorithmTests::aesWrapUnwrapGeneric(CK_MECHANISM_TYPE mechanismTy
 
 	CK_RV rv;
 	CK_BYTE ivPtr[16];
-	if( mechanismType == CKM_AES_CBC_PAD ) {
+	if( mechanismType == CKM_AES_CBC_PAD || mechanismType == CKM_AES_CBC ) {
 		rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, ivPtr, sizeof ivPtr) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 		mechanism.pParameter = ivPtr;
@@ -1148,7 +1148,12 @@ void SymmetricAlgorithmTests::aesWrapUnwrapGeneric(CK_MECHANISM_TYPE mechanismTy
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	auto wrapOverhead = [mechanismType]() {
-		return (mechanismType == CKM_AES_KEY_WRAP || mechanismType == CKM_AES_KEY_WRAP_PAD) ? 8 : 16;
+		if (mechanismType == CKM_AES_KEY_WRAP || mechanismType == CKM_AES_KEY_WRAP_PAD)
+			return 8;
+		else if (mechanismType == CKM_AES_CBC)
+			return 0;  // No padding overhead for CKM_AES_CBC
+		else
+			return 16;  // CKM_AES_CBC_PAD adds padding
 	};
 	CPPUNIT_ASSERT(wrappedLen == rndKeyLen + wrapOverhead() );
 
@@ -1199,7 +1204,7 @@ void SymmetricAlgorithmTests::aesWrapUnwrapNonModifiableGeneric(CK_MECHANISM_TYP
 
 	CK_RV rv;
 	CK_BYTE ivPtr[16];
-	if( mechanismType == CKM_AES_CBC_PAD ) {
+	if( mechanismType == CKM_AES_CBC_PAD || mechanismType == CKM_AES_CBC ) {
 		rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, ivPtr, sizeof ivPtr) );
 		CPPUNIT_ASSERT(rv == CKR_OK);
 		mechanism.pParameter = ivPtr;
@@ -1248,7 +1253,12 @@ void SymmetricAlgorithmTests::aesWrapUnwrapNonModifiableGeneric(CK_MECHANISM_TYP
 	CPPUNIT_ASSERT(rv == CKR_OK);
 
 	auto wrapOverhead = [mechanismType]() {
-		return (mechanismType == CKM_AES_KEY_WRAP || mechanismType == CKM_AES_KEY_WRAP_PAD) ? 8 : 16;
+		if (mechanismType == CKM_AES_KEY_WRAP || mechanismType == CKM_AES_KEY_WRAP_PAD)
+			return 8;
+		else if (mechanismType == CKM_AES_CBC)
+			return 0;  // No padding overhead for CKM_AES_CBC
+		else
+			return 16;  // CKM_AES_CBC_PAD adds padding
 	};
 	CPPUNIT_ASSERT(wrappedLen == rndKeyLen + wrapOverhead() );
 
@@ -1322,13 +1332,14 @@ void SymmetricAlgorithmTests::wrapUnwrapRsa(CK_MECHANISM_TYPE mechanismType, CK_
 
 	CK_BYTE ivPtr[16];
 	switch(mechanismType) {
+		case CKM_AES_CBC:
 		case CKM_AES_CBC_PAD:
 		case CKM_DES_CBC_PAD:
 		case CKM_DES3_CBC_PAD:
 			rv = CRYPTOKI_F_PTR( C_GenerateRandom(hSession, ivPtr, sizeof ivPtr) );
 			CPPUNIT_ASSERT(rv == CKR_OK);
 			mechanism.pParameter = ivPtr;
-			mechanism.ulParameterLen = mechanismType == CKM_AES_CBC_PAD ? 16 : 8;
+			mechanism.ulParameterLen = (mechanismType == CKM_AES_CBC_PAD || mechanismType == CKM_AES_CBC) ? 16 : 8;
 			// falls through
 	}
 		
@@ -1756,10 +1767,13 @@ void SymmetricAlgorithmTests::testAesWrapUnwrap()
 
 	aesWrapUnwrapGeneric(CKM_AES_KEY_WRAP, hSession, hKey);
 	aesWrapUnwrapGeneric(CKM_AES_CBC_PAD, hSession, hKey);
+	aesWrapUnwrapGeneric(CKM_AES_CBC, hSession, hKey);
 	aesWrapUnwrapNonModifiableGeneric(CKM_AES_KEY_WRAP, hSession, hKey);
     aesWrapUnwrapNonModifiableGeneric(CKM_AES_CBC_PAD, hSession, hKey);
+    aesWrapUnwrapNonModifiableGeneric(CKM_AES_CBC, hSession, hKey);
 	aesWrapUnwrapRsa(CKM_AES_KEY_WRAP, hSession, hKey);
 	aesWrapUnwrapRsa(CKM_AES_CBC_PAD, hSession, hKey);
+	aesWrapUnwrapRsa(CKM_AES_CBC, hSession, hKey);
 
 #ifdef WITH_GOST
 	aesWrapUnwrapGost(CKM_AES_KEY_WRAP, hSession, hKey);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AES-CBC block/IV initialization and handling during key wrap, ensuring correct IV length and no unintended unpadding for non-padding AES-CBC.
  * Updated mechanism reporting so AES-CBC is advertised as supporting both wrap and unwrap; added IV-length validation for AES-CBC unwrap.

* **Tests**
  * Added tests for AES-CBC (non-padding) wrap/unwrap and adjusted wrap-length expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->