### PR TITLE
Use default OpenSSL provider for internal ML-DSA key reconstruction

### DIFF
--- a/src/lib/crypto/OSSLMLDSAPrivateKey.cpp
+++ b/src/lib/crypto/OSSLMLDSAPrivateKey.cpp
@@ -203,7 +203,8 @@ void OSSLMLDSAPrivateKey::createOSSLKey()
 
 	*p = OSSL_PARAM_construct_end();
 
-	ctx = EVP_PKEY_CTX_new_from_name(NULL, name, NULL);
+	// Use the default provider for internal ML-DSA key reconstruction.
+	ctx = EVP_PKEY_CTX_new_from_name(NULL, name, "provider=default");
 	if (ctx == NULL) {
 		ERROR_MSG("Could not create context");
 		return;

--- a/src/lib/crypto/OSSLMLDSAPublicKey.cpp
+++ b/src/lib/crypto/OSSLMLDSAPublicKey.cpp
@@ -123,7 +123,8 @@ void OSSLMLDSAPublicKey::createOSSLKey()
 
 	*p = OSSL_PARAM_construct_end();
 
-	ctx = EVP_PKEY_CTX_new_from_name(NULL, name, NULL);
+	// Use the default provider for internal ML-DSA key reconstruction
+	ctx = EVP_PKEY_CTX_new_from_name(NULL, name, "provider=default");
 	if (ctx == NULL) {
 		ERROR_MSG("Could not create context");
 		return;


### PR DESCRIPTION
### Current Behavior:
Relying on implicit provider selection can make `ML-DSA` public/private key reconstruction fail, causing operations such as `C_Sign` to return `CKR_GENERAL_ERROR`.

### Scope of Changes:
This change explicitly uses `provider=default` when creating internal `ML-DSA` key contexts.

### Testing:
Verified `ML-DSA` signing with SoftHSM, OpenSSL 3.6.2, and a development branch of the `pkcs11prov` provider.

Before this change, signing failed because SoftHSM could not obtain the internal OpenSSL private key. After the change, signing succeeds.

### Related Pull Requests:
#823, #862, #874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined internal cryptographic key handling for ML-DSA algorithms by explicitly configuring default provider initialization during the key reconstruction process. This ensures consistent and reliable behavior for both private and public key operations, improving system stability and compatibility with OpenSSL cryptographic frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->