### PR TITLE
Fix repeated insertion of default attributes in SQLite DB

### DIFF
--- a/src/lib/object_store/DBObject.cpp
+++ b/src/lib/object_store/DBObject.cpp
@@ -426,6 +426,7 @@ static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
 	case CKA_HASH_OF_ISSUER_PUBLIC_KEY: return akBinary;
 	case CKA_NAME_HASH_ALGORITHM: return akInteger;
 	case CKA_CHECK_VALUE: return akBinary;
+	case CKA_PUBLIC_KEY_INFO: return akBinary;
 	case CKA_KEY_TYPE: return akInteger;
 	case CKA_SUBJECT: return akBinary;
 	case CKA_ID: return akBinary;
@@ -462,6 +463,7 @@ static AttributeKind attributeKind(CK_ATTRIBUTE_TYPE type)
 	case CKA_NEVER_EXTRACTABLE: return akBoolean;
 	case CKA_ALWAYS_SENSITIVE: return akBoolean;
 	case CKA_KEY_GEN_MECHANISM: return akInteger;
+	case CKA_DESTROYABLE: return akBoolean;
 	case CKA_MODIFIABLE: return akBoolean;
 	case CKA_COPYABLE: return akBoolean;
 	case CKA_ECDSA_PARAMS: return akBinary;


### PR DESCRIPTION
This PR fixes repeated insertion of default attributes in the SQLite DB object store.

The DB backend was able to store CKA_PUBLIC_KEY_INFO and CKA_DESTROYABLE, but could not read them back because DBObject::attributeKind() did not classify these attribute types.

Observed with the DB object store:

- CKA_PUBLIC_KEY_INFO / 0x129 / 297 was repeatedly inserted into attribute_binary as X''
- CKA_DESTROYABLE / 0x172 / 370 was repeatedly inserted into attribute_boolean as 1

After several object initializations, duplicate rows accumulated:

  2|370|16
  3|370|16
  4|370|16
  5|370|16

and:

  2|297|16
  3|297|16
  4|297|16
  5|297|16

The root cause is that P11Attribute::init() calls setDefault() when
osobject->attributeExists(type) returns false. DBObject::attributeExists() depends
on DBObject::accessAttribute(), which uses attributeKind(type) to decide which
attribute table to query. Since these two types returned akUnknown, the attributes
were never found, even though they were already present in SQLite.

At the same time, DBObject::setAttribute() could still insert them because it chooses
the table from the OSAttribute value type:

- CKA_PUBLIC_KEY_INFO is a ByteString and gets inserted into attribute_binary
- CKA_DESTROYABLE is a boolean and gets inserted into attribute_boolean

This made the DB backend repeatedly insert the same default attributes. It also breaks
read-only SQLite token databases, because even operations such as object lookup/signing
can try to initialize these default attributes and write to the DB.

The fix adds the missing mappings:

- CKA_PUBLIC_KEY_INFO -> akBinary
- CKA_DESTROYABLE -> akBoolean

After this, DBObject can read back the attributes it stores, and repeated default
insertion stops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional PKCS#11 cryptographic key attributes, enhancing compatibility with cryptographic key operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->