### PR TITLE
fixed wrong usage of VirtualFree (win32)

### DIFF
--- a/src/lib/data_mgr/SecureAllocator.h
+++ b/src/lib/data_mgr/SecureAllocator.h
@@ -122,7 +122,7 @@ public:
 #ifndef _WIN32
 			free(r);
 #else
-			VirtualFree((const void*) r, MEM_RELEASE);
+			VirtualFree((const void*) r, 0, MEM_RELEASE);
 #endif
 
 			return NULL;
@@ -173,7 +173,7 @@ public:
 #ifndef _WIN32
 		free(p);
 #else
-		VirtualFree((const void*) r, MEM_RELEASE);
+		VirtualFree((const void*) p, 0, MEM_RELEASE);
 #endif
 #else
 		// Release the memory

--- a/src/lib/data_mgr/salloc.cpp
+++ b/src/lib/data_mgr/salloc.cpp
@@ -71,7 +71,7 @@ void* salloc(size_t len)
 #ifndef _WIN32
 		free(ptr);
 #else
-		VirtualFree((const void*) pre, MEM_RELEASE);
+		VirtualFree((const void*) pre, 0, MEM_RELEASE);
 #endif
 
 		return NULL;
@@ -116,7 +116,7 @@ void sfree(void* ptr)
 #ifndef _WIN32
 	munlock((const void*) ptr, len);
 #else
-	VirtualFree((const void*) pre, MEM_RELEASE);
+	VirtualFree((const void*) pre, 0, MEM_RELEASE);
 #endif
 
 #endif // SENSITIVE_NON_PAGED


### PR DESCRIPTION
SecureAlloc should have never even compiled on win32. First, the API usage is wrong - VirtualFree requires a size parameter (0 in case of MEM_RELEASE). Second, the deallocator used a non existing variable name as reference.

This change fixes the usage, but the change itself is untested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows memory cleanup for secure non-paged allocations, including correct handling of allocation-failure cleanup.
  * Updated secure memory deallocation on Windows to better match the expected `VirtualFree` call pattern, reducing the risk of cleanup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->